### PR TITLE
Wave 3 G3 Phase 1: close residual injection + plaintext-HTTP gates (PRD audit 2026-04)

### DIFF
--- a/.github/workflows/issue-management.yml
+++ b/.github/workflows/issue-management.yml
@@ -279,8 +279,9 @@ jobs:
       id: check
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        ISSUE_AUTHOR: ${{ github.event.issue.user.login }}
       run: |
-        AUTHOR="${{ github.event.issue.user.login }}"
+        AUTHOR="$ISSUE_AUTHOR"
 
         # Check if user has previous issues
         PREVIOUS_ISSUES=$(gh issue list --author "$AUTHOR" --state all --json number | jq '. | length')

--- a/.github/workflows/monitoring-notifications.yml
+++ b/.github/workflows/monitoring-notifications.yml
@@ -41,11 +41,16 @@ jobs:
     steps:
     - name: Analyze workflow result
       id: analyze
+      env:
+        WORKFLOW_RUN_NAME: ${{ github.event.workflow_run.name }}
+        WORKFLOW_RUN_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+        WORKFLOW_RUN_ID: ${{ github.event.workflow_run.id }}
+        WORKFLOW_RUN_ACTOR: ${{ github.event.workflow_run.actor.login }}
       run: |
-        WORKFLOW_NAME="${{ github.event.workflow_run.name }}"
-        CONCLUSION="${{ github.event.workflow_run.conclusion }}"
-        RUN_ID="${{ github.event.workflow_run.id }}"
-        ACTOR="${{ github.event.workflow_run.actor.login }}"
+        WORKFLOW_NAME="$WORKFLOW_RUN_NAME"
+        CONCLUSION="$WORKFLOW_RUN_CONCLUSION"
+        RUN_ID="$WORKFLOW_RUN_ID"
+        ACTOR="$WORKFLOW_RUN_ACTOR"
 
         echo "Workflow: $WORKFLOW_NAME"
         echo "Conclusion: $CONCLUSION"
@@ -370,9 +375,12 @@ jobs:
 
     steps:
     - name: Track deployment
+      env:
+        WORKFLOW_RUN_NAME: ${{ github.event.workflow_run.name }}
+        WORKFLOW_RUN_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
       run: |
-        WORKFLOW_NAME="${{ github.event.workflow_run.name }}"
-        CONCLUSION="${{ github.event.workflow_run.conclusion }}"
+        WORKFLOW_NAME="$WORKFLOW_RUN_NAME"
+        CONCLUSION="$WORKFLOW_RUN_CONCLUSION"
 
         echo "Deployment: $WORKFLOW_NAME"
         echo "Status: $CONCLUSION"

--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -138,11 +138,15 @@ jobs:
 
     - name: Determine reviewers
       id: reviewers
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        PR_AUTHOR_LOGIN: ${{ github.event.pull_request.user.login }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
       run: |
-        PR_AUTHOR="${{ github.event.pull_request.user.login }}"
+        PR_AUTHOR="$PR_AUTHOR_LOGIN"
 
         # Get changed files to determine expertise needed
-        CHANGED_FILES=$(gh pr view ${{ github.event.pull_request.number }} --json files --jq '.files[].path' | tr '\n' ' ')
+        CHANGED_FILES=$(gh pr view "$PR_NUMBER" --json files --jq '.files[].path' | tr '\n' ' ')
 
         REVIEWERS=""
 

--- a/.github/workflows/workflow-injection-guard.yml
+++ b/.github/workflows/workflow-injection-guard.yml
@@ -1,0 +1,46 @@
+name: Workflow Injection Guard
+
+# Per PRD audit 2026-04 §3 G3 Phase 1 (F-14-001/002/003): static guard that
+# fails CI if any workflow regresses on the shell-injection or plaintext-HTTP
+# patterns the Wave 1 + Wave 3 G3 fixes closed. Acceptance gates
+# AT-G3-1.1 and AT-G3-1.3 from the workpaper run here.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+
+permissions:
+  contents: read
+
+jobs:
+  guard:
+    name: AT-G3-1 acceptance gates
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: AT-G3-1.1 — no untrusted github.event.* fields inlined into shell vars
+        run: |
+          set -euo pipefail
+          # Catches `VAR="${{ github.event.* }}"` shell-style assignments inside
+          # run: blocks. The safe pattern is `env: VAR: ${{ ... }}` followed by
+          # `VAR="$VAR"` (or just `"$VAR"`) inside the script.
+          if grep -nE '(AUTHOR|TITLE|BODY|MESSAGE|NAME|TEXT|URL|REASON|COMMENT)="\$\{\{ *github\.event' .github/workflows/*.yml; then
+            echo "::error::Workflow shell-injection regression (F-14-001/002). Move the value to an env: block and dereference with \"\$VAR\"."
+            exit 1
+          fi
+
+      - name: AT-G3-1.3 / F-13-009 — no plaintext-HTTP downloads from prdownloads.sourceforge.net
+        run: |
+          set -euo pipefail
+          # Catch wget OR curl HTTP (no -s requirement) plus bare URLs in shell.
+          if grep -rnE 'http://prdownloads\.sourceforge\.net' \
+              .github/workflows/ Dockerfile* infrastructure/ 2>/dev/null \
+              | grep -vE 'workflow-injection-guard\.yml|::error::'; then
+            echo "::error::Plaintext-HTTP TA-Lib download regression (F-14-003/F-13-009). Use https://github.com/ta-lib/ta-lib/releases/... + sha256sum -c."
+            exit 1
+          fi

--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -27,9 +27,19 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Install TA-Lib (required for technical analysis)
-# Use SourceForge URL and install bash + update autoconf files for arm64 QEMU compatibility
+# F-13-009 / F-14-003: HTTPS GitHub release + sha256 verification (was: plaintext
+# HTTP from prdownloads.sourceforge.net with no checksum — MITM path to root-on-
+# build-host). Mirrors the workflow-side fix in
+# .github/workflows/comprehensive-testing.yml and the optimized variant in
+# infrastructure/docker/backend/Dockerfile.optimized.
 RUN apt-get update && apt-get install -y --no-install-recommends bash autoconf automake libtool && \
-    curl -L http://prdownloads.sourceforge.net/ta-lib/ta-lib-0.4.0-src.tar.gz | tar xz && \
+    TA_LIB_VERSION="0.4.0" && \
+    TA_LIB_SHA256="9ff41efcb1c011a4b4b6dfc91610b06e39b1d7973ed5d4dee55029a0ac4dc651" && \
+    curl -fsSL --proto '=https' --tlsv1.2 \
+        "https://github.com/ta-lib/ta-lib/releases/download/v${TA_LIB_VERSION}/ta-lib-${TA_LIB_VERSION}-src.tar.gz" \
+        -o ta-lib-src.tar.gz && \
+    echo "${TA_LIB_SHA256}  ta-lib-src.tar.gz" | sha256sum -c - && \
+    tar -xzf ta-lib-src.tar.gz && \
     cd ta-lib && \
     cp /usr/share/automake-*/config.guess . && \
     cp /usr/share/automake-*/config.sub . && \
@@ -37,7 +47,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends bash autoconf a
     make && \
     make install && \
     cd .. && \
-    rm -rf ta-lib && \
+    rm -rf ta-lib ta-lib-src.tar.gz && \
     apt-get purge -y autoconf automake libtool && apt-get autoremove -y && rm -rf /var/lib/apt/lists/*
 
 # Copy and install Python dependencies


### PR DESCRIPTION
## Summary

Closes the residual G3-Phase-1 acceptance-gate gaps that the bulk Wave 1 commit (`fc948dd`) left behind, mirrors F-13-009 in `Dockerfile.backend`, and adds a CI guard that runs the workpaper's `AT-G3-1.1` and `AT-G3-1.3` grep gates on every workflow PR.

Phase 1 was promoted by the PRD to run from program start in parallel with E and A because every workstream's "CI green for 5 days" gate is unverifiable while CI itself is RCE-vulnerable.

## Findings

| Finding | Severity | Status on `main` before | Status after |
|---------|----------|-------------------------|--------------|
| F-14-001 | critical | mostly fixed by `fc948dd`; 1 residual `AUTHOR="${{ github.event.issue.user.login }}"` in `issue-management.yml`, 1 in `pr-automation.yml` | fixed (env-then-quoted-var) |
| F-14-002 | critical | mostly fixed; 2 `WORKFLOW_NAME="${{ github.event.workflow_run.name }}"` residuals in `monitoring-notifications.yml` | fixed |
| F-14-003 | critical | fixed by `fc948dd` (all workflows on HTTPS + sha256) | guard added |
| F-13-009 | high     | NOT fixed — `Dockerfile.backend:32` still `curl -L http://prdownloads.sourceforge.net/...` with no checksum | fixed (HTTPS GitHub release + sha256) |

## Acceptance gates (per workpaper §5)

Run locally (and now in CI via `.github/workflows/workflow-injection-guard.yml`):

```bash
# AT-G3-1.1: no untrusted github.event.* fields inlined into shell vars
grep -nE '(AUTHOR|TITLE|BODY|MESSAGE|NAME|TEXT|URL|REASON|COMMENT)="\$\{\{ *github\.event' .github/workflows/*.yml
# → no matches (exit 1 from grep) ✅

# AT-G3-1.3 / F-13-009: no plaintext-HTTP prdownloads.sourceforge.net anywhere
grep -rnE 'http://prdownloads\.sourceforge\.net' .github/workflows/ Dockerfile* infrastructure/
# → no matches ✅
```

Both gates run on every PR that touches `.github/workflows/**` via the new guard workflow. The guard exits 1 on regression and surfaces a `::error::` annotation with the workpaper reference.

## Files touched

- `.github/workflows/issue-management.yml` — `AUTHOR="${{ ... }}"` → `env: ISSUE_AUTHOR`.
- `.github/workflows/pr-automation.yml` — `PR_AUTHOR="${{ ... }}"` and `gh pr view ${{ github.event.pull_request.number }}` → `env:` plus `"$VAR"`.
- `.github/workflows/monitoring-notifications.yml` — two `WORKFLOW_NAME=` + adjacent assignments (conclusion, run-id, actor) → env block per step.
- `Dockerfile.backend:32` — HTTPS GitHub release + `sha256sum -c` against the same SHA256 (`9ff41efcb1c011a4b4b6dfc91610b06e39b1d7973ed5d4dee55029a0ac4dc651`) the comprehensive-testing workflow and `Dockerfile.optimized` already use.
- `.github/workflows/workflow-injection-guard.yml` (new) — CI gate, ~50 lines.

## Test plan

- [x] AT-G3-1.1 returns 0 locally.
- [x] AT-G3-1.3 (extended to Dockerfiles + infrastructure) returns 0 locally.
- [x] Guard workflow runs the same checks; self-tested locally before commit.
- [ ] CI green on this PR — guard job in particular should be the canary.
- [ ] Docker `docker build -f Dockerfile.backend .` succeeds against the HTTPS URL (verified separately on a runner; sha256 already proven in `comprehensive-testing.yml`).

## Out of scope

- G3 Phase 2 (Docker prod unblock — F-13-001 named-stage / compose repoint).
- G3 Phase 3 (infra hardening, depends on A + G5).
- G3 Phase 4 (frontend residual + `model_unavailable` empty-state, consumes D's contract from PR #155).

## References

- PRD: [`docs/audits/2026-04/PRD-for-loki.md`](docs/audits/2026-04/PRD-for-loki.md) §3 G3 Phase 1
- Workpaper: [`docs/audits/2026-04/_synthesis/workpaper/G3_frontend_infra.md`](docs/audits/2026-04/_synthesis/workpaper/G3_frontend_infra.md) §3 Phase 1, §5 AT-G3-1.*
- Prior commit closing the bulk of Phase 1: `fc948dd` (Wave 1)