### PR TITLE
Wave 3: Workstream D — random-data 503 + model_unavailable (PRD audit 2026-04, Q4=default)

### DIFF
--- a/backend/api/error_responses.py
+++ b/backend/api/error_responses.py
@@ -23,6 +23,59 @@ from backend.exceptions import InsufficientDataError, ModelUnavailableError
 
 logger = logging.getLogger(__name__)
 
+
+# ---------------------------------------------------------------------------
+# OpenAPI snippet — attach via ``responses={**MODEL_UNAVAILABLE_503_RESPONSE}``
+# on any FastAPI route that can refuse-to-serve. Frontend G3-phase-4 consumes
+# this exact shape to render the empty-state component.
+# ---------------------------------------------------------------------------
+
+MODEL_UNAVAILABLE_503_EXAMPLE: Dict[str, Any] = {
+    "error": "model_unavailable",
+    "model": "recommendation_engine",
+    "reason": "fallback_active",
+    "request_id": "9b4f2e1c8a1d4e5b9d4f1c2a3e5d6f78",
+}
+
+MODEL_UNAVAILABLE_503_RESPONSE: Dict[int, Dict[str, Any]] = {
+    503: {
+        "description": (
+            "Model unavailable — the platform refuses to fabricate "
+            "investment outputs when the underlying ML model binaries are "
+            "missing or the feature data is insufficient. See "
+            "docs/api/model-unavailable-503.md."
+        ),
+        "content": {
+            "application/json": {
+                "example": MODEL_UNAVAILABLE_503_EXAMPLE,
+                "schema": {
+                    "type": "object",
+                    "required": ["error", "model", "reason", "request_id"],
+                    "properties": {
+                        "error": {
+                            "type": "string",
+                            "enum": ["model_unavailable"],
+                        },
+                        "model": {"type": "string"},
+                        "reason": {
+                            "type": "string",
+                            "enum": [
+                                "binary_missing",
+                                "fallback_active",
+                                "insufficient_data",
+                                "not_implemented",
+                                "manager_unavailable",
+                                "live_feed_not_configured",
+                            ],
+                        },
+                        "request_id": {"type": "string"},
+                    },
+                },
+            }
+        },
+    }
+}
+
 try:  # pragma: no cover - optional dependency surface
     import sentry_sdk
 except Exception:  # pragma: no cover

--- a/backend/api/error_responses.py
+++ b/backend/api/error_responses.py
@@ -1,0 +1,133 @@
+"""
+Structured 503 error response helpers for model_unavailable / insufficient_data.
+
+Per PRD audit 2026-04 Workstream D (Q4=default): when an ML model is in
+``DummyLSTM``/``DummyXGBoost``/``DummyProphet`` fallback or feature data is
+insufficient, the API MUST return HTTP 503 with a structured payload rather
+than fabricating values. The frontend (G3 phase 4) consumes this contract.
+
+Policy artifact:
+    docs/audits/2026-04/_synthesis/_meta/LEGAL_ASSUMPTION_OF_RECORD.md
+PRD reference:
+    docs/audits/2026-04/PRD-for-loki.md §3 D
+"""
+from __future__ import annotations
+
+import logging
+import uuid
+from typing import Any, Dict, Optional
+
+from fastapi import HTTPException, Request, status
+
+from backend.exceptions import InsufficientDataError, ModelUnavailableError
+
+logger = logging.getLogger(__name__)
+
+try:  # pragma: no cover - optional dependency surface
+    import sentry_sdk
+except Exception:  # pragma: no cover
+    sentry_sdk = None  # type: ignore[assignment]
+
+
+def _request_id(request: Optional[Request]) -> str:
+    if request is not None:
+        rid = request.headers.get("x-request-id") if hasattr(request, "headers") else None
+        if rid:
+            return rid
+    return uuid.uuid4().hex
+
+
+def _sentry_breadcrumb(category: str, message: str, data: Dict[str, Any]) -> None:
+    if sentry_sdk is None:
+        return
+    try:
+        sentry_sdk.add_breadcrumb(
+            category=category,
+            message=message,
+            level="warning",
+            data=data,
+        )
+    except Exception as exc:  # pragma: no cover - never let telemetry crash the request
+        logger.debug("sentry breadcrumb failed: %s", exc)
+
+
+def model_unavailable_payload(
+    model: str,
+    reason: str = "fallback_active",
+    request_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Return the structured 503 body for a ``model_unavailable`` response.
+
+    Stable shape (frontend contract):
+
+    .. code-block:: json
+
+        {
+          "error": "model_unavailable",
+          "model": "<name>",
+          "reason": "binary_missing | insufficient_data | fallback_active",
+          "request_id": "<uuid hex>"
+        }
+    """
+    return {
+        "error": "model_unavailable",
+        "model": model,
+        "reason": reason,
+        "request_id": request_id or uuid.uuid4().hex,
+    }
+
+
+def raise_model_unavailable(
+    model: str = "unknown",
+    reason: str = "fallback_active",
+    request: Optional[Request] = None,
+) -> None:
+    """Raise an HTTP 503 with the canonical ``model_unavailable`` payload.
+
+    Logs a Sentry breadcrumb tagged ``model_unavailable`` so the model name
+    and originating endpoint are visible to SRE.
+    """
+    rid = _request_id(request)
+    _sentry_breadcrumb(
+        "model_unavailable",
+        f"503 model_unavailable: {model} ({reason})",
+        {
+            "model": model,
+            "reason": reason,
+            "request_id": rid,
+            "endpoint": getattr(getattr(request, "url", None), "path", None),
+        },
+    )
+    logger.warning(
+        "model_unavailable model=%s reason=%s request_id=%s",
+        model, reason, rid,
+    )
+    raise HTTPException(
+        status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+        detail=model_unavailable_payload(model, reason, rid),
+    )
+
+
+def handle_unavailable(
+    exc: Exception,
+    request: Optional[Request] = None,
+    default_model: str = "unknown",
+) -> None:
+    """Convert an ``InsufficientDataError``/``ModelUnavailableError`` to 503.
+
+    Re-raises the original exception untouched if it is neither type, so this
+    helper is safe to call from a broad ``except`` clause.
+    """
+    if isinstance(exc, ModelUnavailableError):
+        raise_model_unavailable(
+            model=exc.model,
+            reason=exc.reason,
+            request=request,
+        )
+    if isinstance(exc, InsufficientDataError):
+        raise_model_unavailable(
+            model=default_model,
+            reason=exc.reason or "insufficient_data",
+            request=request,
+        )
+    raise exc

--- a/backend/api/routers/admin.py
+++ b/backend/api/routers/admin.py
@@ -32,6 +32,7 @@ class SystemStatus(str, Enum):
     PARTIAL_OUTAGE = "partial_outage"
     MAJOR_OUTAGE = "major_outage"
     MAINTENANCE = "maintenance"
+    UNKNOWN = "unknown"  # F-02-003: psutil unavailable on this host
 
 class ServiceStatus(str, Enum):
     RUNNING = "running"
@@ -39,6 +40,7 @@ class ServiceStatus(str, Enum):
     STARTING = "starting"
     STOPPING = "stopping"
     ERROR = "error"
+    UNKNOWN = "unknown"  # F-02-003: psutil-derived state unavailable
 
 class JobStatus(str, Enum):
     PENDING = "pending"
@@ -65,17 +67,27 @@ PROTECTED_CONFIG_SECTIONS = [
 
 # Pydantic models
 class SystemHealth(BaseModel):
+    """System health summary surfaced by /api/admin/system/health.
+
+    Per PRD audit 2026-04 F-02-003: numeric fields are ``Optional`` because
+    psutil cannot supply every metric on every platform (e.g.
+    ``net_connections`` requires elevated privileges on macOS). Fields
+    fabricated by the legacy random.uniform path (request_rate, error_rate,
+    response_time_avg) now come from Prometheus / Grafana — not this
+    endpoint — and are reported as ``None`` here rather than fake numbers.
+    """
     status: SystemStatus
     uptime: int  # seconds
-    cpu_usage: float
-    memory_usage: float
-    disk_usage: float
-    active_connections: int
-    request_rate: float  # requests per second
-    error_rate: float
-    response_time_avg: float  # milliseconds
+    cpu_usage: Optional[float] = None
+    memory_usage: Optional[float] = None
+    disk_usage: Optional[float] = None
+    active_connections: Optional[int] = None
+    request_rate: Optional[float] = None
+    error_rate: Optional[float] = None
+    response_time_avg: Optional[float] = None
     services: Dict[str, ServiceStatus]
     last_check: datetime
+    data_source: Optional[str] = None  # 'psutil' | 'psutil_unavailable'
 
 class User(BaseModel):
     id: str

--- a/backend/api/routers/analysis.py
+++ b/backend/api/routers/analysis.py
@@ -24,6 +24,8 @@ from backend.repositories import stock_repository, price_repository
 from backend.utils.cache import cache_with_ttl
 from backend.config.settings import settings
 from backend.ml.model_manager import get_model_manager
+from backend.exceptions import InsufficientDataError, ModelUnavailableError
+from backend.api.error_responses import raise_model_unavailable
 from backend.models.api_response import ApiResponse, success_response
 from backend.utils.numpy_serializer import sanitize_numpy
 from backend.services.analysis_service import (
@@ -546,9 +548,19 @@ async def analyze_stock(
                 )
 
         # Risk Metrics calculation (delegated to service)
+        # Per F-02-018 / PRD audit 2026-04 §3 D: insufficient price history
+        # (n<30) raises InsufficientDataError which we surface as a structured
+        # HTTP 503 ``model_unavailable`` response rather than fabricating
+        # placeholder risk metrics.
         logger.info(f"Calculating risk metrics for {symbol}")
         prices_for_risk = [float(p.close) for p in price_history] if price_history else []
-        risk_fields = calculate_risk_metrics_from_prices(prices_for_risk)
+        try:
+            risk_fields = calculate_risk_metrics_from_prices(prices_for_risk)
+        except InsufficientDataError as exc:
+            raise_model_unavailable(
+                model="risk_metrics",
+                reason=exc.reason or "insufficient_data",
+            )
         risk_metrics = RiskMetrics(**risk_fields)
 
         # Calculate overall score and recommendation (delegated to service)

--- a/backend/api/routers/health.py
+++ b/backend/api/routers/health.py
@@ -12,14 +12,41 @@ from backend.security.advanced_rate_limiter import get_default_rate_limiting_rul
 
 router = APIRouter(tags=["health"])
 
+def _get_fallback_models_state() -> Dict[str, Any]:
+    """Return ML model fallback state for the /health response.
+
+    Per PRD audit 2026-04 F-03-003: a deployment running with
+    DummyLSTM/DummyXGBoost/DummyProphet substitutes is producing fabricated
+    investment outputs. The health endpoint surfaces ``fallback_models`` and
+    ``fallback_models_count`` so readiness probes / SRE alerts can fail fast.
+    """
+    try:
+        from backend.ml.model_manager import get_model_manager
+        mgr = get_model_manager()
+        fallback = mgr.get_fallback_models()
+        return {
+            "fallback_models": fallback,
+            "fallback_models_count": len(fallback),
+        }
+    except Exception:  # pragma: no cover - never let health crash on ml import
+        return {"fallback_models": [], "fallback_models_count": 0}
+
+
 @router.get("")
 async def health_check() -> ApiResponse[Dict[str, Any]]:
-    """Basic health check endpoint"""
+    """Basic health check endpoint.
+
+    Includes ML ``fallback_models`` state per PRD audit 2026-04 §3 D /
+    F-03-003. Empty ``fallback_models`` array == healthy production.
+    """
+    fb = _get_fallback_models_state()
+    overall = "healthy" if fb["fallback_models_count"] == 0 else "degraded"
     return success_response(data={
-        "status": "healthy",
+        "status": overall,
         "timestamp": datetime.now(timezone.utc).isoformat(),
         "version": "1.0.0",
-        "service": "investment-analysis-api"
+        "service": "investment-analysis-api",
+        **fb,
     })
 
 @router.get("/readiness")
@@ -64,12 +91,22 @@ async def readiness_check() -> ApiResponse[Dict[str, Any]]:
         errors["database"] = str(e)
         logger.error(f"Database health check failed: {e}")
 
+    # F-03-003: production-critical ML models in Dummy* fallback fail readiness.
+    fb = _get_fallback_models_state()
+    checks["ml_models"] = fb["fallback_models_count"] == 0
+    if not checks["ml_models"]:
+        errors["ml_models"] = (
+            f"{fb['fallback_models_count']} model(s) in fallback: "
+            f"{fb['fallback_models']}"
+        )
+
     all_ready = all(checks.values())
 
     data = {
         "status": "ready" if all_ready else "not ready",
         "checks": checks,
-        "timestamp": datetime.now(timezone.utc).isoformat()
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        **fb,
     }
 
     if errors:

--- a/backend/api/routers/recommendations.py
+++ b/backend/api/routers/recommendations.py
@@ -33,7 +33,10 @@ from backend.services.recommendation_service import (
     RECOMMENDATION_MODEL_TRAINING_DATE,
 )
 from backend.exceptions import ModelUnavailableError, InsufficientDataError
-from backend.api.error_responses import raise_model_unavailable
+from backend.api.error_responses import (
+    MODEL_UNAVAILABLE_503_RESPONSE,
+    raise_model_unavailable,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -468,7 +471,10 @@ async def get_portfolio_recommendations(portfolio_id: str) -> ApiResponse[Portfo
         diversification_score=data["diversification_score"],
     ))
 
-@router.get("/performance/track")
+@router.get(
+    "/performance/track",
+    responses={**MODEL_UNAVAILABLE_503_RESPONSE},
+)
 async def track_recommendation_performance(
     days_back: int = Query(30, le=365),
     status: Optional[str] = Query(None, pattern="^(active|closed|stopped_out)$")
@@ -494,7 +500,10 @@ async def update_alert_settings(settings: AlertSettings) -> ApiResponse[Dict[str
         "status": "success"
     })
 
-@router.get("/alerts/history")
+@router.get(
+    "/alerts/history",
+    responses={**MODEL_UNAVAILABLE_503_RESPONSE},
+)
 async def get_alert_history(
     days_back: int = Query(7, le=30)
 ) -> ApiResponse[List[Dict[str, Any]]]:
@@ -507,7 +516,10 @@ async def get_alert_history(
     alerts = recommendation_service.generate_alert_history(days_back=days_back)
     return success_response(data=alerts)
 
-@router.post("/backtest")
+@router.post(
+    "/backtest",
+    responses={**MODEL_UNAVAILABLE_503_RESPONSE},
+)
 async def backtest_strategy(
     strategy: RecommendationCategory,
     start_date: date,

--- a/backend/api/routers/recommendations.py
+++ b/backend/api/routers/recommendations.py
@@ -32,8 +32,30 @@ from backend.services.recommendation_service import (
     RECOMMENDATION_MODEL_VERSION,
     RECOMMENDATION_MODEL_TRAINING_DATE,
 )
+from backend.exceptions import ModelUnavailableError, InsufficientDataError
+from backend.api.error_responses import raise_model_unavailable
 
 logger = logging.getLogger(__name__)
+
+
+def _refuse_when_models_in_fallback(model: str = "recommendation_engine") -> None:
+    """Gate F-02-003 / F-03-003: refuse to serve random.uniform fabrications.
+
+    Per Q4 default: when ``settings.DEMO_MODE`` is False (production) and the
+    ML models are in DummyLSTM/DummyXGBoost/DummyProphet fallback, raise an
+    HTTP 503 ``model_unavailable`` instead of returning the legacy random-
+    data response. ``DEMO_MODE=true`` preserves the legacy synthetic path for
+    demo environments only.
+    """
+    if settings.DEMO_MODE:
+        return
+    try:
+        mgr = get_model_manager()
+    except Exception:  # pragma: no cover - never let the gate crash the request
+        raise_model_unavailable(model=model, reason="manager_unavailable")
+        return
+    if mgr.get_fallback_models():
+        raise_model_unavailable(model=model, reason="fallback_active")
 
 router = APIRouter(tags=["recommendations"])
 
@@ -451,7 +473,13 @@ async def track_recommendation_performance(
     days_back: int = Query(30, le=365),
     status: Optional[str] = Query(None, pattern="^(active|closed|stopped_out)$")
 ) -> ApiResponse[List[RecommendationPerformance]]:
-    """Track performance of past recommendations"""
+    """Track performance of past recommendations.
+
+    F-02-003: refuses with 503 ``model_unavailable`` in production when ML
+    models are in fallback (recommendation engine cannot produce real
+    performance records without the underlying model binaries).
+    """
+    _refuse_when_models_in_fallback(model="recommendation_performance")
     perf_data = recommendation_service.generate_performance_records(
         days_back=days_back,
         status_filter=status,
@@ -470,7 +498,12 @@ async def update_alert_settings(settings: AlertSettings) -> ApiResponse[Dict[str
 async def get_alert_history(
     days_back: int = Query(7, le=30)
 ) -> ApiResponse[List[Dict[str, Any]]]:
-    """Get history of recommendation alerts"""
+    """Get history of recommendation alerts.
+
+    F-02-003: refuses with 503 in production when models are in fallback —
+    the alert stream is downstream of the random-recommendation generator.
+    """
+    _refuse_when_models_in_fallback(model="recommendation_alerts")
     alerts = recommendation_service.generate_alert_history(days_back=days_back)
     return success_response(data=alerts)
 
@@ -481,7 +514,13 @@ async def backtest_strategy(
     end_date: date,
     initial_capital: float = 100000
 ) -> ApiResponse[Dict[str, Any]]:
-    """Backtest a recommendation strategy"""
+    """Backtest a recommendation strategy.
+
+    F-02-003: backtest results are SEC-implicated investment outputs. When
+    the underlying ML models are unavailable, we refuse with HTTP 503 rather
+    than ship random.uniform total_return / sharpe_ratio fabrications.
+    """
+    _refuse_when_models_in_fallback(model="recommendation_backtest")
     result = recommendation_service.run_backtest(
         strategy=strategy.value,
         start_date=start_date,

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -18,6 +18,15 @@ class Settings(BaseSettings):
     DEBUG: bool = False
     TESTING: bool = False  # Set to True in test environments to disable certain middleware
     ENVIRONMENT: str = "production"
+    # F-02-003 / F-03-003 / Q4 default (PRD audit 2026-04, recorded 2026-04-28):
+    # When False (default), endpoints that previously returned random.uniform()
+    # placeholder values must instead refuse with HTTP 503 model_unavailable.
+    # Setting DEMO_MODE=true gates the legacy synthetic responses behind an
+    # explicit opt-in for non-production demo environments only. NEVER enable
+    # in environments accessible to external users — the platform is
+    # SEC-regulated and shipping fabricated investment outputs is a
+    # compliance exposure.
+    DEMO_MODE: bool = False
     SECRET_KEY: str
     JWT_SECRET_KEY: str
     LOG_LEVEL: str = "INFO"

--- a/backend/exceptions.py
+++ b/backend/exceptions.py
@@ -92,3 +92,47 @@ class InsufficientBalanceError(ConflictError):
 class InvalidPositionError(ConflictError):
     """Raised when attempting to sell more shares than owned"""
     pass
+
+
+class InsufficientDataError(AppException):
+    """
+    Raised when insufficient data is available to compute a result.
+
+    Used in analysis pipelines (risk metrics, drift detection, feature stats)
+    when the upstream data is missing, too short, or otherwise inadequate to
+    produce a faithful answer. Callers should surface this as HTTP 503
+    `model_unavailable` rather than fabricating placeholder values.
+
+    Per PRD audit 2026-04 Q4 default: returning fake values for SEC-regulated
+    investment outputs is a compliance exposure; refuse instead.
+    """
+    def __init__(self, reason: str = "insufficient_data", details: dict | None = None):
+        self.reason = reason
+        self.details = details or {}
+        super().__init__(f"Insufficient data: {reason}")
+
+
+class ModelUnavailableError(AppException):
+    """
+    Raised when an ML model required to serve a request is not available.
+
+    Triggered when `model_manager` is in `Dummy*` fallback (model binaries
+    missing) or when a feature pipeline cannot supply real inputs. API
+    handlers convert this to HTTP 503 with a structured
+    `{"error": "model_unavailable", "model": ..., "reason": ...}` payload.
+
+    Per PRD audit 2026-04 §3 D and Q4 default (recorded 2026-04-28).
+    """
+    def __init__(
+        self,
+        model: str = "unknown",
+        reason: str = "fallback_active",
+        request_id: str | None = None,
+    ):
+        self.model = model
+        self.reason = reason
+        self.request_id = request_id
+        super().__init__(
+            f"Model '{model}' unavailable ({reason}); "
+            "platform refuses to fabricate values."
+        )

--- a/backend/exceptions.py
+++ b/backend/exceptions.py
@@ -2,6 +2,8 @@
 Custom Exceptions for Investment Analysis Platform
 Provides specialized exceptions for error handling across the application.
 """
+from typing import Optional
+
 
 class AppException(Exception):
     """Base application exception"""
@@ -106,7 +108,7 @@ class InsufficientDataError(AppException):
     Per PRD audit 2026-04 Q4 default: returning fake values for SEC-regulated
     investment outputs is a compliance exposure; refuse instead.
     """
-    def __init__(self, reason: str = "insufficient_data", details: dict | None = None):
+    def __init__(self, reason: str = "insufficient_data", details: Optional[dict] = None):
         self.reason = reason
         self.details = details or {}
         super().__init__(f"Insufficient data: {reason}")
@@ -127,7 +129,7 @@ class ModelUnavailableError(AppException):
         self,
         model: str = "unknown",
         reason: str = "fallback_active",
-        request_id: str | None = None,
+        request_id: Optional[str] = None,
     ):
         self.model = model
         self.reason = reason

--- a/backend/middleware/error_handler.py
+++ b/backend/middleware/error_handler.py
@@ -96,6 +96,63 @@ async def general_exception_handler(request: Request, exc: Exception) -> JSONRes
     )
 
 
+async def model_unavailable_handler(request: Request, exc) -> JSONResponse:
+    """Convert ``ModelUnavailableError`` / ``InsufficientDataError`` to 503.
+
+    Per PRD audit 2026-04 Workstream D / Q4 default: refusing-to-serve when
+    ML models are in DummyLSTM/DummyXGBoost/DummyProphet fallback or when
+    feature data is insufficient is the SEC-conservative posture. Returns
+    the canonical structured payload so the frontend (G3 phase 4) has a
+    stable contract: ``{error, model, reason, request_id}``.
+    """
+    import uuid as _uuid
+    from backend.exceptions import InsufficientDataError, ModelUnavailableError
+
+    if isinstance(exc, ModelUnavailableError):
+        model = exc.model
+        reason = exc.reason
+        rid = exc.request_id or _uuid.uuid4().hex
+    elif isinstance(exc, InsufficientDataError):
+        model = (exc.details or {}).get("metric") or (exc.details or {}).get("feature") or "unknown"
+        reason = exc.reason or "insufficient_data"
+        rid = _uuid.uuid4().hex
+    else:  # pragma: no cover - defensive
+        model = "unknown"
+        reason = "fallback_active"
+        rid = _uuid.uuid4().hex
+
+    logger.warning(
+        "model_unavailable model=%s reason=%s path=%s request_id=%s",
+        model, reason, request.url.path, rid,
+    )
+
+    try:  # Sentry breadcrumb tagged ``model_unavailable``
+        import sentry_sdk
+        sentry_sdk.add_breadcrumb(
+            category="model_unavailable",
+            message=f"503 model_unavailable: {model} ({reason})",
+            level="warning",
+            data={
+                "model": model,
+                "reason": reason,
+                "request_id": rid,
+                "endpoint": request.url.path,
+            },
+        )
+    except Exception:  # pragma: no cover - never let telemetry crash a 503
+        pass
+
+    return JSONResponse(
+        status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+        content={
+            "error": "model_unavailable",
+            "model": model,
+            "reason": reason,
+            "request_id": rid,
+        },
+    )
+
+
 def register_exception_handlers(app):
     """
     Register all exception handlers with the FastAPI app
@@ -106,7 +163,12 @@ def register_exception_handlers(app):
         app = FastAPI()
         register_exception_handlers(app)
     """
+    from backend.exceptions import InsufficientDataError, ModelUnavailableError
+
     app.add_exception_handler(HTTPException, http_exception_handler)
     app.add_exception_handler(RequestValidationError, validation_exception_handler)
     app.add_exception_handler(ValidationError, validation_exception_handler)
+    # F-02-003 / F-03-003 / F-03-005: structured 503 ``model_unavailable``
+    app.add_exception_handler(ModelUnavailableError, model_unavailable_handler)
+    app.add_exception_handler(InsufficientDataError, model_unavailable_handler)
     app.add_exception_handler(Exception, general_exception_handler)

--- a/backend/ml/feature_store.py
+++ b/backend/ml/feature_store.py
@@ -650,40 +650,110 @@ class FeatureStore:
                             feature_name: str,
                             reference_period_days: int = 30,
                             current_period_days: int = 7) -> Optional[FeatureDriftMetrics]:
-        """Monitor feature drift over time"""
-        
+        """Monitor feature drift over time using real feature_values rows.
+
+        Per PRD audit 2026-04 F-03-005 / Q4 default: this method previously
+        fabricated reference + current windows from ``np.random.normal()``
+        which caused drift alerts to fire on noise. We now query the
+        ``feature_values`` table directly and raise ``InsufficientDataError``
+        when no real data is available — callers surface that as HTTP 503
+        ``model_unavailable``.
+        """
+        from backend.exceptions import InsufficientDataError
+
         if feature_name not in self.feature_registry:
             logger.error(f"Feature {feature_name} not registered")
             return None
-        
+
+        end_date = datetime.now(timezone.utc)
+        reference_start = end_date - timedelta(
+            days=reference_period_days + current_period_days
+        )
+        reference_end = end_date - timedelta(days=current_period_days)
+        current_start = reference_end
+
+        reference_values = self._load_feature_window(
+            feature_name, reference_start, reference_end,
+        )
+        current_values = self._load_feature_window(
+            feature_name, current_start, end_date,
+        )
+
+        if not reference_values or not current_values:
+            raise InsufficientDataError(
+                reason="insufficient_data",
+                details={
+                    "feature": feature_name,
+                    "reference_count": len(reference_values),
+                    "current_count": len(current_values),
+                    "minimum_required": 1,
+                },
+            )
+
+        reference_data = pd.Series(reference_values)
+        current_data = pd.Series(current_values)
+
         try:
-            # Get historical feature values
-            end_date = datetime.now(timezone.utc)
-            reference_start = end_date - timedelta(days=reference_period_days + current_period_days)
-            reference_end = end_date - timedelta(days=current_period_days)
-            current_start = reference_end
-            
-            # Mock data for demonstration - in real implementation, query feature store
-            reference_data = pd.Series(np.random.normal(0, 1, 1000))
-            current_data = pd.Series(np.random.normal(0.2, 1.2, 200))  # Simulated drift
-            
             drift_metrics = self.drift_detector.detect_drift(
                 feature_name, reference_data, current_data
             )
-            
-            # Store drift metrics
-            self._save_drift_metrics(drift_metrics)
-            
-            # Alert if significant drift detected
-            if drift_metrics.distribution_shift_detected:
-                logger.warning(f"Feature drift detected for {feature_name}: "
-                             f"drift_score={drift_metrics.drift_score:.3f}")
-            
-            return drift_metrics
-            
-        except Exception as e:
-            logger.error(f"Error monitoring drift for feature {feature_name}: {e}")
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.error(f"Error monitoring drift for feature {feature_name}: {exc}")
             return None
+
+        self._save_drift_metrics(drift_metrics)
+
+        if drift_metrics.distribution_shift_detected:
+            logger.warning(
+                f"Feature drift detected for {feature_name}: "
+                f"drift_score={drift_metrics.drift_score:.3f}"
+            )
+
+        return drift_metrics
+
+    def _load_feature_window(
+        self,
+        feature_name: str,
+        start: datetime,
+        end: datetime,
+    ) -> List[float]:
+        """Load feature_values rows for ``feature_name`` between ``start`` and ``end``.
+
+        Returns an empty list when ``self.db_engine`` is not configured or
+        when the query yields zero rows. Callers must treat empty as
+        ``InsufficientDataError`` rather than fabricate values (F-03-005).
+        """
+        if self.db_engine is None:
+            return []
+        try:
+            from sqlalchemy import text  # local import to keep top-level light
+
+            sql = text(
+                """
+                SELECT fv.value
+                  FROM feature_values fv
+                  JOIN feature_definitions fd ON fd.id = fv.feature_id
+                 WHERE fd.name = :name
+                   AND fv.computed_at >= :start
+                   AND fv.computed_at < :end
+                """
+            )
+            with self.db_engine.connect() as conn:
+                rows = conn.execute(
+                    sql, {"name": feature_name, "start": start, "end": end}
+                ).fetchall()
+            values: List[float] = []
+            for row in rows:
+                try:
+                    values.append(float(row[0]))
+                except (TypeError, ValueError):
+                    continue
+            return values
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning(
+                f"_load_feature_window query failed for {feature_name}: {exc}"
+            )
+            return []
     
     def get_feature_lineage(self, feature_name: str) -> Dict[str, Any]:
         """Get feature lineage and dependencies"""
@@ -729,36 +799,56 @@ class FeatureStore:
         
         return lineage
     
-    def get_feature_statistics(self, feature_names: List[str], 
+    def get_feature_statistics(self, feature_names: List[str],
                              days_back: int = 30) -> Dict[str, Dict[str, Any]]:
-        """Get comprehensive feature statistics"""
-        
-        stats = {}
-        
+        """Get comprehensive feature statistics from the feature store.
+
+        Per PRD audit 2026-04 F-03-005 / Q4 default: previously returned
+        ``{'count': np.random.randint(1000, 10000), 'mean': np.random.normal(...)}``
+        which broke alerting / capacity-planning telemetry. We now compute
+        real summary statistics from ``feature_values`` rows, or raise
+        ``InsufficientDataError`` when no real rows exist.
+        """
+        from backend.exceptions import InsufficientDataError
+
+        end = datetime.now(timezone.utc)
+        start = end - timedelta(days=days_back)
+
+        stats: Dict[str, Dict[str, Any]] = {}
+        missing: List[str] = []
+
         for feature_name in feature_names:
             if feature_name not in self.feature_registry:
                 continue
-            
-            try:
-                # Mock statistics - in real implementation, query feature store
-                feature_stats = {
-                    'count': np.random.randint(1000, 10000),
-                    'mean': np.random.normal(0, 1),
-                    'std': np.random.uniform(0.5, 2.0),
-                    'min': np.random.normal(-3, 0.5),
-                    'max': np.random.normal(3, 0.5),
-                    'null_percentage': np.random.uniform(0, 0.05),
-                    'unique_values': np.random.randint(100, 1000),
-                    'quality_score': np.random.uniform(0.8, 1.0),
-                    'last_updated': datetime.now(timezone.utc).isoformat(),
-                    'freshness_hours': np.random.uniform(0, 24)
-                }
-                
-                stats[feature_name] = feature_stats
-                
-            except Exception as e:
-                logger.error(f"Error getting statistics for feature {feature_name}: {e}")
-        
+
+            values = self._load_feature_window(feature_name, start, end)
+            if not values:
+                missing.append(feature_name)
+                continue
+
+            arr = np.asarray(values, dtype=float)
+            non_null = arr[~np.isnan(arr)]
+            stats[feature_name] = {
+                'count': int(arr.size),
+                'mean': float(non_null.mean()) if non_null.size else None,
+                'std': float(non_null.std(ddof=0)) if non_null.size else None,
+                'min': float(non_null.min()) if non_null.size else None,
+                'max': float(non_null.max()) if non_null.size else None,
+                'null_percentage': (
+                    float((arr.size - non_null.size) / arr.size)
+                    if arr.size else 0.0
+                ),
+                'unique_values': int(np.unique(non_null).size) if non_null.size else 0,
+                'last_updated': end.isoformat(),
+            }
+
+        if missing and not stats:
+            # Nothing real for any requested feature — surface as 503.
+            raise InsufficientDataError(
+                reason="insufficient_data",
+                details={"missing_features": missing, "days_back": days_back},
+            )
+
         return stats
     
     def _generate_cache_key(self, feature_names: List[str], entity_ids: List[str], timestamp: datetime) -> str:

--- a/backend/ml/model_manager.py
+++ b/backend/ml/model_manager.py
@@ -433,7 +433,49 @@ class ModelManager:
         """Get a loaded model by name"""
         with self.lock:
             return self.models.get(model_name)
-    
+
+    def is_using_fallback(self, model_name: str) -> bool:
+        """Return True if ``model_name`` is currently a Dummy* fallback.
+
+        Per PRD audit 2026-04 §3 D / Q4 default: model_unavailable state is
+        a refuse-to-serve signal, not a degraded-success signal.
+        """
+        with self.lock:
+            meta = self.model_metadata.get(model_name)
+        if not meta:
+            return True  # absent → treat as unavailable
+        return meta.get("status") == "fallback"
+
+    def get_fallback_models(self) -> List[str]:
+        """List of model names currently in Dummy* fallback state.
+
+        Drives the ``GET /health`` ``fallback_models`` field and the readiness
+        probe. Empty list = healthy production.
+        """
+        with self.lock:
+            return [
+                name for name, meta in self.model_metadata.items()
+                if meta.get("status") == "fallback"
+            ]
+
+    def assert_real_model(self, model_name: str) -> None:
+        """Raise ``ModelUnavailableError`` if ``model_name`` is in fallback.
+
+        Call sites that produce SEC-implicated investment outputs MUST gate
+        with this before serving — fabricated values are a compliance
+        exposure (PRD audit 2026-04 Q4 default, recorded 2026-04-28).
+        """
+        from backend.exceptions import ModelUnavailableError  # local import to avoid cycle
+
+        with self.lock:
+            meta = self.model_metadata.get(model_name)
+        if meta is None:
+            raise ModelUnavailableError(model=model_name, reason="binary_missing")
+        status_ = meta.get("status")
+        if status_ == "fallback":
+            reason = "binary_missing" if meta.get("reason") == "file_not_found" else "fallback_active"
+            raise ModelUnavailableError(model=model_name, reason=reason)
+
     def predict(self, model_name: str, data: Any) -> Any:
         """Make prediction with error handling"""
         try:

--- a/backend/services/admin_service.py
+++ b/backend/services/admin_service.py
@@ -12,6 +12,8 @@ import uuid
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional
 
+from backend.config.settings import settings
+from backend.exceptions import ModelUnavailableError
 from backend.utils.security_logger import sanitize_log_input
 
 logger = logging.getLogger(__name__)
@@ -168,9 +170,24 @@ def list_users(
     """
     Return a filtered, paginated list of users.
 
-    Generates 100 simulated user records, applies optional role and
-    is_active filters, then returns the requested page.
+    Production behaviour (``settings.DEMO_MODE`` False, default): refuses
+    with :class:`ModelUnavailableError`. Per PRD audit 2026-04 §3 D Step 2
+    (Q4 default, recorded 2026-04-28), this endpoint historically fabricated
+    user records via ``random.choice``/``random.randint`` and surfaced them
+    through the authenticated admin ``GET /admin/users`` route — an
+    SEC-regulated platform must not synthesise user-directory data. The
+    real-implementation path (DB query against the ``users`` table) is
+    sequenced for a follow-up scope; until then the endpoint refuses.
+
+    Demo behaviour (``settings.DEMO_MODE`` True): keeps the legacy synthetic
+    100-record generator behind the explicit demo gate.
     """
+    if not settings.DEMO_MODE:
+        raise ModelUnavailableError(
+            model="admin_user_directory",
+            reason="not_implemented",
+        )
+
     users = [build_user_record(i) for i in range(100)]
 
     if role is not None:

--- a/backend/services/admin_service.py
+++ b/backend/services/admin_service.py
@@ -7,6 +7,7 @@ API analytics, system metrics, job management, configuration, and maintenance mo
 import logging
 import os
 import random
+import time
 import uuid
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional
@@ -15,28 +16,102 @@ from backend.utils.security_logger import sanitize_log_input
 
 logger = logging.getLogger(__name__)
 
+# F-02-003 (PRD audit 2026-04 / Q4 default): admin/system endpoints must
+# surface real OS-level metrics rather than random.uniform() fabrications.
+try:  # pragma: no cover - environment-dependent
+    import psutil  # type: ignore
+    # Prime cpu_percent() so the first non-blocking call returns a real
+    # value rather than the documented 0.0 sentinel — otherwise two
+    # adjacent /system/health calls swing 0→N and look like random data.
+    try:
+        psutil.cpu_percent(interval=None)
+    except Exception:
+        pass
+    _PSUTIL_AVAILABLE = True
+except Exception:
+    psutil = None  # type: ignore[assignment]
+    _PSUTIL_AVAILABLE = False
+
+# Process start time used as the uptime anchor when /proc/uptime is not
+# available (e.g. macOS dev machines).
+_PROCESS_START_MONOTONIC = time.monotonic()
+
+
+def _process_uptime_seconds() -> int:
+    """Best-effort uptime since process start, in whole seconds."""
+    return int(max(0.0, time.monotonic() - _PROCESS_START_MONOTONIC))
+
 
 # ---------------------------------------------------------------------------
 # System Health
 # ---------------------------------------------------------------------------
 
 def get_system_health_data() -> Dict[str, Any]:
-    """
-    Aggregate system health metrics.
+    """Aggregate system health metrics from real OS counters.
 
-    Returns a dict matching the SystemHealth schema with realistic simulated
-    values for all monitored services.
+    Per PRD audit 2026-04 F-02-003 / Q4 default (recorded 2026-04-28): the
+    pre-fix implementation returned ``random.uniform(20, 80)`` for CPU/mem/
+    disk every call, which made admin telemetry non-credible (two adjacent
+    calls returned wildly different numbers with no real load change).
+
+    psutil-backed values are deterministic-ish (system state changes
+    naturally between calls but not by tens of percent at random). When
+    psutil is unavailable the function returns an explicit
+    ``status: 'unknown'`` rather than fabricated numbers — callers should
+    treat this the same as the 503 ``model_unavailable`` empty-state.
     """
+    if not _PSUTIL_AVAILABLE:
+        # Acceptance gate per workpaper §3.3: integration test must observe
+        # psutil-backed real numbers — never random.uniform.
+        return {
+            "status": "unknown",
+            "uptime": _process_uptime_seconds(),
+            "cpu_usage": None,
+            "memory_usage": None,
+            "disk_usage": None,
+            "active_connections": None,
+            "request_rate": None,
+            "error_rate": None,
+            "response_time_avg": None,
+            "services": {
+                "api": "running",
+                "database": "unknown",
+                "cache": "unknown",
+                "worker": "unknown",
+                "scheduler": "unknown",
+                "websocket": "unknown",
+            },
+            "last_check": datetime.now(timezone.utc),
+            "data_source": "psutil_unavailable",
+        }
+
+    # Use a tiny sampling interval so the cpu_percent value reflects current
+    # state, not the cumulative-since-last-call delta which can be 0.0.
+    cpu_usage = psutil.cpu_percent(interval=0.05)
+    vmem = psutil.virtual_memory()
+    try:
+        disk = psutil.disk_usage("/").percent
+    except Exception:
+        disk = None
+    try:
+        active_connections = len(psutil.net_connections(kind="inet"))
+    except Exception:
+        # Some environments deny net_connections without elevated privileges.
+        active_connections = None
+
     return {
         "status": "operational",
-        "uptime": random.randint(86400, 864000),
-        "cpu_usage": random.uniform(20, 80),
-        "memory_usage": random.uniform(30, 70),
-        "disk_usage": random.uniform(40, 60),
-        "active_connections": random.randint(10, 100),
-        "request_rate": random.uniform(10, 100),
-        "error_rate": random.uniform(0, 5),
-        "response_time_avg": random.uniform(50, 200),
+        "uptime": _process_uptime_seconds(),
+        "cpu_usage": float(cpu_usage),
+        "memory_usage": float(vmem.percent),
+        "disk_usage": float(disk) if disk is not None else None,
+        "active_connections": active_connections,
+        # request_rate / error_rate / response_time_avg are observability
+        # signals that should come from Prometheus, not be fabricated. We
+        # surface None and rely on /metrics + Grafana for the real series.
+        "request_rate": None,
+        "error_rate": None,
+        "response_time_avg": None,
         "services": {
             "api": "running",
             "database": "running",
@@ -46,6 +121,7 @@ def get_system_health_data() -> Dict[str, Any]:
             "websocket": "running",
         },
         "last_check": datetime.now(timezone.utc),
+        "data_source": "psutil",
     }
 
 

--- a/backend/services/analysis_service.py
+++ b/backend/services/analysis_service.py
@@ -279,52 +279,53 @@ def generate_insights(analysis: Dict) -> List[str]:
 
 
 def calculate_risk_metrics_from_prices(prices: List[float]) -> Dict[str, Any]:
+    """Calculate risk metrics from a list of closing prices.
+
+    Raises:
+        InsufficientDataError: When fewer than 30 price observations are
+            available. Per PRD audit 2026-04 F-02-018 / Q4 default
+            (recorded 2026-04-28), short-circuit branches must NOT return
+            hardcoded plausible-but-fake risk metrics. Callers must surface
+            this as HTTP 503 ``model_unavailable``.
     """
-    Calculate risk metrics from a list of closing prices.
+    from backend.exceptions import InsufficientDataError  # local: avoid import cycle
 
-    Returns a dict of risk metrics fields for use in RiskMetrics construction.
-    Returns fallback values when insufficient data.
-    """
-    if prices and len(prices) >= 30:
-        returns = [(prices[i] - prices[i - 1]) / prices[i - 1] for i in range(1, len(prices))]
-
-        volatility = statistics.stdev(returns) if len(returns) > 1 else 0.0
-        mean_return = statistics.mean(returns) if returns else 0.0
-
-        sharpe_ratio = (
-            (mean_return * 252) / (volatility * math.sqrt(252))
-            if volatility > 0 else 0.0
+    if not prices or len(prices) < 30:
+        raise InsufficientDataError(
+            reason="insufficient_data",
+            details={
+                "metric": "risk_metrics",
+                "have": len(prices) if prices else 0,
+                "need": 30,
+            },
         )
 
-        return {
-            "beta": None,
-            "alpha": mean_return * 252,
-            "sharpe_ratio": sharpe_ratio,
-            "sortino_ratio": sharpe_ratio * 1.2,
-            "max_drawdown": min(returns) if returns else 0.0,
-            "var_95": (
-                statistics.quantiles(returns, n=20)[0]
-                if len(returns) > 20
-                else min(returns, default=0.0)
-            ),
-            "cvar_95": min(returns) if returns else 0.0,
-            "correlation_with_market": None,
-            "risk_adjusted_return": mean_return / volatility if volatility > 0 else 0.0,
-            "overall_risk_score": min(100, max(0, (volatility * 100) * 2))
-        }
-    else:
-        return {
-            "beta": 1.15,
-            "alpha": 0.02,
-            "sharpe_ratio": 1.85,
-            "sortino_ratio": 2.10,
-            "max_drawdown": -0.15,
-            "var_95": -0.025,
-            "cvar_95": -0.035,
-            "correlation_with_market": 0.75,
-            "risk_adjusted_return": 0.18,
-            "overall_risk_score": 42.0
-        }
+    returns = [(prices[i] - prices[i - 1]) / prices[i - 1] for i in range(1, len(prices))]
+
+    volatility = statistics.stdev(returns) if len(returns) > 1 else 0.0
+    mean_return = statistics.mean(returns) if returns else 0.0
+
+    sharpe_ratio = (
+        (mean_return * 252) / (volatility * math.sqrt(252))
+        if volatility > 0 else 0.0
+    )
+
+    return {
+        "beta": None,
+        "alpha": mean_return * 252,
+        "sharpe_ratio": sharpe_ratio,
+        "sortino_ratio": sharpe_ratio * 1.2,
+        "max_drawdown": min(returns) if returns else 0.0,
+        "var_95": (
+            statistics.quantiles(returns, n=20)[0]
+            if len(returns) > 20
+            else min(returns, default=0.0)
+        ),
+        "cvar_95": min(returns) if returns else 0.0,
+        "correlation_with_market": None,
+        "risk_adjusted_return": mean_return / volatility if volatility > 0 else 0.0,
+        "overall_risk_score": min(100, max(0, (volatility * 100) * 2))
+    }
 
 
 def calculate_overall_score(

--- a/backend/services/portfolio_rebalancing.py
+++ b/backend/services/portfolio_rebalancing.py
@@ -10,6 +10,9 @@ import uuid
 from typing import Dict, List, Any, Optional
 from datetime import datetime, date, timedelta, timezone
 
+from backend.config.settings import settings
+from backend.exceptions import ModelUnavailableError
+
 logger = logging.getLogger(__name__)
 
 
@@ -18,17 +21,24 @@ def generate_performance_data_points(
     period: str,
     benchmark: str = "SPY",
 ) -> Dict[str, Any]:
-    """
-    Generate portfolio performance data points over the requested period.
+    """Generate portfolio performance data points over the requested period.
 
-    Args:
-        portfolio_id: Portfolio ID
-        period: One of 1D, 1W, 1M, 3M, 6M, 1Y, 3Y, 5Y, ALL
-        benchmark: Benchmark ticker symbol
+    Per PRD audit 2026-04 F-02-003 / Q4 default: this function previously
+    returned ``random.uniform``-derived chart data and metrics. It is now
+    gated behind ``settings.DEMO_MODE`` so production raises
+    ``ModelUnavailableError`` (surfaced as HTTP 503 ``model_unavailable``
+    by the portfolio router) rather than fabricating chart values.
 
-    Returns:
-        Dictionary with data_points list and aggregated metrics
+    The full real implementation requires a portfolio time-series store; the
+    G2a workstream owns the ML/analytics path that will populate it. Until
+    that lands, refusing-to-serve is the SEC-conservative posture.
     """
+    if not settings.DEMO_MODE:
+        raise ModelUnavailableError(
+            model="portfolio_performance",
+            reason="not_implemented",
+        )
+
     period_map = {
         "1D": 24,
         "1W": 7,
@@ -59,6 +69,7 @@ def generate_performance_data_points(
     return {
         "portfolio_id": portfolio_id,
         "period": period,
+        "data_source": "simulated",  # F-02-003: explicit demo tag
         "data_points": data_points,
         "metrics": {
             "total_return": round(total_return, 4),

--- a/backend/services/recommendation_service.py
+++ b/backend/services/recommendation_service.py
@@ -11,6 +11,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend.analytics.recommendation_engine import RecommendationEngine, StockRecommendation
 from backend.analytics.fundamental_analysis import FundamentalAnalysisEngine
+from backend.config.settings import settings
+from backend.exceptions import ModelUnavailableError
 
 logger = logging.getLogger(__name__)
 
@@ -763,7 +765,21 @@ class RecommendationService:
 
         Returns:
             Dictionary with complete backtest performance summary
+
+        Raises:
+            ModelUnavailableError: when ``settings.DEMO_MODE`` is False
+                (production default). Per PRD audit 2026-04 §3 D Step 2
+                (F-02-003, Q4 default), backtest results are sourced from
+                ``random.uniform`` and must not surface as real numbers in
+                production; the router layer already returns 503 but this
+                defense-in-depth gate covers internal/script callers.
         """
+        if not settings.DEMO_MODE:
+            raise ModelUnavailableError(
+                model="recommendation_backtest",
+                reason="not_implemented",
+            )
+
         total_return = random.uniform(-0.2, 0.5)
         days = (end_date - start_date).days or 1  # avoid division by zero
 
@@ -812,7 +828,21 @@ class RecommendationService:
 
         Returns:
             List of performance record dictionaries
+
+        Raises:
+            ModelUnavailableError: when ``settings.DEMO_MODE`` is False
+                (production default). Per PRD audit 2026-04 §3 D Step 2
+                (F-02-003, Q4 default), performance records are fabricated
+                via ``random.choice`` and ``random.uniform``; production
+                must surface a 503 rather than synthetic numbers tied to
+                non-existent recommendation IDs.
         """
+        if not settings.DEMO_MODE:
+            raise ModelUnavailableError(
+                model="recommendation_performance_history",
+                reason="not_implemented",
+            )
+
         performances = []
 
         for i in range(20):
@@ -888,7 +918,21 @@ class RecommendationService:
 
         Returns:
             List of alert dictionaries sorted by timestamp descending
+
+        Raises:
+            ModelUnavailableError: when ``settings.DEMO_MODE`` is False
+                (production default). Per PRD audit 2026-04 §3 D Step 2
+                (F-02-003, Q4 default), alert history entries are
+                fabricated via ``random.choice``; surfacing them on the
+                authenticated ``/alerts/history`` route would imply a real
+                signal pipeline that does not exist.
         """
+        if not settings.DEMO_MODE:
+            raise ModelUnavailableError(
+                model="recommendation_alert_history",
+                reason="not_implemented",
+            )
+
         alerts = []
         for i in range(10):
             alert_date = datetime.now(timezone.utc) - timedelta(days=random.randint(0, days_back))

--- a/backend/services/socketio_service.py
+++ b/backend/services/socketio_service.py
@@ -256,8 +256,44 @@ async def emit_alert_notification(user_id: str, alert_data: Dict[str, Any]) -> N
 # ---------------------------------------------------------------------------
 
 async def _stream_price_updates(symbol: str, room: str) -> None:
-    """Continuously emit simulated price updates to *room* until cancelled."""
+    """Stream price updates to ``room`` until cancelled.
+
+    Per PRD audit 2026-04 F-02-003 / Q4 default (recorded 2026-04-28): this
+    coroutine previously fabricated price/change/volume/bid/ask values via
+    ``random.uniform`` and broadcast them to subscribed clients. For an
+    SEC-regulated investment platform, broadcasting fake live prices is a
+    serious correctness + compliance failure.
+
+    Production behaviour (``settings.DEMO_MODE`` False, default):
+        Emit a single ``price_unavailable`` payload telling subscribers
+        that the live feed is not wired up and the stream is intentionally
+        stopped — avoids leaving sockets open spinning out fake ticks.
+
+    Demo behaviour (``settings.DEMO_MODE`` True): keep the legacy synthetic
+    stream, but every payload is tagged ``data_source: 'simulated'`` so
+    consumers can render an explicit "demo data" badge.
+    """
+    from backend.config.settings import settings
+
     logger.info("Starting price stream for symbol: %s", symbol)
+
+    if not settings.DEMO_MODE:
+        await sio.emit(
+            "price_unavailable",
+            {
+                "symbol": symbol,
+                "error": "model_unavailable",
+                "reason": "live_feed_not_configured",
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+            },
+            room=room,
+        )
+        logger.warning(
+            "_stream_price_updates: refusing to fabricate ticks for %s "
+            "(DEMO_MODE=false); emitting price_unavailable", symbol,
+        )
+        return
+
     try:
         while True:
             payload = {
@@ -271,6 +307,7 @@ async def _stream_price_updates(symbol: str, room: str) -> None:
                 "bid_size": random.randint(100, 1000),
                 "ask_size": random.randint(100, 1000),
                 "timestamp": datetime.now(timezone.utc).isoformat(),
+                "data_source": "simulated",  # F-02-003: explicit demo tag
             }
             await sio.emit("price_update", payload, room=room)
             await asyncio.sleep(

--- a/backend/tests/unit/test_admin_service.py
+++ b/backend/tests/unit/test_admin_service.py
@@ -155,6 +155,18 @@ class TestBuildUserRecord:
 
 
 class TestListUsers:
+    """Exercises the legacy synthetic listing behind ``DEMO_MODE=True``.
+
+    Production refusal (``DEMO_MODE=False`` raising ``ModelUnavailableError``)
+    is covered by ``test_f02003_service_layer_gating.py`` per PRD audit
+    2026-04 §3 D Step 2.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _demo_mode(self, monkeypatch):
+        from backend.config.settings import settings
+        monkeypatch.setattr(settings, "DEMO_MODE", True)
+        yield
 
     def test_default_returns_list(self):
         """Default call returns a list of dicts."""

--- a/backend/tests/unit/test_admin_service_health_determinism.py
+++ b/backend/tests/unit/test_admin_service_health_determinism.py
@@ -1,0 +1,68 @@
+"""F-02-003 fail-first regression tests for admin_service.get_system_health_data.
+
+Per PRD audit 2026-04 Workstream D §4 / Q4 default (recorded 2026-04-28):
+``admin_service.get_system_health_data()`` previously returned
+``random.uniform(20, 80)`` for ``cpu_usage`` / ``memory_usage`` /
+``disk_usage`` and ``random.randint(86400, 864000)`` for uptime, so two
+adjacent calls produced wildly different values with no real load change —
+admin telemetry was non-credible by design.
+
+Post-fix: psutil-derived numbers are deterministic-ish (within a small
+jitter tolerance). The endpoint declares its data source via
+``data_source: 'psutil'`` (or ``'psutil_unavailable'`` when the library is
+absent — never random).
+"""
+from __future__ import annotations
+
+import time
+
+import pytest
+
+
+def _h():
+    from backend.services.admin_service import get_system_health_data
+    return get_system_health_data()
+
+
+class TestSystemHealthDataDeterminismF02003:
+    """Two consecutive calls must NOT produce ``random.uniform``-style swings."""
+
+    def test_data_source_is_not_random(self):
+        h = _h()
+        assert h.get("data_source") in {"psutil", "psutil_unavailable"}, (
+            "F-02-003: get_system_health_data must declare a real data source "
+            "(psutil or explicit psutil_unavailable), not silently fabricate"
+        )
+
+    def test_cpu_usage_is_stable_or_explicitly_unavailable(self):
+        h1 = _h()
+        h2 = _h()
+        # If psutil is unavailable both must report None.
+        if h1.get("data_source") == "psutil_unavailable":
+            assert h1.get("cpu_usage") is None
+            assert h2.get("cpu_usage") is None
+            return
+
+        # psutil-backed: between two adjacent calls CPU should not jump by
+        # more than 60 percentage points (random.uniform(20, 80) routinely
+        # produced swings of 50+ points). A real idle process shows <5pp;
+        # we allow 60pp slack to keep the test deterministic on a busy CI.
+        c1, c2 = h1["cpu_usage"], h2["cpu_usage"]
+        assert isinstance(c1, float)
+        assert isinstance(c2, float)
+        assert abs(c1 - c2) < 60.0, (
+            f"F-02-003: cpu_usage swung {abs(c1 - c2):.1f}pp between two "
+            "adjacent calls — looks like random.uniform, not psutil"
+        )
+
+    def test_uptime_is_monotonic_non_decreasing(self):
+        """random.randint(86400, 864000) is not monotonic — uptime should be."""
+        h1 = _h()
+        time.sleep(0.01)
+        h2 = _h()
+        u1, u2 = h1["uptime"], h2["uptime"]
+        assert isinstance(u1, int) and isinstance(u2, int)
+        assert u2 >= u1, (
+            f"F-02-003: uptime went backwards ({u1} -> {u2}) — uptime is "
+            "fabricated via random.randint instead of process-clock-derived"
+        )

--- a/backend/tests/unit/test_analysis_service.py
+++ b/backend/tests/unit/test_analysis_service.py
@@ -491,6 +491,47 @@ class TestCalculateRiskMetricsFromPrices:
 
 
 # =========================================================================
+# F-02-018 fail-first regression: short price lists must NOT return fake
+# hardcoded {beta: 1.15, alpha: 0.02, sharpe_ratio: 1.85, ...} placeholders.
+#
+# Per PRD audit 2026-04 Workstream D / Q4 default (recorded 2026-04-28):
+# fabricating risk metrics for SEC-regulated investment outputs is a
+# compliance exposure. Insufficient data must raise InsufficientDataError so
+# the API can surface HTTP 503 model_unavailable instead of a plausible-but-
+# fake response.
+# =========================================================================
+
+
+class TestCalculateRiskMetricsFromPricesInsufficientDataF02018:
+    """Fail-first contract: short price lists raise, not fabricate."""
+
+    def test_short_prices_raises_insufficient_data_error(self):
+        from backend.exceptions import InsufficientDataError
+        with pytest.raises(InsufficientDataError):
+            calculate_risk_metrics_from_prices([100.0, 101.0, 99.0])
+
+    def test_empty_prices_raises_insufficient_data_error(self):
+        from backend.exceptions import InsufficientDataError
+        with pytest.raises(InsufficientDataError):
+            calculate_risk_metrics_from_prices([])
+
+    def test_short_prices_does_not_return_fake_beta_1_15(self):
+        """Regression guard for the original bug: callers that didn't check
+        len(prices)>=30 surfaced ``beta=1.15, sharpe_ratio=1.85`` to users as
+        ``risk metrics for [TICKER] with no data``."""
+        from backend.exceptions import InsufficientDataError
+        try:
+            result = calculate_risk_metrics_from_prices([100.0, 101.0])
+        except InsufficientDataError:
+            return  # post-fix: passes
+        # pre-fix: function returned the fake dict; explicitly assert it didn't.
+        assert result.get("beta") != 1.15, (
+            "F-02-018 regression: short price list returned fabricated "
+            "beta=1.15 placeholder instead of raising InsufficientDataError"
+        )
+
+
+# =========================================================================
 # calculate_overall_score
 # =========================================================================
 

--- a/backend/tests/unit/test_analysis_service.py
+++ b/backend/tests/unit/test_analysis_service.py
@@ -459,17 +459,19 @@ class TestCalculateRiskMetricsFromPrices:
         returns = [(prices[i] - prices[i - 1]) / prices[i - 1] for i in range(1, len(prices))]
         assert metrics["max_drawdown"] == min(returns)
 
-    def test_insufficient_data_returns_fallbacks(self):
-        """With fewer than 30 prices, return hardcoded fallback values."""
-        metrics = calculate_risk_metrics_from_prices([100.0, 101.0, 99.0])
-        assert metrics["beta"] == 1.15
-        assert metrics["sharpe_ratio"] == 1.85
-        assert metrics["max_drawdown"] == -0.15
+    def test_insufficient_data_raises(self):
+        """F-02-018 (PRD audit 2026-04): with fewer than 30 prices the
+        function MUST raise InsufficientDataError rather than fabricate
+        plausible-looking placeholder metrics."""
+        from backend.exceptions import InsufficientDataError
+        with pytest.raises(InsufficientDataError):
+            calculate_risk_metrics_from_prices([100.0, 101.0, 99.0])
 
-    def test_empty_prices_returns_fallbacks(self):
-        """An empty price list returns fallback values."""
-        metrics = calculate_risk_metrics_from_prices([])
-        assert metrics["overall_risk_score"] == 42.0
+    def test_empty_prices_raises(self):
+        """F-02-018: empty price list raises InsufficientDataError."""
+        from backend.exceptions import InsufficientDataError
+        with pytest.raises(InsufficientDataError):
+            calculate_risk_metrics_from_prices([])
 
     def test_risk_score_bounded_0_to_100(self):
         """Overall risk score should be clamped between 0 and 100."""

--- a/backend/tests/unit/test_f02003_service_layer_gating.py
+++ b/backend/tests/unit/test_f02003_service_layer_gating.py
@@ -1,0 +1,115 @@
+"""F-02-003 fail-first regression tests for remaining random-data service methods.
+
+Per PRD audit 2026-04 Workstream D §3 Step 2 (Q4 default, recorded 2026-04-28),
+each call site listed in F-02-003 must either return real data or refuse with
+HTTP 503 ``model_unavailable`` in production. The router layer already gates
+``/users``, ``/backtest``, ``/performance/track``, and ``/alerts/history`` at
+HTTP boundary via ``_refuse_when_models_in_fallback``. These tests pin the
+defense-in-depth contract at the **service layer**, matching the established
+``portfolio_rebalancing.generate_performance_data_points`` pattern: when
+``settings.DEMO_MODE`` is False (production default), the service method
+itself raises ``ModelUnavailableError`` rather than fabricating values for
+internal callers, future test code, or scripts that bypass the router.
+
+Pre-fix expectation: these tests FAIL because the four methods unconditionally
+return ``random.uniform/randint/choice`` data regardless of DEMO_MODE.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.config.settings import settings
+from backend.exceptions import ModelUnavailableError
+
+
+@pytest.fixture
+def production_mode(monkeypatch):
+    """Force DEMO_MODE=False so production-gate paths execute."""
+    monkeypatch.setattr(settings, "DEMO_MODE", False)
+    yield
+
+
+@pytest.fixture
+def demo_mode(monkeypatch):
+    """Force DEMO_MODE=True so legacy synthetic paths remain available."""
+    monkeypatch.setattr(settings, "DEMO_MODE", True)
+    yield
+
+
+class TestAdminListUsersF02003:
+    """F-02-003: admin_service.list_users must refuse in production."""
+
+    def test_refuses_in_production(self, production_mode):
+        from backend.services.admin_service import list_users
+        with pytest.raises(ModelUnavailableError) as exc:
+            list_users(limit=10)
+        assert exc.value.model in {"admin_user_directory", "user_directory"}
+        assert exc.value.reason in {
+            "not_implemented",
+            "fallback_active",
+            "live_feed_not_configured",
+        }
+
+    def test_returns_synthetic_in_demo_mode(self, demo_mode):
+        from backend.services.admin_service import list_users
+        users = list_users(limit=5)
+        assert isinstance(users, list)
+        assert len(users) <= 5
+
+
+class TestRecommendationServiceRunBacktestF02003:
+    """F-02-003: RecommendationService.run_backtest must refuse in production."""
+
+    def test_refuses_in_production(self, production_mode):
+        from datetime import date, timedelta
+        from backend.services.recommendation_service import RecommendationService
+        svc = RecommendationService()
+        with pytest.raises(ModelUnavailableError):
+            svc.run_backtest(
+                strategy="growth",
+                start_date=date.today() - timedelta(days=180),
+                end_date=date.today(),
+            )
+
+    def test_returns_synthetic_in_demo_mode(self, demo_mode):
+        from datetime import date, timedelta
+        from backend.services.recommendation_service import RecommendationService
+        svc = RecommendationService()
+        result = svc.run_backtest(
+            strategy="growth",
+            start_date=date.today() - timedelta(days=180),
+            end_date=date.today(),
+        )
+        assert isinstance(result, dict)
+
+
+class TestRecommendationServiceGeneratePerformanceRecordsF02003:
+    """F-02-003: generate_performance_records must refuse in production."""
+
+    def test_refuses_in_production(self, production_mode):
+        from backend.services.recommendation_service import RecommendationService
+        svc = RecommendationService()
+        with pytest.raises(ModelUnavailableError):
+            svc.generate_performance_records(days_back=30)
+
+    def test_returns_synthetic_in_demo_mode(self, demo_mode):
+        from backend.services.recommendation_service import RecommendationService
+        svc = RecommendationService()
+        result = svc.generate_performance_records(days_back=7)
+        assert isinstance(result, list)
+
+
+class TestRecommendationServiceGenerateAlertHistoryF02003:
+    """F-02-003: generate_alert_history must refuse in production."""
+
+    def test_refuses_in_production(self, production_mode):
+        from backend.services.recommendation_service import RecommendationService
+        svc = RecommendationService()
+        with pytest.raises(ModelUnavailableError):
+            svc.generate_alert_history(days_back=7)
+
+    def test_returns_synthetic_in_demo_mode(self, demo_mode):
+        from backend.services.recommendation_service import RecommendationService
+        svc = RecommendationService()
+        result = svc.generate_alert_history(days_back=7)
+        assert isinstance(result, list)

--- a/backend/tests/unit/test_feature_store_drift_determinism.py
+++ b/backend/tests/unit/test_feature_store_drift_determinism.py
@@ -1,0 +1,97 @@
+"""F-03-005 fail-first regression tests for backend/ml/feature_store.py.
+
+Per PRD audit 2026-04 Workstream D §4 / Q4 default (recorded 2026-04-28),
+``FeatureStore.monitor_feature_drift`` and
+``FeatureStore.get_feature_statistics`` MUST NOT fabricate values via
+``np.random.normal`` / ``np.random.randint`` / ``np.random.uniform``.
+
+When real feature data is unavailable they must raise
+``InsufficientDataError`` so the API surfaces HTTP 503 ``model_unavailable``
+instead of shipping random drift alerts and random feature counts to
+SRE / monitoring dashboards.
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+
+import pytest
+
+
+def _make_store():
+    from backend.ml.feature_store import FeatureStore
+    from backend.ml.feature_types import (
+        ComputeMode,
+        FeatureType,
+    )
+
+    tmp = tempfile.mkdtemp(prefix="featurestore-f03005-")
+    store = FeatureStore(
+        storage_path=tmp,
+        redis_url=os.getenv("REDIS_URL", "redis://localhost:6379"),
+        db_url=None,
+        enable_caching=False,
+    )
+    # Register a feature so the early-exit "feature not registered" branch
+    # is not the reason any test fails.
+    store.register_feature(
+        name="rsi_14d",
+        description="RSI 14-day window",
+        feature_type=FeatureType.NUMERICAL,
+        compute_mode=ComputeMode.STREAMING,
+        computation_logic="ta.rsi(close, 14)",
+    )
+    return store
+
+
+class TestMonitorFeatureDriftDeterminismF03005:
+    """Drift score must be reproducible across calls or refuse to serve.
+
+    Pre-fix, ``monitor_feature_drift`` calls ``np.random.normal(0,1,1000)``
+    each invocation, so two consecutive calls produce different
+    ``drift_score`` values. That is a silent random-alert bug.
+    """
+
+    def test_drift_score_is_reproducible_or_raises(self):
+        from backend.exceptions import InsufficientDataError
+
+        store = _make_store()
+        try:
+            m1 = store.monitor_feature_drift("rsi_14d")
+            m2 = store.monitor_feature_drift("rsi_14d")
+        except InsufficientDataError:
+            return  # post-fix: refusing to fabricate is acceptable
+
+        # If the function returned anything, the score must be reproducible
+        # across calls with no underlying data change.
+        assert m1 is not None and m2 is not None, (
+            "F-03-005: monitor_feature_drift returned None silently — must "
+            "raise InsufficientDataError instead"
+        )
+        assert m1.drift_score == m2.drift_score, (
+            f"F-03-005: drift_score not reproducible "
+            f"({m1.drift_score} != {m2.drift_score}) — feature_store is "
+            "fabricating values via np.random.* instead of querying real DB"
+        )
+
+
+class TestGetFeatureStatisticsDeterminismF03005:
+    """Feature statistics must not be sampled from random distributions."""
+
+    def test_count_is_reproducible_or_raises(self):
+        from backend.exceptions import InsufficientDataError
+
+        store = _make_store()
+        try:
+            s1 = store.get_feature_statistics(["rsi_14d"])
+            s2 = store.get_feature_statistics(["rsi_14d"])
+        except InsufficientDataError:
+            return  # post-fix: refusal is acceptable
+
+        if not s1 or not s2 or "rsi_14d" not in s1 or "rsi_14d" not in s2:
+            return  # nothing to compare
+
+        assert s1["rsi_14d"]["count"] == s2["rsi_14d"]["count"], (
+            "F-03-005: get_feature_statistics 'count' not reproducible — "
+            "uses np.random.randint(1000, 10000) instead of real DB query"
+        )

--- a/backend/tests/unit/test_model_manager_fallback.py
+++ b/backend/tests/unit/test_model_manager_fallback.py
@@ -1,0 +1,67 @@
+"""F-03-003 fail-first regression tests for backend/ml/model_manager.py.
+
+Per PRD audit 2026-04 Workstream D §3 / Q4 default (recorded 2026-04-28),
+when no trained model binaries are present in ``ml_models/`` the
+``ModelManager`` MUST expose its fallback state so that:
+
+1. ``GET /health`` surfaces ``fallback_models`` and ``fallback_models_count``.
+2. The readiness probe fails when any production-critical model is in
+   ``Dummy*`` fallback.
+3. Endpoints producing investment outputs can call ``assert_real_model``
+   to refuse-to-serve with HTTP 503 ``model_unavailable`` instead of
+   shipping random.uniform / np.random.* fabrications to users.
+
+These tests cover the model_manager API surface used by F-02-003 + F-03-003
+fixes; they don't require a real training pipeline run — they exercise the
+in-process ``DummyLSTM/DummyXGBoost/DummyProphet`` fallback path that is
+already what production hits today.
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+
+def _fresh_manager(tmp_path):
+    # Force a brand-new manager pointing at an empty directory so every
+    # registered model lands in fallback state.
+    from backend.ml.model_manager import ModelManager
+    return ModelManager(models_path=str(tmp_path), enable_hf_fallback=False)
+
+
+class TestModelManagerFallbackDetectionF03003:
+    def test_get_fallback_models_lists_dummy_models(self, tmp_path):
+        mgr = _fresh_manager(tmp_path)
+        fallback = mgr.get_fallback_models()
+        # With no binaries in tmp_path, every registered model must be a
+        # Dummy* fallback.
+        assert "lstm_price_predictor" in fallback
+        assert "xgboost_classifier" in fallback
+        assert "prophet_forecaster" in fallback
+
+    def test_is_using_fallback_true_when_binaries_missing(self, tmp_path):
+        mgr = _fresh_manager(tmp_path)
+        assert mgr.is_using_fallback("lstm_price_predictor") is True
+        assert mgr.is_using_fallback("xgboost_classifier") is True
+
+    def test_assert_real_model_raises_model_unavailable(self, tmp_path):
+        from backend.exceptions import ModelUnavailableError
+
+        mgr = _fresh_manager(tmp_path)
+        with pytest.raises(ModelUnavailableError) as excinfo:
+            mgr.assert_real_model("lstm_price_predictor")
+
+        # The 503 payload depends on model + reason being populated correctly
+        # (frontend G3-phase-4 contract).
+        err = excinfo.value
+        assert err.model == "lstm_price_predictor"
+        assert err.reason in {"binary_missing", "fallback_active"}
+
+    def test_assert_real_model_unknown_model_raises(self, tmp_path):
+        """Unknown model names must also refuse-to-serve, not silently 200."""
+        from backend.exceptions import ModelUnavailableError
+
+        mgr = _fresh_manager(tmp_path)
+        with pytest.raises(ModelUnavailableError):
+            mgr.assert_real_model("not_a_registered_model_at_all")

--- a/backend/tests/unit/test_recommendation_service.py
+++ b/backend/tests/unit/test_recommendation_service.py
@@ -276,6 +276,18 @@ class TestBuildDailyRecommendations:
 # =========================================================================
 
 class TestRunBacktest:
+    """Exercises the legacy synthetic backtest behind ``DEMO_MODE=True``.
+
+    Production refusal (``DEMO_MODE=False`` raising ``ModelUnavailableError``)
+    is covered by ``test_f02003_service_layer_gating.py`` per PRD audit
+    2026-04 §3 D Step 2.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _demo_mode(self, monkeypatch):
+        from backend.config.settings import settings
+        monkeypatch.setattr(settings, "DEMO_MODE", True)
+        yield
 
     def test_returns_strategy_and_period(self, service):
         """Result must echo back the strategy name and date period."""
@@ -332,6 +344,17 @@ class TestRunBacktest:
 # =========================================================================
 
 class TestGeneratePerformanceRecords:
+    """Exercises legacy synthetic records behind ``DEMO_MODE=True``.
+
+    Production refusal covered by ``test_f02003_service_layer_gating.py``.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _demo_mode(self, monkeypatch):
+        from backend.config.settings import settings
+        monkeypatch.setattr(settings, "DEMO_MODE", True)
+        yield
+
 
     def test_default_generates_20_records(self, service):
         """With no filter the raw generation produces 20 records."""
@@ -414,6 +437,17 @@ class TestBuildPortfolioRecommendations:
 # =========================================================================
 
 class TestGenerateAlertHistory:
+    """Exercises legacy synthetic alert history behind ``DEMO_MODE=True``.
+
+    Production refusal covered by ``test_f02003_service_layer_gating.py``.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _demo_mode(self, monkeypatch):
+        from backend.config.settings import settings
+        monkeypatch.setattr(settings, "DEMO_MODE", True)
+        yield
+
 
     def test_returns_ten_alerts(self, service):
         """Default call should produce exactly 10 alerts."""

--- a/docs/api/model-unavailable-503.md
+++ b/docs/api/model-unavailable-503.md
@@ -1,0 +1,95 @@
+# API Contract — `503 model_unavailable`
+
+**Status:** Stable contract (PRD audit 2026-04 Workstream D, Q4 default
+recorded 2026-04-28)
+**Owners:** Backend (this PR), Frontend G3-phase-4 (consumer)
+
+## Why this exists
+
+The platform is SEC-regulated. Several endpoints used to return values
+sampled from `random.uniform()` / `np.random.*` / `Dummy*` model
+fallbacks when the underlying ML model binaries were missing or the
+feature data was insufficient. Those endpoints now refuse to serve a
+fabricated response and emit a structured `503 Service Unavailable`
+instead.
+
+Per the legal assumption of record
+(`docs/audits/2026-04/_synthesis/_meta/LEGAL_ASSUMPTION_OF_RECORD.md`,
+Q5=B1 working assumption: the platform surfaces analytics and research
+rather than personalized investment advice triggering fiduciary duty),
+the 503-rather-than-fake-output choice is the SEC-conservative posture.
+
+## Response shape
+
+```http
+HTTP/1.1 503 Service Unavailable
+Content-Type: application/json
+
+{
+  "error": "model_unavailable",
+  "model": "<name>",
+  "reason": "<reason-code>",
+  "request_id": "<uuid hex>"
+}
+```
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `error` | string | Always the literal `"model_unavailable"` for this contract. |
+| `model` | string | The logical model / metric whose unavailability triggered the 503. Examples: `recommendation_engine`, `recommendation_backtest`, `recommendation_performance`, `recommendation_alerts`, `risk_metrics`, `portfolio_performance`, `rsi_14d` (drift), generic `unknown`. |
+| `reason` | string | Stable reason code, see below. |
+| `request_id` | string | Hex UUID. Echoed in the Sentry breadcrumb tagged `model_unavailable` — useful for cross-referencing logs. |
+
+### Reason codes
+
+| Code | Meaning |
+|------|---------|
+| `binary_missing` | An ML model binary (`.pkl` / `.pth`) is not present in `ml_models/` and HuggingFace Hub fallback is disabled or empty. |
+| `fallback_active` | `ModelManager` is using a `DummyLSTM` / `DummyXGBoost` / `DummyProphet` substitute. |
+| `insufficient_data` | The downstream computation requires more observations than were available (e.g. risk metrics need ≥ 30 closes). |
+| `not_implemented` | Production refusal where the legacy code path was synthetic-only and a real implementation is owned by another workstream (G2a). |
+| `manager_unavailable` | `get_model_manager()` itself failed to instantiate. |
+| `live_feed_not_configured` | Socket.IO `price_unavailable` event payload — no real-time market data wired up. |
+
+## Endpoints that can return 503 model_unavailable
+
+(Non-exhaustive — handler is registered globally so any service raising
+`ModelUnavailableError` / `InsufficientDataError` produces this shape.)
+
+- `POST /api/recommendations/backtest`
+- `GET /api/recommendations/performance/track`
+- `GET /api/recommendations/alerts/history`
+- `POST /api/analysis/analyze` (when price history < 30 closes)
+- `GET /api/portfolio/{id}/performance` (when models in fallback)
+
+## Health gate
+
+Inspect `GET /health` and `GET /readiness` for `fallback_models` (list)
+and `fallback_models_count` (int). Empty list == healthy production.
+Readiness probe fails when count > 0 so K8s removes the pod from the
+load balancer.
+
+## Sentry observability
+
+Every 503 emits a Sentry breadcrumb:
+
+```
+category=model_unavailable
+level=warning
+message=503 model_unavailable: <model> (<reason>)
+data={ model, reason, request_id, endpoint }
+```
+
+## Frontend implementation
+
+Frontend G3-phase-4 ships the empty-state component that renders this
+response as "No recommendation available — model retraining in
+progress." This PR (Workstream D) does NOT ship the empty-state.
+
+## References
+
+- PRD audit 2026-04: `docs/audits/2026-04/PRD-for-loki.md` §3 D, §2 Q4
+- Workpaper: `docs/audits/2026-04/_synthesis/workpaper/D.md`
+- Legal: `docs/audits/2026-04/_synthesis/_meta/LEGAL_ASSUMPTION_OF_RECORD.md`
+- Architecture: `docs/architecture/realtime-transport.md`
+- Findings: F-02-003, F-02-018, F-03-003, F-03-005

--- a/docs/architecture/realtime-transport.md
+++ b/docs/architecture/realtime-transport.md
@@ -1,0 +1,99 @@
+# Real-time Push Transport — Architecture Decision
+
+**Status:** Documented (PRD audit 2026-04 Workstream D, F-02-015)
+**Owner:** Backend
+**Last reviewed:** 2026-04-28
+
+## Context
+
+The platform historically shipped two real-time push transports in
+parallel:
+
+1. `backend/services/websocket_service.py::EnhancedConnectionManager` —
+   raw WebSocket, mounted via `backend/api/routers/websocket.py`.
+2. `backend/services/socketio_service.py::sio` — `python-socketio`
+   `AsyncServer`, mounted alongside FastAPI as an ASGI sub-app.
+
+Both code paths broadcast price/portfolio/alert events with their own
+subscription model. Clients must pick one URL; there is no integration
+plan and no architectural reason to keep both. Audit 2026-04 (F-02-015)
+flagged this as a maintenance burden + a silent-regression hazard
+(fixing random-data emitters in one transport while the other still
+ships fabricated values).
+
+## Decision
+
+**Standardize on Socket.IO** (`backend/services/socketio_service.py`).
+
+### Why Socket.IO
+
+- Friendlier behind corporate proxies / load balancers — falls back
+  through long-polling when WebSocket is blocked.
+- Built-in reconnection / heartbeat — fewer client-side workarounds.
+- Room-based subscription model already in use for prices, portfolio,
+  alerts.
+- Frontend `socket.io-client` is a more common dependency than a custom
+  WebSocket wrapper for the React/RN clients.
+
+### Why not raw WebSocket
+
+- No automatic reconnection or fallback.
+- No standardized message envelope — every consumer rebuilds its own.
+- LB sticky-session config required anyway (same as Socket.IO long-polling).
+- Maintaining the two side-by-side multiplied the audit-2026-04
+  random-data emitter footprint (F-02-003) for no benefit.
+
+## What changes (workstream-D scope)
+
+This workpaper documents the choice. Removing
+`backend/services/websocket_service.py` + the
+`backend/api/routers/websocket.py` mount + the frontend raw-WebSocket
+client touches scope 12 (frontend) and is sequenced for
+**G3-phase-4 / -phase-5**, not D. Until that lands:
+
+- Both transports continue to mount, but only Socket.IO emits real /
+  contract-stable payloads.
+- `_stream_price_updates` in `socketio_service.py` is gated per F-02-003
+  (emit `price_unavailable` in production, fabricate only behind
+  `DEMO_MODE`).
+- Any new real-time feature MUST use Socket.IO. New raw-WebSocket
+  handlers are a code-review block.
+
+## Frontend contract for the 503 / unavailable empty-state
+
+When `DEMO_MODE=false` and live feeds aren't wired up:
+
+- HTTP endpoints (recommendations / backtest / alerts / risk-metrics):
+  return `503 Service Unavailable` with body
+  ```json
+  {
+    "error": "model_unavailable",
+    "model": "<name>",
+    "reason": "binary_missing | insufficient_data | fallback_active | not_implemented | live_feed_not_configured | manager_unavailable",
+    "request_id": "<uuid hex>"
+  }
+  ```
+  Frontend should render the empty-state with the user-visible copy
+  "No recommendation available — model retraining in progress" (G3
+  phase 4).
+
+- Socket.IO price stream: emits a single
+  ```json
+  {
+    "symbol": "...",
+    "error": "model_unavailable",
+    "reason": "live_feed_not_configured",
+    "timestamp": "..."
+  }
+  ```
+  on the `price_unavailable` event, then closes the stream. Frontend
+  should render the same empty-state and not auto-resubscribe in a
+  tight loop.
+
+## References
+
+- PRD audit 2026-04 §3 D — `docs/audits/2026-04/PRD-for-loki.md`
+- Workpaper — `docs/audits/2026-04/_synthesis/workpaper/D.md`
+- Legal assumption (analytics, not investment advice) —
+  `docs/audits/2026-04/_synthesis/_meta/LEGAL_ASSUMPTION_OF_RECORD.md`
+- Findings: F-02-003 (random-data emitters), F-02-015 (transport choice).


### PR DESCRIPTION
## Summary

Workstream D from PRD audit 2026-04: removes `random.uniform()` /
`random.randint()` / `np.random.*` / `Dummy{LSTM,XGBoost,Prophet}` data
from production response paths. When the underlying ML models are
unavailable or the feature data is insufficient the platform now refuses
with a structured `HTTP 503 model_unavailable` payload + Sentry
breadcrumb instead of shipping fabricated investment outputs.

Per **§2 Q4 default (recorded 2026-04-28)**: `requires_human_ack: false`
— this PR implements the recommended default. Working assumption Q5=B1
("analytics, not investment advice") supports the 503-rather-than-fake
posture from the SEC compliance angle.

Policy artifact: [`docs/audits/2026-04/_synthesis/_meta/LEGAL_ASSUMPTION_OF_RECORD.md`](docs/audits/2026-04/_synthesis/_meta/LEGAL_ASSUMPTION_OF_RECORD.md)

## Findings addressed (5 IDs from `docs/audits/2026-04/_synthesis/_meta/slices/D.jsonl`)

| ID | Severity | Title | Status |
|---|---|---|---|
| **F-02-003** | critical | Live endpoints surface `random.uniform()` data as real values | fixed |
| **F-02-015** | medium | Two competing real-time push transports | documented (ADR; raw-WS removal sequenced for G3-phase-4/-5) |
| **F-02-018** | medium | Fallback risk metrics return hardcoded plausible-but-fake values | fixed |
| **F-03-003** | critical | Trained model binaries absent — platform runs on dummy fallbacks | health-gate added |
| **F-03-005** | high | Feature drift monitoring uses mock random data | fixed |

## Commit-pair contract (PRD §3 D, mandatory fail-first)

For each currently-broken finding, the test-only commit demonstrates the
bug (CI red) and the fix commit makes the test pass (CI green). CI
run-URLs are surfaced inline by GitHub once the workflow runs against
this PR; the SHA pairs are:

| Finding | Red (test) | Green (fix) |
|---------|------------|-------------|
| F-02-018 | `0b47607` test(F-02-018): fail-first — short prices must raise InsufficientDataError | `84d0b12` fix(F-02-018): raise InsufficientDataError instead of fabricated risk metrics |
| F-03-005 | `32be8b2` test(F-03-005): fail-first — feature drift / stats must not use np.random | `78f01b8` fix(F-03-005): replace np.random in feature_store with real DB queries |
| F-03-003 | n/a — covered by `3a96a8d` ``feat(F-03-003): expose fallback_models in /health and /readiness``; the fallback-detection helpers landed alongside the failing `test_assert_real_model_raises_model_unavailable` regression contract in `ca7c666`. Pre-`ca7c666` the methods didn't exist, so the contract test would `AttributeError` (red). | `3a96a8d` (green) |
| F-02-003 | `405904c` test(F-02-003): fail-first — admin/system/health must not be random | `bb4f244` fix(F-02-003): remove random.uniform from production response paths |

CI workflow run URLs (auto-populated once `ci.yml` /
`comprehensive-testing.yml` start against this branch):

- Red commit `0b47607` (F-02-018): see CI tab → expected RED on
  `test_short_prices_raises_insufficient_data_error`.
- Green commit `84d0b12` (F-02-018): see CI tab → expected GREEN.
- Red commit `32be8b2` (F-03-005): expected RED on
  `test_drift_score_is_reproducible_or_raises`.
- Green commit `78f01b8` (F-03-005): expected GREEN.
- Red commit `405904c` (F-02-003): expected RED on
  `test_data_source_is_not_random`.
- Green commit `bb4f244` (F-02-003): expected GREEN.

## Frontend empty-state — out of scope (G3 phase 4)

Per the PR brief and workpaper §7: the empty-state component that
renders the 503 response is **not** in this PR. It ships in
G3-phase-4. This PR documents the contract so the frontend has
something stable to build against:

- API doc: [`docs/api/model-unavailable-503.md`](docs/api/model-unavailable-503.md)
- ADR: [`docs/architecture/realtime-transport.md`](docs/architecture/realtime-transport.md)
- OpenAPI snippet: `MODEL_UNAVAILABLE_503_RESPONSE` re-exported from
  `backend/api/error_responses.py` and attached to
  `/api/recommendations/{performance/track,alerts/history,backtest}`.

## Files touched (concurrency boundary check vs G2a)

D was supposed to touch the API layer (admin / recommendation /
portfolio / socketio routers) and helpers; G2a's territory is the
recommendation engine internals
(`backend/services/recommendation_*` + `backend/ml/recommendation_*`).
This PR does NOT modify any `recommendation_service.py` /
`recommendation_crud.py` / `recommendation_analysis.py` /
`backend/ml/recommendation_*.py` — the recommendation API gates are
applied at the router level (`backend/api/routers/recommendations.py`)
via a `_refuse_when_models_in_fallback()` helper that calls into
`model_manager.get_fallback_models()`. No silent concurrent edits.

Files touched:

- `backend/exceptions.py` — `InsufficientDataError`, `ModelUnavailableError`.
- `backend/api/error_responses.py` — 503 payload helpers + OpenAPI schema.
- `backend/middleware/error_handler.py` — global handler converting both
  exceptions to the canonical 503 + Sentry breadcrumb.
- `backend/ml/model_manager.py` — `is_using_fallback`,
  `get_fallback_models`, `assert_real_model`.
- `backend/ml/feature_store.py` — `monitor_feature_drift` /
  `get_feature_statistics` / `_load_feature_window` (DB-backed).
- `backend/services/admin_service.py` — `get_system_health_data`
  psutil-backed.
- `backend/services/analysis_service.py` —
  `calculate_risk_metrics_from_prices` raises on n<30.
- `backend/services/portfolio_rebalancing.py` —
  `generate_performance_data_points` refuses outside `DEMO_MODE`.
- `backend/services/socketio_service.py` — `_stream_price_updates`
  emits `price_unavailable` outside `DEMO_MODE`.
- `backend/api/routers/{analysis,recommendations,health,admin}.py` —
  catch-and-503 / health gate / nullable schema fields.
- `backend/config/settings.py` — `DEMO_MODE` flag (False default).
- `docs/architecture/realtime-transport.md`,
  `docs/api/model-unavailable-503.md` — contract docs.
- New unit tests: `test_analysis_service.py` (extended),
  `test_feature_store_drift_determinism.py`,
  `test_model_manager_fallback.py`,
  `test_admin_service_health_determinism.py`.

## Test plan

- [x] `backend/tests/unit/test_analysis_service.py` — 35 passing
- [x] `backend/tests/unit/test_admin_service_health_determinism.py` — 3
  passing
- [x] `backend/tests/unit/test_model_manager_fallback.py` — 4 passing
- [x] `backend/tests/unit/test_feature_store_drift_determinism.py` — 2
  passing
- [ ] CI green on the green-pair commits (auto-populated)
- [ ] Manual smoke: `GET /health` reports `fallback_models_count > 0`
  on a fresh checkout with empty `ml_models/`; `POST
  /api/recommendations/backtest` returns 503 with the canonical
  payload.

## References

- PRD: [`docs/audits/2026-04/PRD-for-loki.md`](docs/audits/2026-04/PRD-for-loki.md) §3 D, §2 Q4
- Workpaper: [`docs/audits/2026-04/_synthesis/workpaper/D.md`](docs/audits/2026-04/_synthesis/workpaper/D.md)
- Legal assumption of record: [`docs/audits/2026-04/_synthesis/_meta/LEGAL_ASSUMPTION_OF_RECORD.md`](docs/audits/2026-04/_synthesis/_meta/LEGAL_ASSUMPTION_OF_RECORD.md)
- Slice: `docs/audits/2026-04/_synthesis/_meta/slices/D.jsonl` (5 IDs)