### PR TITLE
Wave 3 G4 follow-up: F-10-017 dead elasticsearch + F-07-016 silent migration excepts (PRD audit 2026-04)

### DIFF
--- a/backend/migrations/versions/002_implement_partitioning.py
+++ b/backend/migrations/versions/002_implement_partitioning.py
@@ -5,10 +5,19 @@ Revises: 001_critical_indexes
 Create Date: 2025-08-07
 
 """
+import logging
+
 from alembic import op
 import sqlalchemy as sa
 from sqlalchemy import text
 from datetime import datetime, timedelta
+
+# F-07-016 (PRD audit 2026-04 §3 G4 Phase 2 follow-up): every fallback path
+# in this migration previously swallowed exceptions silently
+# (`except Exception: pass`). Surface them via a module logger so operators
+# can see why a TimescaleDB / hypertable / partitioning step fell through
+# to the manual-partitioning fallback.
+logger = logging.getLogger("alembic.migration.002_partitioning")
 
 
 # revision identifiers, used by Alembic.
@@ -24,9 +33,11 @@ def upgrade():
     # Enable TimescaleDB extension if not already enabled
     try:
         op.execute("CREATE EXTENSION IF NOT EXISTS timescaledb;")
-    except Exception:
-        # Fallback to manual partitioning if TimescaleDB is not available
-        pass
+    except Exception as exc:
+        # Fallback to manual partitioning if TimescaleDB is not available.
+        # Log the exception so operators can distinguish "TimescaleDB not
+        # installed" from a permissions / connection issue.
+        logger.warning("TimescaleDB extension unavailable, falling back to manual partitioning: %s", exc)
     
     # Convert price_history to hypertable (TimescaleDB) or implement manual partitioning
     try:
@@ -54,8 +65,9 @@ def upgrade():
             SELECT add_compression_policy('price_history', INTERVAL '7 days');
         """)
         
-    except Exception:
+    except Exception as exc:
         # Fallback to manual partitioning
+        logger.warning("create_hypertable(price_history) failed, falling back to manual partitioning: %s", exc)
         implement_manual_partitioning_price_history()
     
     # Convert technical_indicators to hypertable
@@ -82,7 +94,8 @@ def upgrade():
             SELECT add_compression_policy('technical_indicators', INTERVAL '7 days');
         """)
         
-    except Exception:
+    except Exception as exc:
+        logger.warning("create_hypertable(technical_indicators) failed, falling back to manual partitioning: %s", exc)
         implement_manual_partitioning_technical_indicators()
     
     # Create continuous aggregates for common queries
@@ -138,8 +151,9 @@ def upgrade():
                 schedule_interval => INTERVAL '1 day');
         """)
         
-    except Exception:
+    except Exception as exc:
         # Create regular materialized views if TimescaleDB is not available
+        logger.warning("TimescaleDB continuous aggregates failed, falling back to regular materialized views: %s", exc)
         create_regular_materialized_views()
     
     # Create retention policy - keep raw data for 5 years
@@ -151,8 +165,8 @@ def upgrade():
         op.execute("""
             SELECT add_retention_policy('technical_indicators', INTERVAL '2 years');
         """)
-    except Exception:
-        pass
+    except Exception as exc:
+        logger.warning("add_retention_policy() failed (TimescaleDB feature unavailable?): %s", exc)
     
     # Optimize autovacuum for high-write tables
     op.execute("""
@@ -276,8 +290,8 @@ def downgrade():
     try:
         op.execute("DROP MATERIALIZED VIEW IF EXISTS daily_stock_metrics CASCADE;")
         op.execute("DROP MATERIALIZED VIEW IF EXISTS weekly_stock_metrics CASCADE;")
-    except Exception:
-        pass
+    except Exception as exc:
+        logger.warning("DROP MATERIALIZED VIEW failed during downgrade (views may not exist): %s", exc)
     
     # Remove TimescaleDB features if they exist
     try:
@@ -285,8 +299,8 @@ def downgrade():
         op.execute("SELECT remove_compression_policy('technical_indicators');")
         op.execute("SELECT remove_retention_policy('price_history');")
         op.execute("SELECT remove_retention_policy('technical_indicators');")
-    except Exception:
-        pass
+    except Exception as exc:
+        logger.warning("remove_compression_policy/remove_retention_policy failed during downgrade (TimescaleDB may be absent): %s", exc)
     
     # Reset autovacuum settings to defaults
     op.execute("""

--- a/backend/monitoring/log_analysis.py
+++ b/backend/monitoring/log_analysis.py
@@ -582,27 +582,20 @@ class LogAggregator:
     """Aggregates logs from multiple sources."""
 
     def __init__(self):
+        # F-10-017 (PRD audit 2026-04 §3 G4 Phase 3 follow-up): Elasticsearch
+        # was removed to save $15-20/month per PERFORMANCE_OPTIMIZATION.md;
+        # the env var ELASTICSEARCH_URL is never set in production and the
+        # previous `_setup_elasticsearch` ran 20+ lines of dead probing on
+        # every instantiation. The bulk-write paths in
+        # `_bulk_index_to_elasticsearch` already early-return when this
+        # client is None, so setup is now opt-in: callers that genuinely
+        # want Elasticsearch construct an `AsyncElasticsearch` and assign
+        # it explicitly.
         self.elasticsearch_client: Optional[object] = None  # AsyncElasticsearch when available
         self.log_buffers: Dict[str, deque] = defaultdict(lambda: deque(maxlen=10000))
         self.processed_files: Set[str] = set()
-        self._setup_elasticsearch()
 
-    def _setup_elasticsearch(self):
-        """Setup Elasticsearch client if configured and available.
-        Note: Elasticsearch is optional and disabled by default to save $15-20/month.
-        """
-        if not ELASTICSEARCH_AVAILABLE:
-            logger.info("Elasticsearch disabled (not installed) - using file-based logging")
-            return
 
-        es_config = monitoring_config.logging.log_aggregation_endpoint
-        if es_config:
-            try:
-                self.elasticsearch_client = AsyncElasticsearch([es_config])
-                logger.info("Elasticsearch client initialized")
-            except Exception as e:
-                logger.info(f"Elasticsearch not configured (optional): {e}")
-    
     async def aggregate_log_files(self, log_directory: str) -> List[LogEntry]:
         """Aggregate log entries from files."""
         log_entries = []


### PR DESCRIPTION
## Summary

Two low-risk cleanups from PR #151's deferred-items list. No behavior change in the happy path — just removes dead probing and adds operator-visible logging where previously-silent fallbacks fire.

Both items are pure mechanical cleanups; neither touches a parked workstream, neither blocks any other workstream, and neither requires a fail-first commit pair (there's no broken-behavior contract to pin — F-10-017 deletes unreachable code, F-07-016 only adds logging).

## Findings closed (2)

| Finding | Severity | File | Change |
|---------|----------|------|--------|
| **F-10-017** | low | `backend/monitoring/log_analysis.py` | Delete `LogAggregator._setup_elasticsearch()` (20+ lines of dead probing on every instantiation; Elasticsearch was removed to save $15-20/month per `PERFORMANCE_OPTIMIZATION.md`). |
| **F-07-016** | medium | `backend/migrations/versions/002_implement_partitioning.py` | Replace 7× `except Exception: pass` with `except Exception as exc: logger.warning(...)`. Manual-partitioning / regular-MV / downgrade-tolerant fallbacks unchanged. |

## Why this is safe

**F-10-017** — the bulk-write paths in `_bulk_index_to_elasticsearch` (lines 669, 695) already early-return when `self.elasticsearch_client is None`:

```python
if not ELASTICSEARCH_AVAILABLE or not self.elasticsearch_client or not log_entries:
    return
```

Removing the setup just keeps the client None, which is the production reality anyway (`ELASTICSEARCH_URL` is never set). Callers that genuinely want Elasticsearch can construct an `AsyncElasticsearch` and assign it explicitly — documented in the new `__init__` comment.

**F-07-016** — the migration's control flow is preserved exactly. Every `except` block still hits the same fallback (`implement_manual_partitioning_*`, `create_regular_materialized_views`, or downgrade-tolerant no-op). The only difference is the `logger.warning(...)` call before the fallback fires, so operators can distinguish "TimescaleDB not installed → manual fallback" from "permissions / connection issue → manual fallback that may also fail." Logger is namespaced under `alembic.migration.002_partitioning`.

## Out of scope (still deferred per PR #151 §9)

These remain blocked or sequenced after other workstreams land:

- **F-08-001** KDF rotation — must run in the same maintenance window as A1 live secret rotation (PRD §3 G4 footnote).
- **F-08-006** in-process RateLimiter → Redis — overlaps parked Workstream B (jwt-auth).
- **F-08-010** `.secrets.baseline` regen — needs `detect-secrets` run in CI.
- **F-08-014** file-upload polyglot — multi-file security surface.
- **F-10-001 / 005 / 008 / 010 / 011 / 015 / 016** — Prometheus registry chain; per workpaper §3.5 F-10-015 must precede F-10-001, and §10.2 calls out on-call alert flood risk on cutover (needs Alertmanager silencing window — not autonomous-safe).

## Acceptance

- [x] Both files parse (`python3 -c "import ast; ast.parse(open(...).read())"`).
- [x] `grep -n "except Exception:$" backend/migrations/versions/002_implement_partitioning.py` returns 0.
- [x] `grep -n "_setup_elasticsearch" backend/monitoring/log_analysis.py` returns 0 (call site + def both gone).
- [ ] CI green.

## References

- PRD: [`docs/audits/2026-04/PRD-for-loki.md`](docs/audits/2026-04/PRD-for-loki.md) §3 G4
- Workpaper: [`docs/audits/2026-04/_synthesis/workpaper/G4_storage_security_residual.md`](docs/audits/2026-04/_synthesis/workpaper/G4_storage_security_residual.md) §3 Phase 2/3
- Prior G4 work: PR #151 (Phases 1 + 3 partial + 4 partial + 5)