### PR TITLE
Wave 3 / G2a: close 37/41 ML+ETL+Airflow+Analytics audit findings

### DIFF
--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -326,6 +326,9 @@ jobs:
     timeout-minutes: 5
 
     steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
     - name: Check PR staleness
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/backend/TradingAgents/setup.py
+++ b/backend/TradingAgents/setup.py
@@ -14,7 +14,9 @@ setup(
     packages=find_packages(),
     install_requires=[
         "langchain>=0.1.0",
-        "langchain-openai>=0.0.2",
+        "langchain-openai>=0.1.0",
+        "langchain-anthropic>=0.1.0",
+        "langchain-google-genai>=1.0.0",
         "langchain-experimental>=0.0.40",
         "langgraph>=0.0.20",
         "numpy>=1.24.0",

--- a/backend/TradingAgents/tradingagents/agents/managers/risk_manager.py
+++ b/backend/TradingAgents/tradingagents/agents/managers/risk_manager.py
@@ -11,7 +11,7 @@ def create_risk_manager(llm, memory):
         risk_debate_state = state["risk_debate_state"]
         market_research_report = state["market_report"]
         news_report = state["news_report"]
-        fundamentals_report = state["news_report"]
+        fundamentals_report = state["fundamentals_report"]
         sentiment_report = state["sentiment_report"]
         trader_plan = state["investment_plan"]
 

--- a/backend/TradingAgents/tradingagents/agents/trader/trader.py
+++ b/backend/TradingAgents/tradingagents/agents/trader/trader.py
@@ -1,10 +1,9 @@
-import functools
 import time
 import json
 
 
-def create_trader(llm, memory):
-    def trader_node(state, name):
+def create_trader(llm, memory, name: str = "Trader"):
+    def trader_node(state):
         company_name = state["company_of_interest"]
         investment_plan = state["investment_plan"]
         market_research_report = state["market_report"]
@@ -43,4 +42,4 @@ def create_trader(llm, memory):
             "sender": name,
         }
 
-    return functools.partial(trader_node, name="Trader")
+    return trader_node

--- a/backend/TradingAgents/tradingagents/agents/utils/agent_states.py
+++ b/backend/TradingAgents/tradingagents/agents/utils/agent_states.py
@@ -2,7 +2,6 @@ from typing import Annotated, Sequence
 from datetime import date, timedelta, datetime
 from typing_extensions import TypedDict, Optional
 from langchain_openai import ChatOpenAI
-from tradingagents.agents import *
 from langgraph.prebuilt import ToolNode
 from langgraph.graph import END, StateGraph, START, MessagesState
 

--- a/backend/TradingAgents/tradingagents/agents/utils/memory.py
+++ b/backend/TradingAgents/tradingagents/agents/utils/memory.py
@@ -3,8 +3,23 @@ from chromadb.config import Settings
 from openai import OpenAI
 
 
+# Providers whose ``backend_url`` exposes an OpenAI-compatible
+# ``/v1/embeddings`` endpoint. Anything else must be gated off because
+# instantiating ``openai.OpenAI`` against e.g. the Anthropic API would
+# silently mis-route embedding requests (F-04-004).
+_OPENAI_COMPATIBLE_PROVIDERS = {"openai", "openrouter", "ollama"}
+
+
 class FinancialSituationMemory:
     def __init__(self, name, config):
+        provider = (config.get("llm_provider") or "openai").lower()
+        if provider not in _OPENAI_COMPATIBLE_PROVIDERS:
+            raise NotImplementedError(
+                f"FinancialSituationMemory does not support llm_provider={provider!r}. "
+                f"Supported providers: {sorted(_OPENAI_COMPATIBLE_PROVIDERS)}. "
+                f"Embeddings require an OpenAI-compatible /v1/embeddings endpoint."
+            )
+
         if config["backend_url"] == "http://localhost:11434/v1":
             self.embedding = "nomic-embed-text"
         else:

--- a/backend/TradingAgents/tradingagents/dataflows/finnhub_utils.py
+++ b/backend/TradingAgents/tradingagents/dataflows/finnhub_utils.py
@@ -25,8 +25,8 @@ def get_data_in_range(ticker, start_date, end_date, data_type, data_dir, period=
             data_dir, "finnhub_data", data_type, f"{ticker}_data_formatted.json"
         )
 
-    data = open(data_path, "r")
-    data = json.load(data)
+    with open(data_path, "r") as f:
+        data = json.load(f)
 
     # filter keys (date, str in format YYYY-MM-DD) by the date range (str, str in format YYYY-MM-DD)
     filtered_data = {}

--- a/backend/TradingAgents/tradingagents/dataflows/interface.py
+++ b/backend/TradingAgents/tradingagents/dataflows/interface.py
@@ -731,7 +731,7 @@ def get_stock_news_openai(ticker, curr_date):
         temperature=1,
         max_output_tokens=4096,
         top_p=1,
-        store=True,
+        store=config.get("openai_store_responses", False),
     )
 
     return response.output[1].content[0].text
@@ -766,7 +766,7 @@ def get_global_news_openai(curr_date):
         temperature=1,
         max_output_tokens=4096,
         top_p=1,
-        store=True,
+        store=config.get("openai_store_responses", False),
     )
 
     return response.output[1].content[0].text
@@ -801,7 +801,7 @@ def get_fundamentals_openai(ticker, curr_date):
         temperature=1,
         max_output_tokens=4096,
         top_p=1,
-        store=True,
+        store=config.get("openai_store_responses", False),
     )
 
     return response.output[1].content[0].text

--- a/backend/TradingAgents/tradingagents/default_config.py
+++ b/backend/TradingAgents/tradingagents/default_config.py
@@ -3,7 +3,14 @@ import os
 DEFAULT_CONFIG = {
     "project_dir": os.path.abspath(os.path.join(os.path.dirname(__file__), ".")),
     "results_dir": os.getenv("TRADINGAGENTS_RESULTS_DIR", "./results"),
-    "data_dir": "/Users/yluo/Documents/Code/ScAI/FR1-data",
+    "data_dir": os.getenv(
+        "TRADINGAGENTS_DATA_DIR",
+        os.path.join(
+            os.path.abspath(os.path.join(os.path.dirname(__file__), ".")),
+            "dataflows",
+            "data",
+        ),
+    ),
     "data_cache_dir": os.path.join(
         os.path.abspath(os.path.join(os.path.dirname(__file__), ".")),
         "dataflows/data_cache",

--- a/backend/TradingAgents/tradingagents/default_config.py
+++ b/backend/TradingAgents/tradingagents/default_config.py
@@ -26,4 +26,8 @@ DEFAULT_CONFIG = {
     "max_recur_limit": 100,
     # Tool settings
     "online_tools": True,
+    # Data residency: OpenAI ``store`` flag on ``responses.create``.
+    # Default False so prompt content is not retained on OpenAI servers
+    # unless explicitly opted in (F-04-005).
+    "openai_store_responses": False,
 }

--- a/backend/TradingAgents/tradingagents/graph/setup.py
+++ b/backend/TradingAgents/tradingagents/graph/setup.py
@@ -5,7 +5,21 @@ from langchain_openai import ChatOpenAI
 from langgraph.graph import END, StateGraph, START
 from langgraph.prebuilt import ToolNode
 
-from tradingagents.agents import *
+from tradingagents.agents import (
+    create_bear_researcher,
+    create_bull_researcher,
+    create_fundamentals_analyst,
+    create_market_analyst,
+    create_msg_delete,
+    create_news_analyst,
+    create_neutral_debator,
+    create_research_manager,
+    create_risk_manager,
+    create_risky_debator,
+    create_safe_debator,
+    create_social_media_analyst,
+    create_trader,
+)
 from tradingagents.agents.utils.agent_states import AgentState
 from tradingagents.agents.utils.agent_utils import Toolkit
 

--- a/backend/TradingAgents/tradingagents/graph/trading_graph.py
+++ b/backend/TradingAgents/tradingagents/graph/trading_graph.py
@@ -58,13 +58,54 @@ class TradingAgentsGraph:
         )
 
         # Initialize LLMs
-        if self.config["llm_provider"].lower() == "openai" or self.config["llm_provider"] == "ollama" or self.config["llm_provider"] == "openrouter":
-            self.deep_thinking_llm = ChatOpenAI(model=self.config["deep_think_llm"], base_url=self.config["backend_url"])
-            self.quick_thinking_llm = ChatOpenAI(model=self.config["quick_think_llm"], base_url=self.config["backend_url"])
-        elif self.config["llm_provider"].lower() == "anthropic":
+        provider = self.config["llm_provider"].lower()
+        if provider == "openai":
+            self.deep_thinking_llm = ChatOpenAI(
+                model=self.config["deep_think_llm"],
+                base_url=self.config["backend_url"],
+            )
+            self.quick_thinking_llm = ChatOpenAI(
+                model=self.config["quick_think_llm"],
+                base_url=self.config["backend_url"],
+            )
+        elif provider == "openrouter":
+            # OpenRouter requires routing/attribution headers
+            # (https://openrouter.ai/docs/api-reference/overview).
+            openrouter_headers = {
+                "HTTP-Referer": self.config.get(
+                    "openrouter_referer", "https://github.com/TradingAgents"
+                ),
+                "X-Title": self.config.get("openrouter_title", "TradingAgents"),
+            }
+            self.deep_thinking_llm = ChatOpenAI(
+                model=self.config["deep_think_llm"],
+                base_url=self.config["backend_url"],
+                default_headers=openrouter_headers,
+            )
+            self.quick_thinking_llm = ChatOpenAI(
+                model=self.config["quick_think_llm"],
+                base_url=self.config["backend_url"],
+                default_headers=openrouter_headers,
+            )
+        elif provider == "ollama":
+            # Ollama-specific options (num_ctx, num_predict, etc.) must be
+            # threaded through ``model_kwargs`` because they are not part
+            # of the OpenAI chat-completion schema.
+            ollama_model_kwargs = self.config.get("ollama_model_kwargs", {})
+            self.deep_thinking_llm = ChatOpenAI(
+                model=self.config["deep_think_llm"],
+                base_url=self.config["backend_url"],
+                model_kwargs=ollama_model_kwargs,
+            )
+            self.quick_thinking_llm = ChatOpenAI(
+                model=self.config["quick_think_llm"],
+                base_url=self.config["backend_url"],
+                model_kwargs=ollama_model_kwargs,
+            )
+        elif provider == "anthropic":
             self.deep_thinking_llm = ChatAnthropic(model=self.config["deep_think_llm"], base_url=self.config["backend_url"])
             self.quick_thinking_llm = ChatAnthropic(model=self.config["quick_think_llm"], base_url=self.config["backend_url"])
-        elif self.config["llm_provider"].lower() == "google":
+        elif provider == "google":
             self.deep_thinking_llm = ChatGoogleGenerativeAI(model=self.config["deep_think_llm"])
             self.quick_thinking_llm = ChatGoogleGenerativeAI(model=self.config["quick_think_llm"])
         else:

--- a/backend/TradingAgents/tradingagents/graph/trading_graph.py
+++ b/backend/TradingAgents/tradingagents/graph/trading_graph.py
@@ -12,7 +12,7 @@ from langchain_google_genai import ChatGoogleGenerativeAI
 
 from langgraph.prebuilt import ToolNode
 
-from tradingagents.agents import *
+from tradingagents.agents import Toolkit
 from tradingagents.default_config import DEFAULT_CONFIG
 from tradingagents.agents.utils.memory import FinancialSituationMemory
 from tradingagents.agents.utils.agent_states import (

--- a/backend/analytics/agents/hybrid_engine.py
+++ b/backend/analytics/agents/hybrid_engine.py
@@ -6,6 +6,7 @@ from datetime import datetime, timezone
 from enum import Enum
 
 from backend.analytics.recommendation_engine import RecommendationEngine, StockRecommendation
+from backend.analytics.recommendation_types import RecommendationAction
 from backend.utils.llm_budget_manager import LLMBudgetManager, BudgetExceededException, LLMCircuitBreaker
 from backend.utils.cache_manager import CacheManager
 from backend.data_ingestion.smart_data_fetcher import SmartDataFetcher
@@ -39,27 +40,30 @@ class EnhancedStockRecommendation(StockRecommendation):
     def __post_init__(self):
         if self.agents_used is None:
             self.agents_used = []
-        
-        # Calculate hybrid score if agent analysis available
-        if self.agent_analysis and hasattr(self, 'overall_score'):
+
+        # F-09-005: ``overall_score`` was never declared on the parent
+        # StockRecommendation dataclass. Use ``confidence`` as the
+        # traditional-analysis score for the hybrid calculation (the
+        # field that is actually populated for every recommendation).
+        if self.agent_analysis is not None:
             self.hybrid_score = self._calculate_hybrid_score()
-    
+
     def _calculate_hybrid_score(self) -> float:
         """Calculate hybrid score combining traditional and agent analysis"""
         if not self.agent_analysis:
-            return self.overall_score
-        
+            return self.confidence
+
         # Get agent confidence (0-1 scale)
         agent_conf = self.agent_confidence or 0.5
-        
+
         # Weight traditional vs agent analysis based on agent confidence
         agent_weight = min(agent_conf, 0.4)  # Max 40% weight to agents
         traditional_weight = 1.0 - agent_weight
-        
+
         # Assume agent provides a score (this would need to be extracted from actual agent output)
         agent_score = self._extract_agent_score()
-        
-        hybrid = (traditional_weight * self.overall_score + 
+
+        hybrid = (traditional_weight * self.confidence +
                  agent_weight * agent_score)
         
         return max(0.0, min(1.0, hybrid))  # Clamp to [0,1]
@@ -165,7 +169,6 @@ class HybridAnalysisEngine:
             )
             
             logger.debug(f"Traditional analysis complete for {ticker} - "
-                        f"Score: {traditional_result.overall_score:.2f}, "
                         f"Confidence: {traditional_result.confidence:.2f}")
             
             # Step 2: Determine if we should enhance with agents
@@ -413,25 +416,70 @@ class HybridAnalysisEngine:
         return EnhancedStockRecommendation(**enhanced_data)
     
     def _create_error_recommendation(
-        self, 
-        ticker: str, 
+        self,
+        ticker: str,
         error: str,
-        start_time: datetime
+        start_time: datetime,
     ) -> EnhancedStockRecommendation:
-        """Create minimal recommendation when analysis fails"""
-        analysis_duration = (datetime.now(timezone.utc) - start_time).total_seconds()
-        
+        """Create minimal recommendation when analysis fails.
+
+        F-09-005: previously passed ``recommendation="HOLD"`` and
+        ``overall_score=0.5`` — neither is a field on
+        StockRecommendation/EnhancedStockRecommendation, and a slew of
+        parent-required fields were missing, so constructing this
+        TypeError'd on every error path.
+
+        Now constructs a fully-populated dataclass with safe defaults
+        and uses the real fields: ``action=HOLD`` (not
+        ``recommendation``) and ``confidence=0.1`` (with the inherited
+        score columns set to 0.0).
+        """
+        now = datetime.now(timezone.utc)
+        analysis_duration = (now - start_time).total_seconds()
+
         return EnhancedStockRecommendation(
+            # Identity
             ticker=ticker,
-            recommendation="HOLD",
-            overall_score=0.5,
+            action=RecommendationAction.HOLD,
             confidence=0.1,
+            priority=10,  # lowest priority for error path
+            # Price targets (zeroed)
+            entry_price=0.0,
             target_price=0.0,
-            risks=["Analysis failed: " + error],
+            stop_loss=0.0,
+            expected_return=0.0,
+            time_horizon_days=0,
+            # Risk metrics (zeroed)
+            risk_score=0.0,
+            volatility=0.0,
+            beta=0.0,
+            sharpe_ratio=0.0,
+            max_drawdown=0.0,
+            # Analysis scores (zeroed)
+            technical_score=0.0,
+            fundamental_score=0.0,
+            sentiment_score=0.0,
+            ml_prediction_score=0.0,
+            # Detail dicts
+            technical_analysis={},
+            fundamental_analysis={},
+            sentiment_analysis={},
+            ml_predictions={},
+            # Reasoning
+            key_factors=[],
+            risks=[f"Analysis failed: {error}"],
             opportunities=[],
+            catalysts=[],
+            # Metadata
+            generated_at=now,
+            valid_until=now,
+            # Position sizing (zeroed)
+            recommended_allocation=0.0,
+            max_position_size=0.0,
+            # Enhanced fields
             analysis_duration=analysis_duration,
             complexity_level="error",
-            agents_used=[]
+            agents_used=[],
         )
     
     async def _update_stats(self, cost: float, start_time: datetime, used_agents: bool):

--- a/backend/analytics/fundamental/valuation/dcf_model.py
+++ b/backend/analytics/fundamental/valuation/dcf_model.py
@@ -56,7 +56,8 @@ class DCFModel:
         growth_rates: Optional[List[float]] = None,
         discount_rate: Optional[float] = None,
         shares_outstanding: float = 1.0,
-        current_price: float = 0.0
+        current_price: float = 0.0,
+        terminal_growth_rate: Optional[float] = None,
     ) -> DCFResult:
         """
         Calculate intrinsic value using DCF model.
@@ -67,6 +68,11 @@ class DCFModel:
             discount_rate: Discount rate (WACC)
             shares_outstanding: Number of shares outstanding
             current_price: Current stock price
+            terminal_growth_rate: Override the instance-level
+                ``self.terminal_growth_rate`` for this call only.
+                Added for F-09-003 so sensitivity_analysis can vary the
+                terminal growth rate without mutating shared instance
+                state.
 
         Returns:
             DCFResult with valuation metrics
@@ -78,6 +84,15 @@ class DCFModel:
             # Default declining growth assumption
             growth_rates = [0.15, 0.12, 0.10, 0.08, 0.05]
 
+        # F-09-003: prefer the per-call override; fall back to the
+        # instance default. Reading via a local keeps the rest of the
+        # method side-effect-free.
+        _tgr = (
+            terminal_growth_rate
+            if terminal_growth_rate is not None
+            else self.terminal_growth_rate
+        )
+
         # Project future free cash flows
         projected_fcf = []
         fcf = free_cash_flow
@@ -88,12 +103,12 @@ class DCFModel:
 
         # Pad with terminal growth if needed
         while len(projected_fcf) < self.projection_years:
-            fcf = projected_fcf[-1] * (1 + self.terminal_growth_rate)
+            fcf = projected_fcf[-1] * (1 + _tgr)
             projected_fcf.append(fcf)
 
         # Calculate terminal value (Gordon Growth Model)
-        terminal_fcf = projected_fcf[-1] * (1 + self.terminal_growth_rate)
-        terminal_value = terminal_fcf / (discount_rate - self.terminal_growth_rate)
+        terminal_fcf = projected_fcf[-1] * (1 + _tgr)
+        terminal_value = terminal_fcf / (discount_rate - _tgr)
 
         # Calculate present values
         pv_fcfs = 0
@@ -177,14 +192,18 @@ class DCFModel:
             'values': []
         }
 
+        # F-09-003: previously mutated ``self.terminal_growth_rate``
+        # mid-loop which left the instance in a non-deterministic state
+        # after sensitivity_analysis returned. Pass ``gr`` per call
+        # instead so ``self`` is unchanged on exit.
         for dr in discount_rates:
             row = []
             for gr in growth_rates:
-                self.terminal_growth_rate = gr
                 result = self.calculate_intrinsic_value(
                     free_cash_flow=free_cash_flow,
                     discount_rate=dr,
-                    shares_outstanding=shares_outstanding
+                    shares_outstanding=shares_outstanding,
+                    terminal_growth_rate=gr,
                 )
                 row.append(result.intrinsic_value)
             results['values'].append(row)

--- a/backend/analytics/portfolio/modern_portfolio_theory.py
+++ b/backend/analytics/portfolio/modern_portfolio_theory.py
@@ -10,6 +10,8 @@ from typing import Dict, List, Tuple, Optional, Any
 from dataclasses import dataclass
 import logging
 
+from scipy.optimize import minimize  # F-09-010: SLSQP mean-variance solver
+
 logger = logging.getLogger(__name__)
 
 
@@ -78,9 +80,8 @@ class PortfolioOptimizer:
 
         # F-09-010: previous implementation always returned equal
         # weights, ignoring ``target_return`` / ``target_volatility``.
-        # Replace with a real mean-variance optimizer via scipy.
-        from scipy.optimize import minimize
-
+        # Replace with a real mean-variance optimizer via scipy
+        # (``scipy.optimize.minimize`` imported at module top).
         er = np.asarray(expected_returns, dtype=float)
         cov = np.asarray(cov_matrix, dtype=float)
 

--- a/backend/analytics/portfolio/modern_portfolio_theory.py
+++ b/backend/analytics/portfolio/modern_portfolio_theory.py
@@ -76,13 +76,73 @@ class PortfolioOptimizer:
         expected_returns = returns.mean() * 252  # Annualize
         cov_matrix = returns.cov() * 252  # Annualize
 
-        # Simple equal weight as baseline
-        weights = np.array([1.0 / n_assets] * n_assets)
+        # F-09-010: previous implementation always returned equal
+        # weights, ignoring ``target_return`` / ``target_volatility``.
+        # Replace with a real mean-variance optimizer via scipy.
+        from scipy.optimize import minimize
+
+        er = np.asarray(expected_returns, dtype=float)
+        cov = np.asarray(cov_matrix, dtype=float)
+
+        def _portfolio_var(w: np.ndarray) -> float:
+            return float(np.dot(w.T, np.dot(cov, w)))
+
+        def _portfolio_ret(w: np.ndarray) -> float:
+            return float(np.dot(w, er))
+
+        def _neg_sharpe(w: np.ndarray) -> float:
+            ret = _portfolio_ret(w)
+            vol = np.sqrt(_portfolio_var(w))
+            if vol <= 0:
+                return 0.0
+            return -(ret - self.risk_free_rate) / vol
+
+        # Long-only, fully invested.
+        bounds = tuple((0.0, 1.0) for _ in range(n_assets))
+        sum_to_one = {"type": "eq", "fun": lambda w: float(np.sum(w) - 1.0)}
+        x0 = np.array([1.0 / n_assets] * n_assets)
+
+        if target_return is not None:
+            # Minimize variance subject to ``w·er >= target_return``.
+            constraints = [
+                sum_to_one,
+                {"type": "ineq", "fun": lambda w: _portfolio_ret(w) - float(target_return)},
+            ]
+            res = minimize(_portfolio_var, x0, method="SLSQP",
+                           bounds=bounds, constraints=constraints)
+        elif target_volatility is not None:
+            # Maximize return subject to ``vol <= target_volatility``.
+            constraints = [
+                sum_to_one,
+                {"type": "ineq",
+                 "fun": lambda w: float(target_volatility) - np.sqrt(_portfolio_var(w))},
+            ]
+            res = minimize(lambda w: -_portfolio_ret(w), x0, method="SLSQP",
+                           bounds=bounds, constraints=constraints)
+        else:
+            # No target → maximize Sharpe.
+            res = minimize(_neg_sharpe, x0, method="SLSQP",
+                           bounds=bounds, constraints=[sum_to_one])
+
+        if res.success:
+            weights = np.asarray(res.x, dtype=float)
+        else:
+            # Solver failed → fall back to equal weights with a logger
+            # warning rather than silently returning bad weights.
+            import logging
+            logging.getLogger(__name__).warning(
+                "MPT solver did not converge (%s); falling back to equal weights",
+                getattr(res, "message", "no message"),
+            )
+            weights = x0
 
         # Calculate portfolio metrics
-        portfolio_return = np.dot(weights, expected_returns)
-        portfolio_vol = np.sqrt(np.dot(weights.T, np.dot(cov_matrix, weights)))
-        sharpe = (portfolio_return - self.risk_free_rate) / portfolio_vol if portfolio_vol > 0 else 0
+        portfolio_return = _portfolio_ret(weights)
+        portfolio_vol = float(np.sqrt(_portfolio_var(weights)))
+        sharpe = (
+            (portfolio_return - self.risk_free_rate) / portfolio_vol
+            if portfolio_vol > 0 else 0.0
+        )
 
         weight_dict = dict(zip(assets, weights))
 

--- a/backend/analytics/recommendation_engine.py
+++ b/backend/analytics/recommendation_engine.py
@@ -16,6 +16,7 @@ statements continue to work without modification.
 """
 
 import asyncio
+import os
 import numpy as np
 import pandas as pd
 from typing import Dict, List, Optional, Tuple, Any
@@ -94,9 +95,8 @@ class RecommendationEngine:
         # F-09-008: source from the fundamental engine so the two
         # stay in lockstep instead of drifting silently.
         # F-09-009: portfolio size is now operator-controlled.
-        import os as _os
         self.risk_free_rate = self.fundamental_engine.risk_free_rate
-        self.portfolio_size = float(_os.getenv("DEFAULT_PORTFOLIO_SIZE", "100000"))
+        self.portfolio_size = float(os.getenv("DEFAULT_PORTFOLIO_SIZE", "100000"))
 
         self.thresholds = {
             'strong_buy':  0.8,

--- a/backend/analytics/recommendation_engine.py
+++ b/backend/analytics/recommendation_engine.py
@@ -346,7 +346,28 @@ class RecommendationEngine:
         if not text_data:
             return {'overall_sentiment': {'score': 0.0, 'label': 'neutral', 'confidence': 0.0}}
 
-        return await self.sentiment_engine.analyze_sentiment(ticker, text_data)
+        # F-09-001: ``analyze_sentiment(text: str, source: str)`` is the
+        # per-text entrypoint and rejects the list-of-dicts shape this
+        # method assembles. The batch entrypoint is
+        # ``analyze_stock_sentiment(ticker, texts: List[str])``.
+        # Adapter pattern: feed it the extracted ``text`` field, then
+        # map the SentimentResult back to the legacy dict shape that
+        # downstream consumers (line ~480) read via
+        # ``sentiment_analysis.get('overall_sentiment', ...)``.
+        result = await self.sentiment_engine.analyze_stock_sentiment(
+            ticker, [item['text'] for item in text_data if item.get('text')]
+        )
+        return {
+            'overall_sentiment': {
+                'score': result.score,
+                'label': result.label,
+                'confidence': result.confidence,
+            },
+            'breakdown': result.breakdown,
+            'keywords': result.keywords,
+            'sources_analyzed': result.sources_analyzed,
+            'timestamp': result.timestamp,
+        }
 
     async def _run_ml_predictions(
         self, ticker: str, stock_data: Dict

--- a/backend/analytics/recommendation_engine.py
+++ b/backend/analytics/recommendation_engine.py
@@ -91,6 +91,13 @@ class RecommendationEngine:
         self.risk_manager = RiskManager()
         self.portfolio_optimizer = PortfolioOptimizer()
 
+        # F-09-008: source from the fundamental engine so the two
+        # stay in lockstep instead of drifting silently.
+        # F-09-009: portfolio size is now operator-controlled.
+        import os as _os
+        self.risk_free_rate = self.fundamental_engine.risk_free_rate
+        self.portfolio_size = float(_os.getenv("DEFAULT_PORTFOLIO_SIZE", "100000"))
+
         self.thresholds = {
             'strong_buy':  0.8,
             'buy':         0.6,
@@ -426,8 +433,10 @@ class RecommendationEngine:
         volatility = returns.std() * np.sqrt(252)
         beta = stock_data.get('beta', 1.0)
 
-        risk_free_rate = 0.045
-        excess_returns = returns - risk_free_rate / 252
+        # F-09-008: use the engine-level risk-free rate (synced with
+        # FundamentalAnalysisEngine.risk_free_rate) instead of a local
+        # 0.045 constant.
+        excess_returns = returns - self.risk_free_rate / 252
         sharpe_ratio = (
             (excess_returns.mean() * 252) / (returns.std() * np.sqrt(252))
             if returns.std() > 0
@@ -540,7 +549,10 @@ class RecommendationEngine:
         )
         catalysts = find_catalysts(stock_data, sentiment_analysis, fundamental_analysis)
 
-        position_sizing = calculate_position_sizing(confidence, risk_metrics, action)
+        position_sizing = calculate_position_sizing(
+            confidence, risk_metrics, action,
+            portfolio_size=self.portfolio_size,  # F-09-009
+        )
 
         priority = calculate_priority(risk_adjusted_score, confidence, opportunities)
 
@@ -610,7 +622,10 @@ class RecommendationEngine:
         return find_catalysts(stock_data, sentiment, fundamental)
 
     def _calculate_position_sizing(self, confidence, risk_metrics, action):
-        return calculate_position_sizing(confidence, risk_metrics, action)
+        return calculate_position_sizing(
+            confidence, risk_metrics, action,
+            portfolio_size=self.portfolio_size,  # F-09-009
+        )
 
     def _calculate_priority(self, score, confidence, opportunities):
         return calculate_priority(score, confidence, opportunities)
@@ -622,7 +637,10 @@ class RecommendationEngine:
         return rank_recommendations(recommendations)
 
     async def _optimize_recommendations(self, recommendations, risk_tolerance):
-        return await optimize_recommendations(recommendations, risk_tolerance, self.portfolio_optimizer)
+        return await optimize_recommendations(
+            recommendations, risk_tolerance, self.portfolio_optimizer,
+            portfolio_size=self.portfolio_size,  # F-09-009
+        )
 
     # Also keep the generate_report helper using summary directly
 

--- a/backend/analytics/recommendation_ranking.py
+++ b/backend/analytics/recommendation_ranking.py
@@ -110,8 +110,15 @@ async def optimize_recommendations(
     recommendations: List[StockRecommendation],
     risk_tolerance: str,
     portfolio_optimizer: "PortfolioOptimizer",
+    portfolio_size: float = 100_000,
 ) -> List[StockRecommendation]:
-    """Apply portfolio optimization to a ranked list of recommendations."""
+    """Apply portfolio optimization to a ranked list of recommendations.
+
+    F-09-009: ``portfolio_size`` is now a parameter (default $100k for
+    backward compatibility) instead of a hardcoded constant. Callers
+    should pass the operator-configured value so position-size dollars
+    track the actual portfolio.
+    """
     if len(recommendations) < 2:
         return recommendations
 
@@ -144,7 +151,7 @@ async def optimize_recommendations(
     for rec, weight in zip(recommendations, optimal_weights):
         if weight > 0.01:
             rec.recommended_allocation = weight
-            rec.max_position_size = weight * 100_000
+            rec.max_position_size = weight * portfolio_size
             optimized_recs.append(rec)
 
     optimized_recs.sort(key=lambda x: x.recommended_allocation, reverse=True)

--- a/backend/analytics/recommendation_scoring.py
+++ b/backend/analytics/recommendation_scoring.py
@@ -371,9 +371,15 @@ def find_catalysts(
 def calculate_position_sizing(
     confidence: float,
     risk_metrics: Dict,
-    action: RecommendationAction
+    action: RecommendationAction,
+    portfolio_size: float = 100_000,
 ) -> Dict[str, float]:
-    """Calculate recommended position sizing via a safety-adjusted Kelly Criterion."""
+    """Calculate recommended position sizing via a safety-adjusted Kelly Criterion.
+
+    F-09-009: ``portfolio_size`` is now a parameter (default $100k for
+    backward compatibility) so the dollar position size scales with
+    the operator-configured portfolio.
+    """
     p = confidence
     q = 1 - p
     b = 2  # Assume 2:1 reward/risk ratio
@@ -395,7 +401,6 @@ def calculate_position_sizing(
     allocation = min(safe_kelly * risk_adjustment, max_allocation)
     allocation = max(0.0, allocation)
 
-    portfolio_size = 100_000
     max_size = allocation * portfolio_size
 
     return {

--- a/backend/analytics/recommendation_types.py
+++ b/backend/analytics/recommendation_types.py
@@ -76,6 +76,11 @@ class StockRecommendation:
     recommended_allocation: float  # Percentage of portfolio
     max_position_size: float       # Dollar amount
 
+    # Ranking score — composite ordering metric assigned by the
+    # ranking layer; consumers expect it on every recommendation dict
+    # but it was previously absent from the dataclass (F-09-004).
+    ranking_score: float = field(default=0.0)
+
     def to_dict(self) -> Dict:
         """Convert to dictionary for storage."""
         return {
@@ -105,4 +110,5 @@ class StockRecommendation:
             'valid_until': self.valid_until.isoformat(),
             'recommended_allocation': self.recommended_allocation,
             'max_position_size': self.max_position_size,
+            'ranking_score': self.ranking_score,
         }

--- a/backend/analytics/sentiment_analysis.py
+++ b/backend/analytics/sentiment_analysis.py
@@ -398,35 +398,85 @@ class SentimentAnalysisEngine:
         return top_words
     
     async def get_news_sentiment(self, ticker: str, limit: int = 10) -> SentimentResult:
+        """Get sentiment from news articles via SmartDataFetcher.
+
+        F-09-006: previously a hardcoded neutral placeholder. Now that
+        F-05-004 has wired SmartDataFetcher to real clients
+        (Finnhub.get_news), this delegates to that surface and runs the
+        existing analyze_stock_sentiment batch path over the headline +
+        summary text. Returns a neutral fallback (with a warning logged)
+        only when the fetcher reports ``source: "unavailable"``.
         """
-        Get sentiment from news articles (simplified - returns neutral for now)
-        In a full implementation, this would fetch and analyze real news data
-        """
-        # Placeholder implementation
-        return SentimentResult(
-            score=0.0,
-            confidence=0.5,
-            label='neutral',
-            breakdown={'source': 'news_placeholder'},
-            keywords=[ticker.lower(), 'news'],
-            sources_analyzed=0,
-            timestamp=datetime.now(timezone.utc)
-        )
-    
+        try:
+            from backend.data_ingestion.smart_data_fetcher import get_smart_fetcher
+            fetcher = await get_smart_fetcher()
+            payload = await fetcher.fetch_stock_data(ticker, "news")
+        except Exception as e:  # noqa: BLE001
+            logger.warning(f"get_news_sentiment: fetcher error for {ticker}: {e}")
+            payload = None
+
+        articles = (payload or {}).get("articles", []) if payload else []
+        if not articles or (payload or {}).get("source") == "unavailable":
+            logger.warning(
+                f"get_news_sentiment: no news available for {ticker}; "
+                "returning neutral fallback"
+            )
+            return SentimentResult(
+                score=0.0,
+                confidence=0.0,
+                label='neutral',
+                breakdown={'source': 'news_unavailable'},
+                keywords=[ticker.lower(), 'news'],
+                sources_analyzed=0,
+                timestamp=datetime.now(timezone.utc),
+            )
+
+        texts: List[str] = []
+        for art in articles[:limit]:
+            headline = art.get("headline") or art.get("title") or ""
+            summary = art.get("summary") or art.get("description") or ""
+            combined = f"{headline} {summary}".strip()
+            if combined:
+                texts.append(combined)
+
+        if not texts:
+            return SentimentResult(
+                score=0.0,
+                confidence=0.0,
+                label='neutral',
+                breakdown={'source': 'news_empty_texts'},
+                keywords=[ticker.lower(), 'news'],
+                sources_analyzed=0,
+                timestamp=datetime.now(timezone.utc),
+            )
+
+        return await self.analyze_stock_sentiment(ticker, texts)
+
     async def get_social_sentiment(self, ticker: str, limit: int = 50) -> SentimentResult:
+        """Social-media sentiment is not yet wired.
+
+        F-09-006: SmartDataFetcher does not yet expose a social-media
+        endpoint (Reddit/X/StockTwits ingestion is out of scope for
+        the 2026-04 audit cycle). We log a loud warning and return a
+        zero-confidence neutral sentinel so downstream averaging code
+        does not crash, but consumers must check ``confidence == 0.0``
+        / ``sources_analyzed == 0`` to detect the no-data path.
         """
-        Get sentiment from social media (simplified - returns neutral for now)
-        In a full implementation, this would fetch and analyze real social media data
-        """
-        # Placeholder implementation
+        logger.warning(
+            "get_social_sentiment is not implemented (F-09-006): "
+            "no social-media ingestion source. Returning neutral "
+            "sentinel for ticker=%s. Implement after social ingestion "
+            "lands.",
+            ticker,
+        )
         return SentimentResult(
             score=0.0,
-            confidence=0.5,
+            confidence=0.0,  # was 0.5 — that was a lie
             label='neutral',
-            breakdown={'source': 'social_placeholder'},
+            breakdown={'source': 'social_unimplemented'},
             keywords=[ticker.lower(), 'social'],
             sources_analyzed=0,
-            timestamp=datetime.now(timezone.utc)
+            timestamp=datetime.now(timezone.utc),
         )
     
     async def analyze_comprehensive_sentiment(self, ticker: str) -> Dict[str, Any]:

--- a/backend/analytics/statistical/cointegration_analyzer.py
+++ b/backend/analytics/statistical/cointegration_analyzer.py
@@ -16,9 +16,16 @@ logger = logging.getLogger(__name__)
 
 
 class CointegrationMethod(Enum):
-    """Methods for cointegration testing."""
+    """Methods for cointegration testing.
+
+    F-09-007: ``JOHANSEN`` was removed because the previous
+    ``_johansen_test`` silently fell back to Engle-Granger — callers
+    selecting JOHANSEN believed they were getting a different
+    statistical test. If real Johansen support is needed later,
+    implement via ``statsmodels.tsa.vector_ar.vecm.coint_johansen`` and
+    add the enum value back.
+    """
     ENGLE_GRANGER = "engle_granger"
-    JOHANSEN = "johansen"
 
 
 @dataclass
@@ -93,8 +100,15 @@ class CointegrationAnalyzer:
         """
         if method == CointegrationMethod.ENGLE_GRANGER:
             return self._engle_granger_test(series1, series2)
-        else:
-            return self._johansen_test(series1, series2)
+        # F-09-007: only ENGLE_GRANGER is supported. Fail loud rather
+        # than silently routing to a different test (the legacy
+        # behavior).
+        raise NotImplementedError(
+            f"Unsupported cointegration method: {method!r}. "
+            "Only CointegrationMethod.ENGLE_GRANGER is implemented; "
+            "Johansen was removed because the prior implementation "
+            "silently delegated to Engle-Granger."
+        )
 
     def _engle_granger_test(
         self,
@@ -185,17 +199,11 @@ class CointegrationAnalyzer:
             half_life=half_life
         )
 
-    def _johansen_test(
-        self,
-        series1: pd.Series,
-        series2: pd.Series
-    ) -> CointegrationResult:
-        """
-        Perform Johansen cointegration test.
-        (Simplified implementation - for full version use statsmodels)
-        """
-        # For now, fall back to Engle-Granger
-        return self._engle_granger_test(series1, series2)
+    # F-09-007: _johansen_test removed — it silently returned
+    # Engle-Granger results, which gave callers false confidence that
+    # they had run a different test. If Johansen is ever needed,
+    # implement properly via statsmodels.tsa.vector_ar.vecm.coint_johansen
+    # and add the enum value back.
 
     def _calculate_half_life(self, spread: np.ndarray) -> float:
         """Calculate mean reversion half-life using OLS."""

--- a/backend/data_ingestion/sec_edgar_client.py
+++ b/backend/data_ingestion/sec_edgar_client.py
@@ -8,6 +8,7 @@ import aiohttp
 from typing import Dict, Optional, List, Any
 from datetime import datetime, timedelta, timezone
 import logging
+import os
 import xml.etree.ElementTree as ET
 from bs4 import BeautifulSoup
 import re
@@ -25,10 +26,23 @@ class SECEdgarClient(BaseAPIClient):
     """
     
     def __init__(self):
-        # SEC requires user agent with contact info
+        # SEC requires a User-Agent with real contact info; placeholder
+        # addresses (``contact@example.com``) get the platform throttled
+        # or banned from sec.gov. Operators must set
+        # ``SEC_EDGAR_CONTACT_EMAIL`` to a real, monitored mailbox
+        # (F-05-006).
+        contact_email = os.getenv("SEC_EDGAR_CONTACT_EMAIL", "").strip()
+        if not contact_email or "example.com" in contact_email.lower():
+            raise RuntimeError(
+                "SEC_EDGAR_CONTACT_EMAIL must be set to a real contact email "
+                "address (not example.com). SEC EDGAR requires identifying "
+                "contact info in the User-Agent header and will rate-limit "
+                "or ban clients that omit it."
+            )
+
         super().__init__("sec_edgar", api_key=None)
         self.headers = {
-            'User-Agent': 'InvestmentAnalysisPlatform/1.0 (contact@example.com)'
+            'User-Agent': f'InvestmentAnalysisPlatform/1.0 ({contact_email})'
         }
         self.cik_map = {}  # Cache CIK mappings
     

--- a/backend/data_ingestion/smart_data_fetcher.py
+++ b/backend/data_ingestion/smart_data_fetcher.py
@@ -3,46 +3,77 @@ Smart Data Fetcher - Intelligent data fetching with caching and rate limiting.
 
 This module provides a unified interface for fetching stock data from
 multiple sources with intelligent caching and rate limit management.
+
+F-05-004 (audit 2026-04, G2a sub-theme C step 25): the previous
+implementation returned hardcoded zeros / empty lists from every
+``_fetch_*`` method, which silently degraded any downstream analytics
+that consumed it. Each fetcher now delegates to the existing real
+clients (``FinnhubClient``, ``AlphaVantageClient``, ``PolygonClient``,
+``SECEdgarClient``) and only falls back to a ``source: "unavailable"``
+sentinel when every client either failed or is not configured.
 """
 
 import logging
-from typing import Dict, Any, List, Optional
-from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional
+from datetime import datetime, timezone
 
 logger = logging.getLogger(__name__)
 
 
 class SmartDataFetcher:
-    """
-    Smart data fetcher that combines multiple data sources with intelligent caching.
-    
-    This class provides a unified interface for fetching various types of stock
-    data while managing API rate limits and implementing intelligent caching.
-    """
-    
+    """Unified data fetcher backed by real API clients with graceful fallback."""
+
     def __init__(self, cache_manager=None, rate_limiter=None):
-        """
-        Initialize the smart data fetcher.
-        
+        """Initialize the smart data fetcher.
+
         Args:
-            cache_manager: Optional cache manager for caching data
-            rate_limiter: Optional rate limiter for managing API calls
+            cache_manager: Optional cache manager for caching data.
+            rate_limiter: Optional rate limiter for managing API calls.
         """
         self.cache_manager = cache_manager
         self.rate_limiter = rate_limiter
         self._clients: Dict[str, Any] = {}
-        
+
+    # ------------------------------------------------------------------
+    # Client lazy init
+    # ------------------------------------------------------------------
+
+    def _get_client(self, name: str):
+        """Lazily build the requested client, swallowing config errors.
+
+        Returns ``None`` if the client is missing required configuration
+        (e.g. unset API key) so callers can move on to the next source.
+        """
+        if name in self._clients:
+            return self._clients[name]
+
+        client = None
+        try:
+            if name == "finnhub":
+                from backend.data_ingestion.finnhub_client import FinnhubClient
+                client = FinnhubClient()
+            elif name == "alpha_vantage":
+                from backend.data_ingestion.alpha_vantage_client import AlphaVantageClient
+                client = AlphaVantageClient()
+            elif name == "polygon":
+                from backend.data_ingestion.polygon_client import PolygonClient
+                client = PolygonClient()
+            elif name == "sec_edgar":
+                from backend.data_ingestion.sec_edgar_client import SECEdgarClient
+                client = SECEdgarClient()
+        except Exception as e:  # noqa: BLE001 - log and degrade
+            logger.warning(f"Smart fetcher: client {name!r} unavailable: {e}")
+            client = None
+
+        self._clients[name] = client
+        return client
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
     async def fetch_stock_data(self, ticker: str, data_type: str) -> Dict[str, Any]:
-        """
-        Fetch stock data with intelligent source selection.
-        
-        Args:
-            ticker: Stock ticker symbol
-            data_type: Type of data to fetch (price, fundamentals, news, etc.)
-            
-        Returns:
-            Dictionary containing the requested data
-        """
+        """Fetch stock data with intelligent source selection."""
         data_fetchers = {
             "price": self._fetch_price_data,
             "fundamentals": self._fetch_fundamentals,
@@ -51,86 +82,195 @@ class SmartDataFetcher:
             "earnings": self._fetch_earnings,
             "sentiment": self._fetch_sentiment,
         }
-        
         fetcher = data_fetchers.get(data_type, self._fetch_generic)
         return await fetcher(ticker)
-        
-    async def _fetch_price_data(self, ticker: str) -> Dict[str, Any]:
-        """Fetch current price data."""
-        return {
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _unavailable(self, ticker: str, **extra: Any) -> Dict[str, Any]:
+        """Sentinel response when no source can satisfy the request."""
+        payload = {
             "ticker": ticker,
-            "price": 0.0,
-            "change": 0.0,
-            "change_percent": 0.0,
-            "volume": 0,
+            "source": "unavailable",
             "timestamp": datetime.now(timezone.utc).isoformat(),
-            "source": "mock"
         }
-        
+        payload.update(extra)
+        return payload
+
+    async def _try_client(self, name: str, method: str, *args, **kwargs):
+        """Call ``client.method(*args, **kwargs)`` if the client exists."""
+        client = self._get_client(name)
+        if client is None:
+            return None
+        func = getattr(client, method, None)
+        if func is None:
+            return None
+        try:
+            return await func(*args, **kwargs)
+        except Exception as e:  # noqa: BLE001 - log and try next source
+            logger.warning(f"Smart fetcher: {name}.{method}({args!r}) failed: {e}")
+            return None
+
+    # ------------------------------------------------------------------
+    # Concrete fetchers
+    # ------------------------------------------------------------------
+
+    async def _fetch_price_data(self, ticker: str) -> Dict[str, Any]:
+        """Fetch current price data; tries finnhub → alpha_vantage → polygon."""
+        quote = await self._try_client("finnhub", "get_quote", ticker)
+        if quote:
+            return {
+                "ticker": ticker,
+                "price": quote.get("c") or quote.get("current_price") or 0.0,
+                "change": quote.get("d") or 0.0,
+                "change_percent": quote.get("dp") or 0.0,
+                "volume": quote.get("v") or 0,
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "source": "finnhub",
+            }
+
+        av_quote = await self._try_client("alpha_vantage", "get_quote", ticker)
+        if av_quote:
+            return {
+                "ticker": ticker,
+                "price": av_quote.get("price", 0.0),
+                "change": av_quote.get("change", 0.0),
+                "change_percent": av_quote.get("change_percent", 0.0),
+                "volume": av_quote.get("volume", 0),
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "source": "alpha_vantage",
+            }
+
+        last_quote = await self._try_client("polygon", "get_last_quote", ticker)
+        if last_quote:
+            return {
+                "ticker": ticker,
+                "price": last_quote.get("last_price", 0.0),
+                "change": 0.0,
+                "change_percent": 0.0,
+                "volume": last_quote.get("volume", 0),
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "source": "polygon",
+            }
+
+        return self._unavailable(
+            ticker,
+            price=0.0,
+            change=0.0,
+            change_percent=0.0,
+            volume=0,
+        )
+
     async def _fetch_fundamentals(self, ticker: str) -> Dict[str, Any]:
-        """Fetch fundamental data."""
-        return {
-            "ticker": ticker,
-            "pe_ratio": 0.0,
-            "market_cap": 0,
-            "eps": 0.0,
-            "dividend_yield": 0.0,
-            "source": "mock"
-        }
-        
+        """Fetch fundamental metrics; finnhub basic_financials → alpha_vantage overview."""
+        fin = await self._try_client("finnhub", "get_basic_financials", ticker)
+        if fin and isinstance(fin, dict):
+            metrics = fin.get("metric", {}) or {}
+            return {
+                "ticker": ticker,
+                "pe_ratio": metrics.get("peNormalizedAnnual") or metrics.get("peBasicExclExtraTTM", 0.0),
+                "market_cap": metrics.get("marketCapitalization", 0),
+                "eps": metrics.get("epsAnnual") or metrics.get("epsBasicExclExtraItemsTTM", 0.0),
+                "dividend_yield": metrics.get("dividendYieldIndicatedAnnual", 0.0),
+                "source": "finnhub",
+            }
+
+        overview = await self._try_client("alpha_vantage", "get_company_overview", ticker)
+        if overview:
+            return {
+                "ticker": ticker,
+                "pe_ratio": float(overview.get("PERatio", 0.0) or 0.0),
+                "market_cap": int(float(overview.get("MarketCapitalization", 0) or 0)),
+                "eps": float(overview.get("EPS", 0.0) or 0.0),
+                "dividend_yield": float(overview.get("DividendYield", 0.0) or 0.0),
+                "source": "alpha_vantage",
+            }
+
+        return self._unavailable(
+            ticker, pe_ratio=0.0, market_cap=0, eps=0.0, dividend_yield=0.0
+        )
+
     async def _fetch_news(self, ticker: str) -> Dict[str, Any]:
-        """Fetch news data."""
-        return {
-            "ticker": ticker,
-            "articles": [],
-            "source": "mock"
-        }
-        
+        """Fetch news headlines; finnhub get_news is the canonical source."""
+        articles = await self._try_client("finnhub", "get_news", ticker)
+        if articles is not None:
+            return {"ticker": ticker, "articles": articles, "source": "finnhub"}
+        return self._unavailable(ticker, articles=[])
+
     async def _fetch_financials(self, ticker: str) -> Dict[str, Any]:
-        """Fetch financial statements."""
-        return {
-            "ticker": ticker,
-            "income_statement": {},
-            "balance_sheet": {},
-            "cash_flow": {},
-            "source": "mock"
-        }
-        
+        """Fetch financial statements; SEC EDGAR is the authoritative source."""
+        sec = self._get_client("sec_edgar")
+        if sec is not None and hasattr(sec, "get_company_facts"):
+            try:
+                facts = await sec.get_company_facts(ticker)
+                if facts:
+                    return {"ticker": ticker, **facts, "source": "sec_edgar"}
+            except Exception as e:  # noqa: BLE001
+                logger.warning(f"SEC EDGAR facts for {ticker} failed: {e}")
+
+        return self._unavailable(
+            ticker,
+            income_statement={},
+            balance_sheet={},
+            cash_flow={},
+        )
+
     async def _fetch_earnings(self, ticker: str) -> Dict[str, Any]:
-        """Fetch earnings data."""
-        return {
-            "ticker": ticker,
-            "next_earnings_date": None,
-            "eps_history": [],
-            "source": "mock"
-        }
-        
+        """Fetch earnings data via Finnhub recommendations / price targets."""
+        recs = await self._try_client("finnhub", "get_recommendations", ticker)
+        target = await self._try_client("finnhub", "get_price_target", ticker)
+        if recs is not None or target is not None:
+            return {
+                "ticker": ticker,
+                "recommendations": recs or [],
+                "price_target": target or {},
+                "source": "finnhub",
+            }
+        return self._unavailable(
+            ticker, next_earnings_date=None, eps_history=[],
+        )
+
     async def _fetch_sentiment(self, ticker: str) -> Dict[str, Any]:
-        """Fetch sentiment data."""
-        return {
-            "ticker": ticker,
-            "sentiment_score": 0.0,
-            "sentiment_label": "neutral",
-            "source": "mock"
-        }
-        
+        """Fetch sentiment via Finnhub."""
+        sent = await self._try_client("finnhub", "get_sentiment", ticker)
+        if sent:
+            return {
+                "ticker": ticker,
+                "sentiment_score": sent.get("sentiment", 0.0),
+                "sentiment_label": sent.get("label", "neutral"),
+                "source": "finnhub",
+            }
+        return self._unavailable(
+            ticker, sentiment_score=0.0, sentiment_label="neutral",
+        )
+
     async def _fetch_generic(self, ticker: str) -> Dict[str, Any]:
-        """Fetch generic data as fallback."""
-        return {
-            "ticker": ticker,
-            "data": {},
-            "source": "mock"
-        }
-        
+        """Unknown data_type — explicit unavailability."""
+        return self._unavailable(ticker, data={})
+
+    # ------------------------------------------------------------------
+    # Diagnostics
+    # ------------------------------------------------------------------
+
     async def get_available_sources(self) -> List[str]:
-        """Get list of available data sources."""
-        return ["alpha_vantage", "finnhub", "polygon", "sec_edgar"]
-        
+        """Get list of available data sources (only those that initialized)."""
+        return [
+            name
+            for name in ("alpha_vantage", "finnhub", "polygon", "sec_edgar")
+            if self._get_client(name) is not None
+        ]
+
     async def get_source_status(self) -> Dict[str, Dict[str, Any]]:
         """Get status of all data sources."""
+        available = await self.get_available_sources()
         return {
-            source: {"available": True, "rate_limit_remaining": 100}
-            for source in await self.get_available_sources()
+            name: {
+                "available": name in available,
+                "rate_limit_remaining": None,
+            }
+            for name in ("alpha_vantage", "finnhub", "polygon", "sec_edgar")
         }
 
 

--- a/backend/data_ingestion/smart_data_fetcher.py
+++ b/backend/data_ingestion/smart_data_fetcher.py
@@ -14,8 +14,15 @@ sentinel when every client either failed or is not configured.
 """
 
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, TYPE_CHECKING
 from datetime import datetime, timezone
+
+if TYPE_CHECKING:
+    # ``BaseAPIClient`` is used only for type annotations. Importing it
+    # at runtime would drag in the backend.config chain (Pydantic
+    # Settings, secrets manager, etc.) which is too heavy for the
+    # surface this module presents.
+    from backend.data_ingestion.base_client import BaseAPIClient
 
 logger = logging.getLogger(__name__)
 
@@ -32,13 +39,16 @@ class SmartDataFetcher:
         """
         self.cache_manager = cache_manager
         self.rate_limiter = rate_limiter
-        self._clients: Dict[str, Any] = {}
+        # ``None`` values are cached for clients that failed to
+        # initialize (e.g. missing API key) so we don't retry them
+        # on every fetch.
+        self._clients: Dict[str, Optional["BaseAPIClient"]] = {}
 
     # ------------------------------------------------------------------
     # Client lazy init
     # ------------------------------------------------------------------
 
-    def _get_client(self, name: str):
+    def _get_client(self, name: str) -> Optional["BaseAPIClient"]:
         """Lazily build the requested client, swallowing config errors.
 
         Returns ``None`` if the client is missing required configuration
@@ -47,7 +57,7 @@ class SmartDataFetcher:
         if name in self._clients:
             return self._clients[name]
 
-        client = None
+        client: Optional["BaseAPIClient"] = None
         try:
             if name == "finnhub":
                 from backend.data_ingestion.finnhub_client import FinnhubClient

--- a/backend/etl/cache_storage.py
+++ b/backend/etl/cache_storage.py
@@ -12,6 +12,7 @@ import json
 import logging
 import os
 import sqlite3
+from contextlib import closing
 import threading
 from datetime import datetime, timedelta
 from typing import Any, Dict, Optional
@@ -199,75 +200,71 @@ class DiskTierCache:
 
     def _init_index_db(self):
         """Initialize SQLite index database"""
-        conn = sqlite3.connect(self.index_db_path)
-        cursor = conn.cursor()
+        with closing(sqlite3.connect(self.index_db_path)) as conn:
+            cursor = conn.cursor()
 
-        cursor.execute("""
-            CREATE TABLE IF NOT EXISTS cache_index (
-                key TEXT PRIMARY KEY,
-                file_path TEXT NOT NULL,
-                created_at TEXT NOT NULL,
-                expires_at TEXT NOT NULL,
-                access_count INTEGER DEFAULT 0,
-                last_accessed TEXT,
-                size_bytes INTEGER DEFAULT 0,
-                compression_method TEXT DEFAULT 'gzip',
-                compression_ratio REAL DEFAULT 1.0
-            )
-        """)
+            cursor.execute("""
+                CREATE TABLE IF NOT EXISTS cache_index (
+                    key TEXT PRIMARY KEY,
+                    file_path TEXT NOT NULL,
+                    created_at TEXT NOT NULL,
+                    expires_at TEXT NOT NULL,
+                    access_count INTEGER DEFAULT 0,
+                    last_accessed TEXT,
+                    size_bytes INTEGER DEFAULT 0,
+                    compression_method TEXT DEFAULT 'gzip',
+                    compression_ratio REAL DEFAULT 1.0
+                )
+            """)
 
-        cursor.execute("CREATE INDEX IF NOT EXISTS idx_expires_at ON cache_index(expires_at)")
-        cursor.execute("CREATE INDEX IF NOT EXISTS idx_last_accessed ON cache_index(last_accessed)")
+            cursor.execute("CREATE INDEX IF NOT EXISTS idx_expires_at ON cache_index(expires_at)")
+            cursor.execute("CREATE INDEX IF NOT EXISTS idx_last_accessed ON cache_index(last_accessed)")
 
-        conn.commit()
-        conn.close()
+            conn.commit()
 
     def get(self, key: str) -> Optional[Any]:
         """Get item from disk cache"""
         with self.lock:
-            conn = sqlite3.connect(self.index_db_path)
-            cursor = conn.cursor()
-
-            try:
-                cursor.execute("""
-                    SELECT file_path, compression_method, expires_at
-                    FROM cache_index
-                    WHERE key = ? AND expires_at > ?
-                """, (key, datetime.now().isoformat()))
-
-                result = cursor.fetchone()
-                if not result:
-                    return None
-
-                file_path, compression_method, _ = result
+            with closing(sqlite3.connect(self.index_db_path)) as conn:
+                cursor = conn.cursor()
 
                 try:
-                    with open(file_path, 'rb') as f:
-                        compressed_data = f.read()
-
-                    data = self.compression_manager.decompress_data(compressed_data, compression_method)
-
                     cursor.execute("""
-                        UPDATE cache_index
-                        SET access_count = access_count + 1, last_accessed = ?
-                        WHERE key = ?
-                    """, (datetime.now().isoformat(), key))
+                        SELECT file_path, compression_method, expires_at
+                        FROM cache_index
+                        WHERE key = ? AND expires_at > ?
+                    """, (key, datetime.now().isoformat()))
 
-                    conn.commit()
-                    return data
+                    result = cursor.fetchone()
+                    if not result:
+                        return None
 
-                except (IOError, OSError) as e:
-                    logger.warning(f"Failed to read cache file {file_path}: {e}")
-                    cursor.execute("DELETE FROM cache_index WHERE key = ?", (key,))
-                    conn.commit()
+                    file_path, compression_method, _ = result
+
+                    try:
+                        with open(file_path, 'rb') as f:
+                            compressed_data = f.read()
+
+                        data = self.compression_manager.decompress_data(compressed_data, compression_method)
+
+                        cursor.execute("""
+                            UPDATE cache_index
+                            SET access_count = access_count + 1, last_accessed = ?
+                            WHERE key = ?
+                        """, (datetime.now().isoformat(), key))
+
+                        conn.commit()
+                        return data
+
+                    except (IOError, OSError) as e:
+                        logger.warning(f"Failed to read cache file {file_path}: {e}")
+                        cursor.execute("DELETE FROM cache_index WHERE key = ?", (key,))
+                        conn.commit()
+                        return None
+
+                except Exception as e:
+                    logger.error(f"Disk cache get error for {key}: {e}")
                     return None
-
-            except Exception as e:
-                logger.error(f"Disk cache get error for {key}: {e}")
-                return None
-
-            finally:
-                conn.close()
 
     def set(self, key: str, data: Any, ttl_hours: Optional[int] = None) -> bool:
         """Set item in disk cache"""
@@ -287,19 +284,18 @@ class DiskTierCache:
 
                 expires_at = datetime.now() + timedelta(hours=ttl_hours or self.ttl_hours)
 
-                conn = sqlite3.connect(self.index_db_path)
-                cursor = conn.cursor()
+                with closing(sqlite3.connect(self.index_db_path)) as conn:
+                    cursor = conn.cursor()
 
-                cursor.execute("""
-                    INSERT OR REPLACE INTO cache_index
-                    (key, file_path, created_at, expires_at, size_bytes,
-                     compression_method, compression_ratio, last_accessed)
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-                """, (key, file_path, datetime.now().isoformat(), expires_at.isoformat(),
-                      len(compressed_data), 'gzip', compression_ratio, datetime.now().isoformat()))
+                    cursor.execute("""
+                        INSERT OR REPLACE INTO cache_index
+                        (key, file_path, created_at, expires_at, size_bytes,
+                         compression_method, compression_ratio, last_accessed)
+                        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                    """, (key, file_path, datetime.now().isoformat(), expires_at.isoformat(),
+                          len(compressed_data), 'gzip', compression_ratio, datetime.now().isoformat()))
 
-                conn.commit()
-                conn.close()
+                    conn.commit()
 
                 return True
 
@@ -310,132 +306,120 @@ class DiskTierCache:
     def delete(self, key: str) -> bool:
         """Delete item from disk cache"""
         with self.lock:
-            conn = sqlite3.connect(self.index_db_path)
-            cursor = conn.cursor()
+            with closing(sqlite3.connect(self.index_db_path)) as conn:
+                cursor = conn.cursor()
 
-            try:
-                cursor.execute("SELECT file_path FROM cache_index WHERE key = ?", (key,))
-                result = cursor.fetchone()
+                try:
+                    cursor.execute("SELECT file_path FROM cache_index WHERE key = ?", (key,))
+                    result = cursor.fetchone()
 
-                if result:
-                    file_path = result[0]
+                    if result:
+                        file_path = result[0]
 
-                    try:
-                        if os.path.exists(file_path):
-                            os.unlink(file_path)
-                    except OSError as e:
-                        logger.warning(f"Failed to delete cache file {file_path}: {e}")
+                        try:
+                            if os.path.exists(file_path):
+                                os.unlink(file_path)
+                        except OSError as e:
+                            logger.warning(f"Failed to delete cache file {file_path}: {e}")
 
-                    cursor.execute("DELETE FROM cache_index WHERE key = ?", (key,))
-                    conn.commit()
+                        cursor.execute("DELETE FROM cache_index WHERE key = ?", (key,))
+                        conn.commit()
 
-                    return True
+                        return True
 
-                return False
+                    return False
 
-            except Exception as e:
-                logger.error(f"Disk cache delete error for {key}: {e}")
-                return False
-
-            finally:
-                conn.close()
+                except Exception as e:
+                    logger.error(f"Disk cache delete error for {key}: {e}")
+                    return False
 
     def _ensure_disk_space(self, needed_bytes: int) -> bool:
         """Ensure sufficient disk space by cleaning up if needed"""
-        conn = sqlite3.connect(self.index_db_path)
-        cursor = conn.cursor()
+        with closing(sqlite3.connect(self.index_db_path)) as conn:
+            cursor = conn.cursor()
 
-        try:
-            cursor.execute("SELECT SUM(size_bytes) FROM cache_index")
-            current_usage = cursor.fetchone()[0] or 0
+            try:
+                cursor.execute("SELECT SUM(size_bytes) FROM cache_index")
+                current_usage = cursor.fetchone()[0] or 0
 
-            if current_usage + needed_bytes <= self.max_size_bytes:
-                return True
+                if current_usage + needed_bytes <= self.max_size_bytes:
+                    return True
 
-            bytes_to_free = (current_usage + needed_bytes) - self.max_size_bytes
+                bytes_to_free = (current_usage + needed_bytes) - self.max_size_bytes
 
-            cursor.execute("""
-                SELECT key, size_bytes
-                FROM cache_index
-                ORDER BY last_accessed ASC
-            """)
+                cursor.execute("""
+                    SELECT key, size_bytes
+                    FROM cache_index
+                    ORDER BY last_accessed ASC
+                """)
 
-            freed_bytes = 0
-            for key, size_bytes in cursor.fetchall():
-                if freed_bytes >= bytes_to_free:
-                    break
+                freed_bytes = 0
+                for key, size_bytes in cursor.fetchall():
+                    if freed_bytes >= bytes_to_free:
+                        break
 
-                self.delete(key)
-                freed_bytes += size_bytes
+                    self.delete(key)
+                    freed_bytes += size_bytes
 
-            return freed_bytes >= bytes_to_free
+                return freed_bytes >= bytes_to_free
 
-        except Exception as e:
-            logger.error(f"Error ensuring disk space: {e}")
-            return False
-
-        finally:
-            conn.close()
+            except Exception as e:
+                logger.error(f"Error ensuring disk space: {e}")
+                return False
 
     def _cleanup_expired(self):
         """Remove expired cache entries"""
-        conn = sqlite3.connect(self.index_db_path)
-        cursor = conn.cursor()
+        with closing(sqlite3.connect(self.index_db_path)) as conn:
+            cursor = conn.cursor()
 
-        try:
-            cursor.execute("""
-                SELECT key, file_path
-                FROM cache_index
-                WHERE expires_at < ?
-            """, (datetime.now().isoformat(),))
+            try:
+                cursor.execute("""
+                    SELECT key, file_path
+                    FROM cache_index
+                    WHERE expires_at < ?
+                """, (datetime.now().isoformat(),))
 
-            expired_entries = cursor.fetchall()
+                expired_entries = cursor.fetchall()
 
-            for key, file_path in expired_entries:
-                try:
-                    if os.path.exists(file_path):
-                        os.unlink(file_path)
-                except OSError:
-                    pass
+                for key, file_path in expired_entries:
+                    try:
+                        if os.path.exists(file_path):
+                            os.unlink(file_path)
+                    except OSError:
+                        pass
 
-            cursor.execute("DELETE FROM cache_index WHERE expires_at < ?",
-                           (datetime.now().isoformat(),))
+                cursor.execute("DELETE FROM cache_index WHERE expires_at < ?",
+                               (datetime.now().isoformat(),))
 
-            conn.commit()
+                conn.commit()
 
-            if expired_entries:
-                logger.info(f"Cleaned up {len(expired_entries)} expired cache entries")
+                if expired_entries:
+                    logger.info(f"Cleaned up {len(expired_entries)} expired cache entries")
 
-        except Exception as e:
-            logger.error(f"Error during cache cleanup: {e}")
-
-        finally:
-            conn.close()
+            except Exception as e:
+                logger.error(f"Error during cache cleanup: {e}")
 
     def get_stats(self) -> Dict:
         """Get disk cache statistics"""
-        conn = sqlite3.connect(self.index_db_path)
-        cursor = conn.cursor()
+        with closing(sqlite3.connect(self.index_db_path)) as conn:
+            cursor = conn.cursor()
 
-        try:
-            cursor.execute("SELECT COUNT(*), SUM(size_bytes), AVG(compression_ratio) FROM cache_index")
-            count, total_size, avg_compression = cursor.fetchone()
+            try:
+                cursor.execute("SELECT COUNT(*), SUM(size_bytes), AVG(compression_ratio) FROM cache_index")
+                count, total_size, avg_compression = cursor.fetchone()
 
-            return {
-                'entries': count or 0,
-                'size_bytes': total_size or 0,
-                'size_mb': (total_size or 0) / (1024 * 1024),
-                'max_size_mb': self.max_size_bytes / (1024 * 1024),
-                'utilization': (total_size or 0) / self.max_size_bytes,
-                'avg_compression_ratio': avg_compression or 1.0,
-                'compression_saved_mb': (
-                    (total_size or 0) * (1 - (avg_compression or 1.0)) / (1024 * 1024)
-                )
-            }
+                return {
+                    'entries': count or 0,
+                    'size_bytes': total_size or 0,
+                    'size_mb': (total_size or 0) / (1024 * 1024),
+                    'max_size_mb': self.max_size_bytes / (1024 * 1024),
+                    'utilization': (total_size or 0) / self.max_size_bytes,
+                    'avg_compression_ratio': avg_compression or 1.0,
+                    'compression_saved_mb': (
+                        (total_size or 0) * (1 - (avg_compression or 1.0)) / (1024 * 1024)
+                    )
+                }
 
-        except Exception as e:
-            logger.error(f"Error getting disk cache stats: {e}")
-            return {}
-
-        finally:
-            conn.close()
+            except Exception as e:
+                logger.error(f"Error getting disk cache stats: {e}")
+                return {}

--- a/backend/etl/distributed_batch_processor.py
+++ b/backend/etl/distributed_batch_processor.py
@@ -8,6 +8,7 @@ import json
 import logging
 import os
 import sqlite3
+from contextlib import closing
 from datetime import datetime, timedelta
 from typing import List, Dict, Any, Optional, Tuple, Set
 from dataclasses import dataclass, asdict
@@ -96,51 +97,50 @@ class DistributedBatchProcessor:
     
     def _init_job_db(self):
         """Initialize job tracking database"""
-        conn = sqlite3.connect(self.job_db_path)
-        cursor = conn.cursor()
+        with closing(sqlite3.connect(self.job_db_path)) as conn:
+            cursor = conn.cursor()
         
-        cursor.execute("""
-            CREATE TABLE IF NOT EXISTS batch_jobs (
-                job_id TEXT PRIMARY KEY,
-                status TEXT NOT NULL,
-                priority INTEGER,
-                created_at TIMESTAMP,
-                started_at TIMESTAMP,
-                completed_at TIMESTAMP,
-                progress INTEGER DEFAULT 0,
-                total_tickers INTEGER,
-                successful_extractions INTEGER DEFAULT 0,
-                failed_extractions INTEGER DEFAULT 0,
-                error_message TEXT,
-                config_json TEXT
-            )
-        """)
+            cursor.execute("""
+                CREATE TABLE IF NOT EXISTS batch_jobs (
+                    job_id TEXT PRIMARY KEY,
+                    status TEXT NOT NULL,
+                    priority INTEGER,
+                    created_at TIMESTAMP,
+                    started_at TIMESTAMP,
+                    completed_at TIMESTAMP,
+                    progress INTEGER DEFAULT 0,
+                    total_tickers INTEGER,
+                    successful_extractions INTEGER DEFAULT 0,
+                    failed_extractions INTEGER DEFAULT 0,
+                    error_message TEXT,
+                    config_json TEXT
+                )
+            """)
         
-        cursor.execute("""
-            CREATE TABLE IF NOT EXISTS job_tickers (
-                job_id TEXT,
-                ticker TEXT,
-                status TEXT,
-                extraction_source TEXT,
-                extracted_at TIMESTAMP,
-                error_message TEXT,
-                FOREIGN KEY (job_id) REFERENCES batch_jobs (job_id)
-            )
-        """)
+            cursor.execute("""
+                CREATE TABLE IF NOT EXISTS job_tickers (
+                    job_id TEXT,
+                    ticker TEXT,
+                    status TEXT,
+                    extraction_source TEXT,
+                    extracted_at TIMESTAMP,
+                    error_message TEXT,
+                    FOREIGN KEY (job_id) REFERENCES batch_jobs (job_id)
+                )
+            """)
         
-        cursor.execute("""
-            CREATE TABLE IF NOT EXISTS processor_stats (
-                timestamp TIMESTAMP PRIMARY KEY,
-                total_jobs_running INTEGER,
-                tickers_per_minute REAL,
-                success_rate REAL,
-                avg_time_per_ticker REAL,
-                memory_usage_mb REAL
-            )
-        """)
+            cursor.execute("""
+                CREATE TABLE IF NOT EXISTS processor_stats (
+                    timestamp TIMESTAMP PRIMARY KEY,
+                    total_jobs_running INTEGER,
+                    tickers_per_minute REAL,
+                    success_rate REAL,
+                    avg_time_per_ticker REAL,
+                    memory_usage_mb REAL
+                )
+            """)
         
-        conn.commit()
-        conn.close()
+            conn.commit()
     
     def create_job(self, tickers: List[str], priority: int = 1, job_id: str = None) -> str:
         """Create a new batch job"""
@@ -190,36 +190,34 @@ class DistributedBatchProcessor:
     
     def _save_job_to_db(self, job: BatchJob):
         """Save job to database"""
-        conn = sqlite3.connect(self.job_db_path)
-        cursor = conn.cursor()
+        with closing(sqlite3.connect(self.job_db_path)) as conn:
+            cursor = conn.cursor()
         
-        cursor.execute("""
-            INSERT OR REPLACE INTO batch_jobs 
-            (job_id, status, priority, created_at, started_at, completed_at, 
-             progress, total_tickers, successful_extractions, failed_extractions, 
-             error_message, config_json)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-        """, (
-            job.job_id, job.status, job.priority,
-            job.created_at.isoformat() if job.created_at else None,
-            job.started_at.isoformat() if job.started_at else None,
-            job.completed_at.isoformat() if job.completed_at else None,
-            job.progress, job.total_tickers,
-            job.successful_extractions, job.failed_extractions,
-            job.error_message, json.dumps(asdict(self.config), default=str)
-        ))
+            cursor.execute("""
+                INSERT OR REPLACE INTO batch_jobs 
+                (job_id, status, priority, created_at, started_at, completed_at, 
+                 progress, total_tickers, successful_extractions, failed_extractions, 
+                 error_message, config_json)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """, (
+                job.job_id, job.status, job.priority,
+                job.created_at.isoformat() if job.created_at else None,
+                job.started_at.isoformat() if job.started_at else None,
+                job.completed_at.isoformat() if job.completed_at else None,
+                job.progress, job.total_tickers,
+                job.successful_extractions, job.failed_extractions,
+                job.error_message, json.dumps(asdict(self.config), default=str)
+            ))
         
-        conn.commit()
-        conn.close()
+            conn.commit()
     
     def _load_job_from_db(self, job_id: str) -> Optional[BatchJob]:
         """Load job from database"""
-        conn = sqlite3.connect(self.job_db_path)
-        cursor = conn.cursor()
+        with closing(sqlite3.connect(self.job_db_path)) as conn:
+            cursor = conn.cursor()
         
-        cursor.execute("SELECT * FROM batch_jobs WHERE job_id = ?", (job_id,))
-        row = cursor.fetchone()
-        conn.close()
+            cursor.execute("SELECT * FROM batch_jobs WHERE job_id = ?", (job_id,))
+            row = cursor.fetchone()
         
         if not row:
             return None
@@ -259,32 +257,31 @@ class DistributedBatchProcessor:
     
     def list_jobs(self, status_filter: str = None) -> List[Dict]:
         """List all jobs, optionally filtered by status"""
-        conn = sqlite3.connect(self.job_db_path)
-        cursor = conn.cursor()
+        with closing(sqlite3.connect(self.job_db_path)) as conn:
+            cursor = conn.cursor()
         
-        if status_filter:
-            cursor.execute(
-                "SELECT job_id, status, priority, progress, total_tickers, created_at FROM batch_jobs WHERE status = ? ORDER BY priority, created_at",
-                (status_filter,)
-            )
-        else:
-            cursor.execute(
-                "SELECT job_id, status, priority, progress, total_tickers, created_at FROM batch_jobs ORDER BY priority, created_at"
-            )
+            if status_filter:
+                cursor.execute(
+                    "SELECT job_id, status, priority, progress, total_tickers, created_at FROM batch_jobs WHERE status = ? ORDER BY priority, created_at",
+                    (status_filter,)
+                )
+            else:
+                cursor.execute(
+                    "SELECT job_id, status, priority, progress, total_tickers, created_at FROM batch_jobs ORDER BY priority, created_at"
+                )
         
-        jobs = []
-        for row in cursor.fetchall():
-            jobs.append({
-                'job_id': row[0],
-                'status': row[1],
-                'priority': row[2],
-                'progress': row[3],
-                'total_tickers': row[4],
-                'completion_percentage': (row[3] / row[4] * 100) if row[4] > 0 else 0,
-                'created_at': row[5]
-            })
+            jobs = []
+            for row in cursor.fetchall():
+                jobs.append({
+                    'job_id': row[0],
+                    'status': row[1],
+                    'priority': row[2],
+                    'progress': row[3],
+                    'total_tickers': row[4],
+                    'completion_percentage': (row[3] / row[4] * 100) if row[4] > 0 else 0,
+                    'created_at': row[5]
+                })
         
-        conn.close()
         return jobs
     
     async def _process_single_job(self, job: BatchJob) -> BatchJob:
@@ -442,79 +439,77 @@ class DistributedBatchProcessor:
     
     def _load_pending_jobs(self):
         """Load pending jobs from database"""
-        conn = sqlite3.connect(self.job_db_path)
-        cursor = conn.cursor()
+        with closing(sqlite3.connect(self.job_db_path)) as conn:
+            cursor = conn.cursor()
         
-        cursor.execute("""
-            SELECT job_id FROM batch_jobs 
-            WHERE status = 'pending'
-            ORDER BY priority, created_at
-            LIMIT 20
-        """)
+            cursor.execute("""
+                SELECT job_id FROM batch_jobs 
+                WHERE status = 'pending'
+                ORDER BY priority, created_at
+                LIMIT 20
+            """)
         
-        for row in cursor.fetchall():
-            job_id = row[0]
+            for row in cursor.fetchall():
+                job_id = row[0]
             
-            # Load job data from file
-            job_file = self.jobs_dir / f"{job_id}.json"
-            if job_file.exists():
-                try:
-                    with open(job_file, 'r') as f:
-                        job_data = json.load(f)
-                        job = BatchJob(
-                            job_id=job_data['job_id'],
-                            tickers=job_data['tickers'],
-                            status=job_data['status'],
-                            priority=job_data['priority'],
-                            created_at=datetime.fromisoformat(job_data['created_at']),
-                            total_tickers=job_data['total_tickers']
-                        )
-                        self.job_queue.append(job)
-                except Exception as e:
-                    logger.error(f"Error loading job {job_id}: {e}")
+                # Load job data from file
+                job_file = self.jobs_dir / f"{job_id}.json"
+                if job_file.exists():
+                    try:
+                        with open(job_file, 'r') as f:
+                            job_data = json.load(f)
+                            job = BatchJob(
+                                job_id=job_data['job_id'],
+                                tickers=job_data['tickers'],
+                                status=job_data['status'],
+                                priority=job_data['priority'],
+                                created_at=datetime.fromisoformat(job_data['created_at']),
+                                total_tickers=job_data['total_tickers']
+                            )
+                            self.job_queue.append(job)
+                    except Exception as e:
+                        logger.error(f"Error loading job {job_id}: {e}")
         
-        conn.close()
     
     def _update_stats(self):
         """Update processor statistics"""
         try:
-            conn = sqlite3.connect(self.job_db_path)
-            cursor = conn.cursor()
+            with closing(sqlite3.connect(self.job_db_path)) as conn:
+                cursor = conn.cursor()
             
-            # Calculate current metrics
-            current_time = datetime.now()
-            running_jobs = len(self.active_jobs)
+                # Calculate current metrics
+                current_time = datetime.now()
+                running_jobs = len(self.active_jobs)
             
-            # Calculate tickers per minute (last hour)
-            hour_ago = (current_time - timedelta(hours=1)).isoformat()
-            cursor.execute("""
-                SELECT COUNT(*) FROM job_tickers 
-                WHERE extracted_at > ? AND status = 'success'
-            """, (hour_ago,))
+                # Calculate tickers per minute (last hour)
+                hour_ago = (current_time - timedelta(hours=1)).isoformat()
+                cursor.execute("""
+                    SELECT COUNT(*) FROM job_tickers 
+                    WHERE extracted_at > ? AND status = 'success'
+                """, (hour_ago,))
             
-            tickers_last_hour = cursor.fetchone()[0] or 0
-            tickers_per_minute = tickers_last_hour / 60.0 if tickers_last_hour > 0 else 0
+                tickers_last_hour = cursor.fetchone()[0] or 0
+                tickers_per_minute = tickers_last_hour / 60.0 if tickers_last_hour > 0 else 0
             
-            # Calculate success rate (last hour)
-            cursor.execute("""
-                SELECT 
-                    SUM(CASE WHEN status = 'success' THEN 1 ELSE 0 END) * 100.0 / COUNT(*) as success_rate
-                FROM job_tickers 
-                WHERE extracted_at > ?
-            """, (hour_ago,))
+                # Calculate success rate (last hour)
+                cursor.execute("""
+                    SELECT 
+                        SUM(CASE WHEN status = 'success' THEN 1 ELSE 0 END) * 100.0 / COUNT(*) as success_rate
+                    FROM job_tickers 
+                    WHERE extracted_at > ?
+                """, (hour_ago,))
             
-            result = cursor.fetchone()
-            success_rate = result[0] if result and result[0] else 0
+                result = cursor.fetchone()
+                success_rate = result[0] if result and result[0] else 0
             
-            # Insert stats
-            cursor.execute("""
-                INSERT INTO processor_stats 
-                (timestamp, total_jobs_running, tickers_per_minute, success_rate, avg_time_per_ticker)
-                VALUES (?, ?, ?, ?, ?)
-            """, (current_time.isoformat(), running_jobs, tickers_per_minute, success_rate, 0))
+                # Insert stats
+                cursor.execute("""
+                    INSERT INTO processor_stats 
+                    (timestamp, total_jobs_running, tickers_per_minute, success_rate, avg_time_per_ticker)
+                    VALUES (?, ?, ?, ?, ?)
+                """, (current_time.isoformat(), running_jobs, tickers_per_minute, success_rate, 0))
             
-            conn.commit()
-            conn.close()
+                conn.commit()
             
         except Exception as e:
             logger.debug(f"Error updating stats: {e}")
@@ -531,21 +526,19 @@ class DistributedBatchProcessor:
             del self.active_jobs[job_id]
             
             # Update job status
-            conn = sqlite3.connect(self.job_db_path)
-            cursor = conn.cursor()
-            cursor.execute("UPDATE batch_jobs SET status = 'paused' WHERE job_id = ?", (job_id,))
-            conn.commit()
-            conn.close()
+            with closing(sqlite3.connect(self.job_db_path)) as conn:
+                cursor = conn.cursor()
+                cursor.execute("UPDATE batch_jobs SET status = 'paused' WHERE job_id = ?", (job_id,))
+                conn.commit()
             
             logger.info(f"Paused job {job_id}")
     
     def resume_job(self, job_id: str):
         """Resume a paused job"""
-        conn = sqlite3.connect(self.job_db_path)
-        cursor = conn.cursor()
-        cursor.execute("UPDATE batch_jobs SET status = 'pending' WHERE job_id = ?", (job_id,))
-        conn.commit()
-        conn.close()
+        with closing(sqlite3.connect(self.job_db_path)) as conn:
+            cursor = conn.cursor()
+            cursor.execute("UPDATE batch_jobs SET status = 'pending' WHERE job_id = ?", (job_id,))
+            conn.commit()
         
         logger.info(f"Resumed job {job_id}")
     

--- a/backend/etl/etl_orchestrator.py
+++ b/backend/etl/etl_orchestrator.py
@@ -50,6 +50,10 @@ class ETLOrchestrator:
     def __init__(self, use_distributed: bool = True, cache_dir: str = "/tmp/stock_cache"):
         # Legacy components (maintained for backward compatibility)
         self.legacy_extractor = DataExtractor()
+        # F-05-007: realtime / single-ticker code paths reference
+        # ``self.extractor`` (etl_orchestrator.py lines 387, 633). Alias
+        # to the legacy extractor so those paths do not AttributeError.
+        self.extractor = self.legacy_extractor
         self.transformer = DataTransformer()
         self.loader = DataLoader()
         self.batch_loader = BatchLoader(self.loader)

--- a/backend/etl/etl_orchestrator.py
+++ b/backend/etl/etl_orchestrator.py
@@ -146,28 +146,69 @@ class ETLOrchestrator:
             
             logger.info(f"Created {len(job_ids)} processing jobs")
             
-            # Start distributed processing
+            # F-05-002: bound the monitor loop. The original version only
+            # counted ``status == 'completed'`` jobs, so any failed/cancelled
+            # job left the loop spinning forever. We now:
+            #   - count terminal states (completed | failed | cancelled |
+            #     error) toward the exit condition
+            #   - enforce ``max_wait_seconds`` so a stuck processor cannot
+            #     hang the pipeline indefinitely
+            #   - cancel ``processing_task`` in ``finally`` so a leaked
+            #     task does not survive the exit
+            max_wait_seconds = int(
+                os.getenv("ETL_DISTRIBUTED_MAX_WAIT_SECONDS", "7200")
+            )
+            poll_interval_seconds = 30
+            terminal_states = {"completed", "failed", "cancelled", "error"}
+
             processing_task = asyncio.create_task(
                 self.distributed_processor.start_processing()
             )
-            
-            # Monitor progress
-            completed_jobs = 0
-            while completed_jobs < len(job_ids):
-                await asyncio.sleep(30)  # Check every 30 seconds
-                
-                completed_count = 0
-                for job_id in job_ids:
-                    status = self.distributed_processor.get_job_status(job_id)
-                    if status and status['status'] == 'completed':
-                        completed_count += 1
-                
-                if completed_count > completed_jobs:
-                    completed_jobs = completed_count
-                    logger.info(f"Progress: {completed_jobs}/{len(job_ids)} jobs completed")
-            
-            # Stop processing and collect results
-            self.distributed_processor.stop_processing()
+
+            start_time = asyncio.get_event_loop().time()
+            try:
+                terminal_jobs = 0
+                while terminal_jobs < len(job_ids):
+                    elapsed = asyncio.get_event_loop().time() - start_time
+                    if elapsed > max_wait_seconds:
+                        logger.warning(
+                            f"Distributed pipeline exceeded "
+                            f"max_wait_seconds={max_wait_seconds}; aborting "
+                            f"with {terminal_jobs}/{len(job_ids)} jobs terminal"
+                        )
+                        self.metrics["errors"].append(
+                            f"distributed_pipeline_timeout after {elapsed:.0f}s"
+                        )
+                        break
+
+                    await asyncio.sleep(poll_interval_seconds)
+
+                    terminal_count = 0
+                    completed_count = 0
+                    failed_count = 0
+                    for job_id in job_ids:
+                        status = self.distributed_processor.get_job_status(job_id)
+                        if status and status["status"] in terminal_states:
+                            terminal_count += 1
+                            if status["status"] == "completed":
+                                completed_count += 1
+                            else:
+                                failed_count += 1
+
+                    if terminal_count > terminal_jobs:
+                        terminal_jobs = terminal_count
+                        logger.info(
+                            f"Progress: {terminal_jobs}/{len(job_ids)} jobs terminal "
+                            f"({completed_count} ok, {failed_count} failed)"
+                        )
+            finally:
+                self.distributed_processor.stop_processing()
+                if not processing_task.done():
+                    processing_task.cancel()
+                    try:
+                        await processing_task
+                    except (asyncio.CancelledError, Exception):
+                        pass
             
             # Update metrics from processor stats
             processor_stats = self.distributed_processor.get_processor_stats()

--- a/backend/etl/multi_source_extractor.py
+++ b/backend/etl/multi_source_extractor.py
@@ -42,18 +42,9 @@ load_dotenv()
 logger = logging.getLogger(__name__)
 
 
-@dataclass
-class ExtractionResult:
-    ticker: str
-    success: bool
-    data: Optional[Dict] = None
-    source: Optional[str] = None
-    error: Optional[str] = None
-    timestamp: datetime = None
-    
-    def __post_init__(self):
-        if self.timestamp is None:
-            self.timestamp = datetime.now()
+# F-05-005: re-export canonical ExtractionResult from backend.etl.types
+# so downstream isinstance() checks pass across both extractor modules.
+from .types import ExtractionResult  # noqa: E402
 
 
 @dataclass

--- a/backend/etl/multi_source_extractor.py
+++ b/backend/etl/multi_source_extractor.py
@@ -21,6 +21,7 @@ import time
 import random
 from concurrent.futures import ThreadPoolExecutor, as_completed
 import sqlite3
+from contextlib import closing
 import hashlib
 from dataclasses import dataclass
 # SECURITY: Removed pickle - using JSON for safer serialization
@@ -194,34 +195,33 @@ class MultiSourceStockExtractor:
     
     def _init_progress_db(self):
         """Initialize progress tracking database"""
-        conn = sqlite3.connect(self.progress_db_path)
-        cursor = conn.cursor()
+        with closing(sqlite3.connect(self.progress_db_path)) as conn:
+            cursor = conn.cursor()
         
-        cursor.execute("""
-            CREATE TABLE IF NOT EXISTS extraction_log (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                ticker TEXT,
-                source TEXT,
-                status TEXT,
-                timestamp TIMESTAMP,
-                error_message TEXT,
-                data_quality_score REAL
-            )
-        """)
+            cursor.execute("""
+                CREATE TABLE IF NOT EXISTS extraction_log (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    ticker TEXT,
+                    source TEXT,
+                    status TEXT,
+                    timestamp TIMESTAMP,
+                    error_message TEXT,
+                    data_quality_score REAL
+                )
+            """)
         
-        cursor.execute("""
-            CREATE TABLE IF NOT EXISTS ticker_progress (
-                ticker TEXT PRIMARY KEY,
-                last_successful_extraction TIMESTAMP,
-                successful_sources TEXT,
-                failed_sources TEXT,
-                total_attempts INTEGER DEFAULT 0,
-                data_completeness_score REAL DEFAULT 0.0
-            )
-        """)
+            cursor.execute("""
+                CREATE TABLE IF NOT EXISTS ticker_progress (
+                    ticker TEXT PRIMARY KEY,
+                    last_successful_extraction TIMESTAMP,
+                    successful_sources TEXT,
+                    failed_sources TEXT,
+                    total_attempts INTEGER DEFAULT 0,
+                    data_completeness_score REAL DEFAULT 0.0
+                )
+            """)
         
-        conn.commit()
-        conn.close()
+            conn.commit()
     
     def _can_make_request(self, source: str) -> bool:
         """Check if we can make a request to the source using TokenBucket.
@@ -756,16 +756,15 @@ class MultiSourceStockExtractor:
     def _log_extraction(self, ticker: str, source: str, status: str, error: str):
         """Log extraction attempt to database"""
         try:
-            conn = sqlite3.connect(self.progress_db_path)
-            cursor = conn.cursor()
+            with closing(sqlite3.connect(self.progress_db_path)) as conn:
+                cursor = conn.cursor()
             
-            cursor.execute("""
-                INSERT INTO extraction_log (ticker, source, status, timestamp, error_message)
-                VALUES (?, ?, ?, ?, ?)
-            """, (ticker, source, status, datetime.now().isoformat(), error))
+                cursor.execute("""
+                    INSERT INTO extraction_log (ticker, source, status, timestamp, error_message)
+                    VALUES (?, ?, ?, ?, ?)
+                """, (ticker, source, status, datetime.now().isoformat(), error))
             
-            conn.commit()
-            conn.close()
+                conn.commit()
         except Exception as e:
             logger.debug(f"Error logging extraction: {e}")
     
@@ -868,25 +867,24 @@ class MultiSourceStockExtractor:
     def get_extraction_stats(self) -> Dict:
         """Get statistics about extraction performance"""
         try:
-            conn = sqlite3.connect(self.progress_db_path)
-            cursor = conn.cursor()
+            with closing(sqlite3.connect(self.progress_db_path)) as conn:
+                cursor = conn.cursor()
             
-            # Get overall stats
-            cursor.execute("""
-                SELECT source, status, COUNT(*) as count
-                FROM extraction_log
-                WHERE timestamp > datetime('now', '-24 hours')
-                GROUP BY source, status
-            """)
+                # Get overall stats
+                cursor.execute("""
+                    SELECT source, status, COUNT(*) as count
+                    FROM extraction_log
+                    WHERE timestamp > datetime('now', '-24 hours')
+                    GROUP BY source, status
+                """)
             
-            stats = {'sources': {}}
-            for row in cursor.fetchall():
-                source, status, count = row
-                if source not in stats['sources']:
-                    stats['sources'][source] = {}
-                stats['sources'][source][status] = count
+                stats = {'sources': {}}
+                for row in cursor.fetchall():
+                    source, status, count = row
+                    if source not in stats['sources']:
+                        stats['sources'][source] = {}
+                    stats['sources'][source][status] = count
             
-            conn.close()
             return stats
             
         except Exception as e:

--- a/backend/etl/types.py
+++ b/backend/etl/types.py
@@ -1,0 +1,34 @@
+"""
+Shared ETL types.
+
+F-05-005 (audit 2026-04, G2a sub-theme C): ``ExtractionResult`` was
+previously defined twice — once in ``multi_source_extractor.py`` and
+once in ``unlimited_data_extractor.py`` — with subtly different ``data``
+field types. Consolidated here so both modules re-export the same
+class and downstream isinstance checks behave consistently.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Optional
+
+
+@dataclass
+class ExtractionResult:
+    """Result of a data extraction attempt."""
+
+    ticker: str
+    success: bool
+    data: Any = None
+    source: Optional[str] = None
+    error: Optional[str] = None
+    timestamp: Optional[datetime] = None
+
+    def __post_init__(self) -> None:
+        if self.timestamp is None:
+            self.timestamp = datetime.now()
+
+
+__all__ = ["ExtractionResult"]

--- a/backend/etl/unlimited_data_extractor.py
+++ b/backend/etl/unlimited_data_extractor.py
@@ -18,11 +18,26 @@ from urllib.parse import quote
 import yfinance as yf
 from concurrent.futures import ThreadPoolExecutor
 import requests
-from selenium import webdriver
-from selenium.webdriver.chrome.options import Options
-from selenium.webdriver.common.by import By
-from selenium.webdriver.support.ui import WebDriverWait
-from selenium.webdriver.support import expected_conditions as EC
+# F-05-001: selenium is an optional dependency. Top-level imports made
+# this whole module unimportable in environments without selenium
+# (e.g. CI, minimal containers, fresh-clone smoke tests), which in turn
+# broke ``from backend.etl.data_extractor import DataExtractor``.
+try:
+    from selenium import webdriver
+    from selenium.webdriver.chrome.options import Options
+    from selenium.webdriver.common.by import By
+    from selenium.webdriver.support.ui import WebDriverWait
+    from selenium.webdriver.support import expected_conditions as EC
+
+    SELENIUM_AVAILABLE = True
+except ImportError:  # pragma: no cover - exercised in selenium-less envs
+    webdriver = None  # type: ignore[assignment]
+    Options = None  # type: ignore[assignment]
+    By = None  # type: ignore[assignment]
+    WebDriverWait = None  # type: ignore[assignment]
+    EC = None  # type: ignore[assignment]
+
+    SELENIUM_AVAILABLE = False
 import os
 from dataclasses import dataclass, field
 
@@ -77,14 +92,20 @@ class UnlimitedDataExtractor:
     """Extract stock data without rate limits using web scraping and free sources"""
     
     def __init__(self):
-        # Configure Selenium for headless scraping
-        self.chrome_options = Options()
-        self.chrome_options.add_argument('--headless')
-        self.chrome_options.add_argument('--no-sandbox')
-        self.chrome_options.add_argument('--disable-dev-shm-usage')
-        self.chrome_options.add_argument('--disable-gpu')
-        self.chrome_options.add_argument('--window-size=1920x1080')
-        self.chrome_options.add_argument('--user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36')
+        # F-05-001: only build Selenium Options when selenium is importable.
+        # Code paths that need a driver must check SELENIUM_AVAILABLE first.
+        if SELENIUM_AVAILABLE:
+            self.chrome_options = Options()
+            self.chrome_options.add_argument('--headless')
+            self.chrome_options.add_argument('--no-sandbox')
+            self.chrome_options.add_argument('--disable-dev-shm-usage')
+            self.chrome_options.add_argument('--disable-gpu')
+            self.chrome_options.add_argument('--window-size=1920x1080')
+            self.chrome_options.add_argument(
+                '--user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36'
+            )
+        else:
+            self.chrome_options = None
         
         # Session management
         self.session = None
@@ -103,6 +124,12 @@ class UnlimitedDataExtractor:
     
     def get_driver(self):
         """Get or create Selenium driver"""
+        if not SELENIUM_AVAILABLE:
+            logger.warning(
+                "Selenium is not installed; driver-based extraction unavailable"
+            )
+            self.driver = None
+            return self.driver
         if not self.driver:
             try:
                 self.driver = webdriver.Chrome(options=self.chrome_options)

--- a/backend/etl/unlimited_data_extractor.py
+++ b/backend/etl/unlimited_data_extractor.py
@@ -67,19 +67,11 @@ class StockData:
         self.extra = kwargs
 
 
-@dataclass
-class ExtractionResult:
-    """Result of a data extraction attempt"""
-    ticker: str
-    success: bool
-    data: Any = None
-    source: Optional[str] = None
-    error: Optional[str] = None
-    timestamp: datetime = None
-
-    def __post_init__(self):
-        if self.timestamp is None:
-            self.timestamp = datetime.now()
+# F-05-005: re-export canonical ExtractionResult from backend.etl.types
+# so isinstance() checks behave consistently across both extractor
+# modules. Relative import keeps the module loadable standalone for the
+# F-05-001 selenium-guard regression test.
+from .types import ExtractionResult  # noqa: E402
 
 
 # Aliases for classes imported by unlimited_extractor_with_fallbacks

--- a/backend/ml/artifact_manager.py
+++ b/backend/ml/artifact_manager.py
@@ -177,7 +177,14 @@ class ModelArtifactManager:
         if format == ModelFormat.PYTORCH:
             if torch is None:
                 raise RuntimeError("torch is not installed")
-            return torch.load(path, map_location='cpu')
+            # F-03-002: torch.load defaults to pickle deserialization which
+            # is RCE-equivalent on untrusted artifacts. ``weights_only=True``
+            # restricts deserialization to tensor primitives. Full-model
+            # artifacts that need non-tensor classes must be allowlisted via
+            # ``torch.serialization.add_safe_globals([Cls, ...])`` before
+            # the load — see workpaper §9 for the safe_globals escalation
+            # path.
+            return torch.load(path, map_location='cpu', weights_only=True)
 
         elif format == ModelFormat.SKLEARN_JOBLIB:
             if joblib is None:

--- a/backend/ml/feature_store.py
+++ b/backend/ml/feature_store.py
@@ -346,6 +346,14 @@ class FeatureStore:
             'rsi_14d': self._compute_rsi_14d,
             'sma_20d': self._compute_sma_20d,
             'ema_20d': self._compute_ema_20d,
+            # F-03-008: ML_PIPELINE_DOCUMENTATION.md advertised MACD and
+            # Bollinger Bands as builtin features but the computations
+            # were never implemented. Adds them so the documented
+            # surface and the runtime surface agree.
+            'macd': self._compute_macd,
+            'macd_signal': self._compute_macd_signal,
+            'bollinger_upper_20d': self._compute_bollinger_upper_20d,
+            'bollinger_lower_20d': self._compute_bollinger_lower_20d,
             'pe_ratio': self._compute_pe_ratio,
             'market_cap': self._compute_market_cap
         }
@@ -574,6 +582,101 @@ class FeatureStore:
         
         return pd.Series(ema_values, index=entity_ids)
     
+    # F-03-008: MACD and Bollinger Bands implementations follow.
+    # All four share a small helper that returns the per-entity close
+    # series, sorted by date.
+
+    def _entity_close_series(
+        self,
+        entity_id: str,
+        price_data: pd.DataFrame,
+    ) -> pd.Series:
+        rows = price_data[price_data['ticker'] == entity_id].sort_values('date')
+        return rows['close'].astype(float)
+
+    def _compute_macd(self, entity_ids: List[str], timestamp: datetime,
+                     data_sources: Dict[str, pd.DataFrame], computed_features: pd.DataFrame) -> pd.Series:
+        """MACD = EMA(12) - EMA(26) on closing prices."""
+        if 'price_data' not in data_sources:
+            return pd.Series(np.nan, index=entity_ids)
+
+        price_data = data_sources['price_data']
+        values: List[float] = []
+        for entity_id in entity_ids:
+            try:
+                closes = self._entity_close_series(entity_id, price_data)
+                if len(closes) >= 26:
+                    ema_fast = closes.ewm(span=12, adjust=False).mean().iloc[-1]
+                    ema_slow = closes.ewm(span=26, adjust=False).mean().iloc[-1]
+                    values.append(float(ema_fast - ema_slow))
+                else:
+                    values.append(np.nan)
+            except Exception as e:
+                logger.error(f"Error computing MACD for {entity_id}: {e}")
+                values.append(np.nan)
+        return pd.Series(values, index=entity_ids)
+
+    def _compute_macd_signal(self, entity_ids: List[str], timestamp: datetime,
+                            data_sources: Dict[str, pd.DataFrame], computed_features: pd.DataFrame) -> pd.Series:
+        """MACD signal line = EMA(9) of the MACD series."""
+        if 'price_data' not in data_sources:
+            return pd.Series(np.nan, index=entity_ids)
+
+        price_data = data_sources['price_data']
+        values: List[float] = []
+        for entity_id in entity_ids:
+            try:
+                closes = self._entity_close_series(entity_id, price_data)
+                if len(closes) >= 26 + 9:
+                    macd_series = (
+                        closes.ewm(span=12, adjust=False).mean()
+                        - closes.ewm(span=26, adjust=False).mean()
+                    )
+                    signal = macd_series.ewm(span=9, adjust=False).mean().iloc[-1]
+                    values.append(float(signal))
+                else:
+                    values.append(np.nan)
+            except Exception as e:
+                logger.error(f"Error computing MACD signal for {entity_id}: {e}")
+                values.append(np.nan)
+        return pd.Series(values, index=entity_ids)
+
+    def _compute_bollinger_upper_20d(self, entity_ids: List[str], timestamp: datetime,
+                                     data_sources: Dict[str, pd.DataFrame], computed_features: pd.DataFrame) -> pd.Series:
+        """20-day Bollinger upper band = SMA(20) + 2 * std(20)."""
+        return self._compute_bollinger_band(entity_ids, data_sources, k=2.0)
+
+    def _compute_bollinger_lower_20d(self, entity_ids: List[str], timestamp: datetime,
+                                     data_sources: Dict[str, pd.DataFrame], computed_features: pd.DataFrame) -> pd.Series:
+        """20-day Bollinger lower band = SMA(20) - 2 * std(20)."""
+        return self._compute_bollinger_band(entity_ids, data_sources, k=-2.0)
+
+    def _compute_bollinger_band(
+        self,
+        entity_ids: List[str],
+        data_sources: Dict[str, pd.DataFrame],
+        k: float,
+    ) -> pd.Series:
+        if 'price_data' not in data_sources:
+            return pd.Series(np.nan, index=entity_ids)
+
+        price_data = data_sources['price_data']
+        values: List[float] = []
+        for entity_id in entity_ids:
+            try:
+                closes = self._entity_close_series(entity_id, price_data)
+                if len(closes) >= 20:
+                    window = closes.tail(20)
+                    mean = float(window.mean())
+                    std = float(window.std(ddof=0))
+                    values.append(mean + k * std)
+                else:
+                    values.append(np.nan)
+            except Exception as e:
+                logger.error(f"Error computing Bollinger band for {entity_id}: {e}")
+                values.append(np.nan)
+        return pd.Series(values, index=entity_ids)
+
     def _compute_pe_ratio(self, entity_ids: List[str], timestamp: datetime,
                         data_sources: Dict[str, pd.DataFrame], computed_features: pd.DataFrame) -> pd.Series:
         """Compute P/E ratio"""

--- a/backend/ml/minimal_training.py
+++ b/backend/ml/minimal_training.py
@@ -14,27 +14,30 @@ import joblib
 def create_sample_model():
     """Create a minimal sample model"""
     print("Creating minimal sample model...")
-    
-    # Create directories
-    os.makedirs('backend/ml_models', exist_ok=True)
-    os.makedirs('backend/ml_logs', exist_ok=True)
-    
+
+    # F-03-007: anchor paths to project root regardless of cwd.
+    _project_root = Path(__file__).resolve().parent.parent.parent
+    _models_dir = _project_root / "backend" / "ml_models"
+    _logs_dir = _project_root / "backend" / "ml_logs"
+    _models_dir.mkdir(parents=True, exist_ok=True)
+    _logs_dir.mkdir(parents=True, exist_ok=True)
+
     # Create simple dummy model (using sklearn)
     from sklearn.linear_model import LinearRegression
-    
+
     # Generate sample data
     X = np.random.randn(100, 5)
     y = np.random.randn(100)
-    
+
     # Train model
     model = LinearRegression()
     model.fit(X, y)
-    
+
     # Save model
     # SECURITY: Use joblib instead of pickle for safer serialization
-    model_path = 'backend/ml_models/sample_model.pkl'
+    model_path = str(_models_dir / "sample_model.pkl")
     joblib.dump(model, model_path)
-    
+
     # Save metadata
     metadata = {
         'timestamp': datetime.now().isoformat(),
@@ -44,8 +47,8 @@ def create_sample_model():
         'samples': 100,
         'score': float(model.score(X, y))
     }
-    
-    metadata_path = 'backend/ml_logs/sample_model_metadata.json'
+
+    metadata_path = str(_logs_dir / "sample_model_metadata.json")
     with open(metadata_path, 'w') as f:
         json.dump(metadata, f, indent=2)
     

--- a/backend/ml/ml_api_server.py
+++ b/backend/ml/ml_api_server.py
@@ -5,6 +5,7 @@ Serves ML models via FastAPI on port 8001
 """
 
 import os
+import re
 import sys
 import logging
 import uvicorn
@@ -67,12 +68,48 @@ class ModelInfo(BaseModel):
     score: float
     loaded_at: str
 
+# F-03-006: model_name is operator-controlled via the
+# ``POST /models/{model_name}/load`` route and the prediction request
+# body. Without validation a caller could pass ``../../../etc/passwd``
+# and read arbitrary paths off the host filesystem. We enforce a
+# strict character class AND a resolved-path containment check.
+_MODEL_NAME_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+_MODELS_ROOT = Path("backend/ml_models").resolve()
+_MODELS_LOGS_ROOT = Path("backend/ml_logs").resolve()
+
+
+def _validate_model_name(model_name: str) -> str:
+    """Reject any model_name that doesn't match ``[A-Za-z0-9_-]+``.
+
+    Raises ``ValueError`` — callers map this to HTTP 400 (not 500) so
+    operators can distinguish "bad input" from "server error" in logs.
+    """
+    if not isinstance(model_name, str) or not _MODEL_NAME_RE.fullmatch(model_name):
+        raise ValueError(
+            f"invalid model_name: must match [A-Za-z0-9_-]+ (got {model_name!r})"
+        )
+    return model_name
+
+
+def _safe_model_path(root: Path, model_name: str, suffix: str) -> Path:
+    """Resolve ``{root}/{model_name}{suffix}`` and assert containment."""
+    candidate = (root / f"{model_name}{suffix}").resolve()
+    try:
+        candidate.relative_to(root)
+    except ValueError as e:
+        raise ValueError(
+            f"resolved path {candidate!s} escapes models root {root!s}"
+        ) from e
+    return candidate
+
+
 def load_model(model_name: str):
     """Load a model from disk"""
     try:
-        model_path = Path(f"backend/ml_models/{model_name}.pkl")
-        metadata_path = Path(f"backend/ml_logs/{model_name}_metadata.json")
-        
+        _validate_model_name(model_name)
+        model_path = _safe_model_path(_MODELS_ROOT, model_name, ".pkl")
+        metadata_path = _safe_model_path(_MODELS_LOGS_ROOT, model_name, "_metadata.json")
+
         if not model_path.exists():
             raise FileNotFoundError(f"Model file not found: {model_path}")
         
@@ -196,8 +233,13 @@ async def load_model_endpoint(model_name: str):
             "message": f"Model {model_name} loaded successfully",
             "timestamp": datetime.now().isoformat()
         }
-    except Exception as e:
+    except ValueError as e:
+        # F-03-006: malformed/path-traversing model_name → 400, not 500.
+        raise HTTPException(status_code=400, detail=str(e))
+    except FileNotFoundError as e:
         raise HTTPException(status_code=404, detail=str(e))
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
 
 @app.delete("/models/{model_name}")
 async def unload_model(model_name: str):

--- a/backend/ml/model_manager.py
+++ b/backend/ml/model_manager.py
@@ -218,7 +218,10 @@ class ModelManager:
     def _load_pytorch_model(self, path: Path):
         """Load PyTorch model with error handling"""
         try:
-            model = torch.load(path, map_location='cpu')
+            # F-03-002: weights_only=True blocks pickle RCE. Full-model
+            # artifacts that fail with WeightsUnpickler must register their
+            # constructor classes via torch.serialization.add_safe_globals.
+            model = torch.load(path, map_location='cpu', weights_only=True)
             model.eval()
             return model
         except Exception as e:
@@ -297,7 +300,9 @@ class ModelManager:
                 num_layers=config['num_layers'],
                 dropout=config['dropout']
             )
-            model.load_state_dict(torch.load(path, map_location='cpu'))
+            # F-03-002: state_dict-only loads are tensor primitives —
+            # weights_only=True is always safe here.
+            model.load_state_dict(torch.load(path, map_location='cpu', weights_only=True))
             model.eval()
 
             # Return wrapper with config and scaler

--- a/backend/ml/model_versioning.py
+++ b/backend/ml/model_versioning.py
@@ -591,7 +591,9 @@ class ModelVersionManager:
             
             # Load model based on type
             if model_version.model_type == ModelType.PYTORCH:
-                model = torch.load(model_path, map_location='cpu')
+                # F-03-002: see artifact_manager.py for the weights_only=True
+                # rationale and the safe_globals escalation path.
+                model = torch.load(model_path, map_location='cpu', weights_only=True)
             elif model_version.model_type in [ModelType.SKLEARN, ModelType.ENSEMBLE]:
                 model = joblib.load(model_path)
             else:

--- a/backend/ml/simple_training_pipeline.py
+++ b/backend/ml/simple_training_pipeline.py
@@ -18,12 +18,18 @@ import joblib
 # Add parent directory to path
 sys.path.append(str(Path(__file__).parent.parent.parent))
 
+# F-03-007: anchor log path to project root (__file__-relative).
+_ML_LOGS_DIR = Path(__file__).resolve().parent.parent.parent / "backend" / "ml_logs"
+_ML_LOGS_DIR.mkdir(parents=True, exist_ok=True)
+
 # Configure logging
 logging.basicConfig(
     level=logging.INFO,
     format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
     handlers=[
-        logging.FileHandler(f'backend/ml_logs/simple_training_{datetime.now().strftime("%Y%m%d_%H%M%S")}.log'),
+        logging.FileHandler(
+            _ML_LOGS_DIR / f'simple_training_{datetime.now().strftime("%Y%m%d_%H%M%S")}.log'
+        ),
         logging.StreamHandler()
     ]
 )

--- a/backend/ml/training/evaluate_models.py
+++ b/backend/ml/training/evaluate_models.py
@@ -88,7 +88,8 @@ class ModelEvaluator:
                 num_layers=config['num_layers'],
                 dropout=config['dropout']
             )
-            model.load_state_dict(torch.load(model_path, map_location='cpu'))
+            # F-03-002: state_dict-only — weights_only=True is always safe.
+            model.load_state_dict(torch.load(model_path, map_location='cpu', weights_only=True))
             model.eval()
 
             # Load scaler

--- a/backend/ml/training_pipeline.py
+++ b/backend/ml/training_pipeline.py
@@ -18,12 +18,20 @@ from typing import Dict, Any, Optional
 # Add parent directory to path
 sys.path.append(str(Path(__file__).parent.parent.parent))
 
+# F-03-007: anchor log path to the project root (__file__-relative)
+# so that running training from any cwd writes to the same directory
+# instead of creating a stray ``backend/ml_logs/`` next to the caller.
+_ML_LOGS_DIR = Path(__file__).resolve().parent.parent.parent / "backend" / "ml_logs"
+_ML_LOGS_DIR.mkdir(parents=True, exist_ok=True)
+
 # Configure logging
 logging.basicConfig(
     level=logging.INFO,
     format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
     handlers=[
-        logging.FileHandler(f'backend/ml_logs/training_{datetime.now().strftime("%Y%m%d_%H%M%S")}.log'),
+        logging.FileHandler(
+            _ML_LOGS_DIR / f'training_{datetime.now().strftime("%Y%m%d_%H%M%S")}.log'
+        ),
         logging.StreamHandler()
     ]
 )

--- a/backend/tests/unit/test_airflow_dag_cleanup.py
+++ b/backend/tests/unit/test_airflow_dag_cleanup.py
@@ -1,0 +1,63 @@
+"""
+Regression tests for Airflow DAG cleanup (F-06-005, F-06-006, F-06-007, F-06-009).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+_DAGS_DIR = (
+    Path(__file__).resolve().parents[3]
+    / "data_pipelines"
+    / "airflow"
+    / "dags"
+)
+_DAILY = _DAGS_DIR / "daily_stock_pipeline.py"
+_ML = _DAGS_DIR / "ml_training_pipeline_dag.py"
+
+
+def test_no_schedule_interval_kwarg() -> None:
+    """F-06-005: ``schedule_interval=`` deprecated in Airflow 2.4+."""
+
+    for dag_path in _DAGS_DIR.glob("*.py"):
+        text = dag_path.read_text()
+        assert not re.search(r"\bschedule_interval\s*=", text), (
+            f"{dag_path.name} still uses deprecated schedule_interval kwarg"
+        )
+
+
+def test_no_create_session_call_in_dag() -> None:
+    """F-06-006: ``airflow.utils.db.create_session`` removed from public API."""
+
+    text = _DAILY.read_text()
+    assert not re.search(r"\bcreate_session\s*\(", text), (
+        "daily_stock_pipeline.py still calls airflow.utils.db.create_session"
+    )
+    assert "from airflow.utils.db import create_session" not in text
+
+
+def test_no_legacy_deprecated_block_in_daily_pipeline() -> None:
+    """F-06-007: ``DEPRECATED``/``LEGACY`` comment block must be gone."""
+
+    text = _DAILY.read_text()
+    assert "DEPRECATED" not in text, (
+        "daily_stock_pipeline.py still contains DEPRECATED label"
+    )
+    assert "LEGACY FUNCTIONS" not in text, (
+        "daily_stock_pipeline.py still contains LEGACY FUNCTIONS block"
+    )
+
+
+def test_no_placeholder_alert_email() -> None:
+    """F-06-009: ``ml-alerts@company.com`` placeholder must be gone."""
+
+    text = _ML.read_text()
+    assert "ml-alerts@company.com" not in text, (
+        "ml_training_pipeline_dag.py still ships the placeholder alert email"
+    )
+    assert "ml_alert_emails" in text, (
+        "ml_training_pipeline_dag.py must source alert recipients from "
+        "the ``ml_alert_emails`` Airflow Variable"
+    )

--- a/backend/tests/unit/test_airflow_dag_data_quality.py
+++ b/backend/tests/unit/test_airflow_dag_data_quality.py
@@ -1,0 +1,45 @@
+"""
+Regression tests for the check_data_quality DAG task.
+
+F-06-003 (audit 2026-04, G2a sub-theme D step 12): the task called the
+non-existent method ``DataQualityChecker.check_recent_data_quality``,
+raising AttributeError at runtime.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+_DAG = (
+    Path(__file__).resolve().parents[3]
+    / "data_pipelines"
+    / "airflow"
+    / "dags"
+    / "ml_training_pipeline_dag.py"
+)
+
+
+def test_check_data_quality_does_not_call_removed_method() -> None:
+    """F-06-003: ``checker.check_recent_data_quality(...)`` call must be gone."""
+
+    text = _DAG.read_text()
+    assert not re.search(
+        r"\.check_recent_data_quality\s*\(", text
+    ), (
+        "ml_training_pipeline_dag.py still calls the non-existent "
+        "DataQualityChecker.check_recent_data_quality method"
+    )
+
+
+def test_check_data_quality_uses_existing_methods() -> None:
+    """F-06-003: must use real public surface of DataQualityChecker."""
+
+    text = _DAG.read_text()
+    assert "validate_price_data" in text, (
+        "check_data_quality must call validate_price_data on real rows"
+    )
+    assert "generate_quality_report" in text, (
+        "check_data_quality must call generate_quality_report to aggregate"
+    )

--- a/backend/tests/unit/test_airflow_dag_imports.py
+++ b/backend/tests/unit/test_airflow_dag_imports.py
@@ -1,0 +1,49 @@
+"""
+Regression tests for Airflow 1.x → 2.x import migration.
+
+F-06-001 (audit 2026-04, G2a sub-theme D step 10):
+``data_pipelines/airflow/dags/ml_training_pipeline_dag.py`` still imported
+from removed Airflow 1.x module paths:
+- ``airflow.operators.python_operator``
+- ``airflow.operators.bash_operator``
+- ``airflow.sensors.external_task_sensor``
+
+``airflow dags list`` surfaces ImportError for any DAG file containing
+these. The fail-first tests below scan the DAG source for the legacy
+paths.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+_DAGS_DIR = (
+    Path(__file__).resolve().parents[3]
+    / "data_pipelines"
+    / "airflow"
+    / "dags"
+)
+
+_REMOVED_IMPORTS = [
+    "airflow.operators.python_operator",
+    "airflow.operators.bash_operator",
+    "airflow.sensors.external_task_sensor",
+]
+
+
+@pytest.mark.parametrize("removed", _REMOVED_IMPORTS)
+def test_no_removed_airflow_1x_imports_in_dags(removed: str) -> None:
+    """F-06-001: removed Airflow 1.x import paths must not appear in DAGs."""
+
+    offenders = []
+    for dag_path in _DAGS_DIR.glob("*.py"):
+        text = dag_path.read_text()
+        if removed in text:
+            offenders.append(dag_path.name)
+    assert not offenders, (
+        f"DAG(s) still import the removed Airflow 1.x path {removed!r}: "
+        f"{offenders}"
+    )

--- a/backend/tests/unit/test_airflow_dag_numpy.py
+++ b/backend/tests/unit/test_airflow_dag_numpy.py
@@ -1,0 +1,32 @@
+"""
+Regression tests for missing numpy import in ml_training_pipeline_dag.
+
+F-06-002 (audit 2026-04, G2a sub-theme D step 11):
+``evaluate_models`` referenced ``np.random.randn`` without importing
+numpy, raising ``NameError`` at task execution time.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+_DAG = (
+    Path(__file__).resolve().parents[3]
+    / "data_pipelines"
+    / "airflow"
+    / "dags"
+    / "ml_training_pipeline_dag.py"
+)
+
+
+def test_numpy_is_imported() -> None:
+    """F-06-002: numpy must be imported wherever np.* is referenced."""
+
+    text = _DAG.read_text()
+    if "np." not in text:
+        return  # nothing to verify
+    assert re.search(r"^import numpy(\s+as\s+np)?$", text, re.MULTILINE), (
+        "ml_training_pipeline_dag.py uses np.* but does not import numpy"
+    )

--- a/backend/tests/unit/test_airflow_dag_vacuum.py
+++ b/backend/tests/unit/test_airflow_dag_vacuum.py
@@ -1,0 +1,55 @@
+"""
+Regression tests for VACUUM-in-transaction bug.
+
+F-06-004 (audit 2026-04, G2a sub-theme D step 15):
+``enhanced_stock_pipeline.cleanup_and_optimize`` issued
+``VACUUM ANALYZE ...`` through ``PostgresHook.run``, which wraps each
+statement in a transaction — Postgres rejects this with
+``ERROR: VACUUM cannot run inside a transaction block``. VACUUMs must
+go through a raw connection with isolation level AUTOCOMMIT.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+_DAG = (
+    Path(__file__).resolve().parents[3]
+    / "data_pipelines"
+    / "airflow"
+    / "dags"
+    / "enhanced_stock_pipeline.py"
+)
+
+
+def test_vacuum_not_run_through_pg_hook_run() -> None:
+    """F-06-004: VACUUM must not be issued via the transactional run() path."""
+
+    text = _DAG.read_text()
+    # The VACUUM strings live in a dedicated ``vacuum_queries`` list now.
+    assert "vacuum_queries" in text, (
+        "VACUUM statements should be isolated into a vacuum_queries list "
+        "so they bypass the transactional path"
+    )
+    # And the raw-connection autocommit hop must be present.
+    assert "set_isolation_level(0)" in text, (
+        "VACUUM block must use ``conn.set_isolation_level(0)`` "
+        "(AUTOCOMMIT) to satisfy Postgres"
+    )
+
+
+def test_vacuum_strings_not_inside_transactional_block() -> None:
+    """F-06-004: VACUUM statements must not be inside ``transactional_queries``."""
+
+    text = _DAG.read_text()
+    # Slice the file between transactional_queries = [ ... ] and verify no
+    # VACUUM string appears in that slice.
+    match = re.search(
+        r"transactional_queries\s*=\s*\[(.*?)\]", text, re.DOTALL
+    )
+    assert match is not None, "transactional_queries list not found"
+    assert "VACUUM" not in match.group(1).upper(), (
+        "VACUUM statement leaked back into the transactional list"
+    )

--- a/backend/tests/unit/test_cointegration_no_fake_johansen.py
+++ b/backend/tests/unit/test_cointegration_no_fake_johansen.py
@@ -1,0 +1,59 @@
+"""
+Regression tests for the Johansen "fake test" removal.
+
+F-09-007 (audit 2026-04, G2a sub-theme E step 39):
+``CointegrationAnalyzer._johansen_test`` silently delegated to
+Engle-Granger and returned its result. Callers selecting
+``CointegrationMethod.JOHANSEN`` believed they were getting a
+different statistical test but got identical numbers — false
+confidence in a downstream stat-arb strategy.
+
+Per workpaper §3, the cheaper-and-honest fix is to remove the
+JOHANSEN enum value entirely. If real Johansen support is needed
+later, implement properly via
+``statsmodels.tsa.vector_ar.vecm.coint_johansen``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "analytics"
+    / "statistical"
+    / "cointegration_analyzer.py"
+)
+
+
+def test_johansen_enum_value_removed() -> None:
+    """F-09-007: ``JOHANSEN = "johansen"`` enum member must be gone."""
+
+    text = _PATH.read_text()
+    # The actual enum-member line was ``    JOHANSEN = "johansen"``.
+    # Comments documenting the removal may still mention the name —
+    # match only the assignment form.
+    assert "JOHANSEN = " not in text, (
+        "CointegrationMethod still declares the JOHANSEN enum member"
+    )
+
+
+def test_johansen_method_helper_removed() -> None:
+    """F-09-007: ``def _johansen_test`` must be gone."""
+
+    text = _PATH.read_text()
+    assert "def _johansen_test" not in text, (
+        "_johansen_test helper still defined — it silently delegated to "
+        "Engle-Granger which is exactly the false-confidence bug"
+    )
+
+
+def test_test_cointegration_raises_for_unknown_method() -> None:
+    """F-09-007: passing a non-ENGLE_GRANGER method must raise, not fallthrough."""
+
+    text = _PATH.read_text()
+    assert "raise NotImplementedError" in text, (
+        "test_cointegration must raise NotImplementedError for unsupported "
+        "methods so callers cannot silently get the wrong test"
+    )

--- a/backend/tests/unit/test_dcf_no_self_mutation.py
+++ b/backend/tests/unit/test_dcf_no_self_mutation.py
@@ -1,0 +1,97 @@
+"""
+Regression tests for DCF sensitivity_analysis self-mutation.
+
+F-09-003 (audit 2026-04, G2a sub-theme E step 36):
+``DCFModel.sensitivity_analysis`` set ``self.terminal_growth_rate = gr``
+inside a nested loop, leaving the instance's terminal-growth-rate
+attribute set to the *last* growth rate tested after the method
+returned. Subsequent calls to ``calculate_intrinsic_value`` then used
+the wrong terminal growth rate.
+
+The fix threads ``terminal_growth_rate`` as a per-call parameter on
+``calculate_intrinsic_value`` and removes the mutation.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+
+_DCF = (
+    Path(__file__).resolve().parents[2]
+    / "analytics"
+    / "fundamental"
+    / "valuation"
+    / "dcf_model.py"
+)
+
+
+def _load_module(monkeypatch: pytest.MonkeyPatch):
+    for name in list(sys.modules):
+        if name == "backend" or name.startswith("backend."):
+            monkeypatch.delitem(sys.modules, name, raising=False)
+
+    name = "dcf_model_under_test"
+    spec = importlib.util.spec_from_file_location(name, _DCF)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[name] = module
+    monkeypatch.setitem(sys.modules, name, module)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_terminal_growth_rate_unchanged_after_sensitivity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """F-09-003: ``self.terminal_growth_rate`` must be the same value after sensitivity_analysis returns."""
+
+    mod = _load_module(monkeypatch)
+    model = mod.DCFModel(terminal_growth_rate=0.025)
+
+    model.sensitivity_analysis(
+        free_cash_flow=1_000_000,
+        discount_rates=[0.08, 0.10, 0.12],
+        growth_rates=[0.01, 0.02, 0.03, 0.04],
+        shares_outstanding=10_000,
+    )
+
+    assert model.terminal_growth_rate == 0.025, (
+        f"sensitivity_analysis mutated self.terminal_growth_rate "
+        f"(now {model.terminal_growth_rate})"
+    )
+
+
+def test_calculate_intrinsic_value_accepts_terminal_growth_rate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """F-09-003: calculate_intrinsic_value must accept terminal_growth_rate kwarg."""
+
+    mod = _load_module(monkeypatch)
+    model = mod.DCFModel(terminal_growth_rate=0.025)
+
+    r1 = model.calculate_intrinsic_value(
+        free_cash_flow=1_000_000,
+        discount_rate=0.10,
+        shares_outstanding=10_000,
+        terminal_growth_rate=0.01,
+    )
+    r2 = model.calculate_intrinsic_value(
+        free_cash_flow=1_000_000,
+        discount_rate=0.10,
+        shares_outstanding=10_000,
+        terminal_growth_rate=0.04,
+    )
+
+    # Higher terminal growth → higher intrinsic value (everything else equal).
+    assert r2.intrinsic_value > r1.intrinsic_value, (
+        f"expected r2 > r1 (terminal growth 0.04 > 0.01), "
+        f"got r1={r1.intrinsic_value}, r2={r2.intrinsic_value}"
+    )
+
+    # And the override must not have leaked back into the instance.
+    assert model.terminal_growth_rate == 0.025

--- a/backend/tests/unit/test_etl_extended_agent2.py
+++ b/backend/tests/unit/test_etl_extended_agent2.py
@@ -135,7 +135,11 @@ _dl = _load_etl_module("data_loader")
 # data_validator (no relative imports)
 _dv = _load_etl_module("data_validator")
 
-# unlimited_data_extractor (relative: none, but uses selenium etc. -- all stubbed)
+# F-05-005: both extractor modules now do ``from .types import ExtractionResult``.
+# Register the real types module so the relative import resolves.
+_types = _load_etl_module("types")
+
+# unlimited_data_extractor (relative: .types, plus selenium etc. -- all stubbed)
 _ude = _load_etl_module("unlimited_data_extractor")
 
 # intelligent_cache_system (no relative imports)

--- a/backend/tests/unit/test_etl_extended_agent3.py
+++ b/backend/tests/unit/test_etl_extended_agent3.py
@@ -120,6 +120,19 @@ sys.modules["_etl_pkg"] = _fake_pkg
 sys.modules["_etl_pkg.web_scrapers"] = _ws
 sys.modules["_etl_pkg.rate_limiting"] = _rl
 
+# F-05-005: the extractor modules now do ``from .types import
+# ExtractionResult``. Load the real types module under the synthetic
+# package so relative imports resolve.
+_types_spec = importlib.util.spec_from_file_location(
+    "_etl_pkg.types",
+    _etl_dir / "types.py",
+    submodule_search_locations=[],
+)
+_types = importlib.util.module_from_spec(_types_spec)
+_types.__package__ = "_etl_pkg"
+sys.modules["_etl_pkg.types"] = _types
+_types_spec.loader.exec_module(_types)
+
 _mse_spec = importlib.util.spec_from_file_location(
     "_etl_pkg.multi_source_extractor",
     _etl_dir / "multi_source_extractor.py",
@@ -139,12 +152,18 @@ extract_stocks_data = _mse.extract_stocks_data
 # ---------------------------------------------------------------------------
 # 4. Load unlimited_data_extractor
 # ---------------------------------------------------------------------------
+# F-05-005: unlimited_data_extractor now does ``from .types import
+# ExtractionResult``. Load under the synthetic ``_etl_pkg`` so the
+# relative import resolves to the same stub already registered above.
 _ude_spec = importlib.util.spec_from_file_location(
-    "unlimited_data_extractor",
+    "_etl_pkg.unlimited_data_extractor",
     _etl_dir / "unlimited_data_extractor.py",
+    submodule_search_locations=[],
 )
 _ude = importlib.util.module_from_spec(_ude_spec)
-sys.modules["unlimited_data_extractor"] = _ude
+_ude.__package__ = "_etl_pkg"
+sys.modules["_etl_pkg.unlimited_data_extractor"] = _ude
+sys.modules["unlimited_data_extractor"] = _ude  # legacy alias retained
 _ude_spec.loader.exec_module(_ude)
 
 StockData = _ude.StockData

--- a/backend/tests/unit/test_etl_extraction_result.py
+++ b/backend/tests/unit/test_etl_extraction_result.py
@@ -1,0 +1,70 @@
+"""
+Regression tests for the consolidated ExtractionResult type.
+
+F-05-005 (audit 2026-04, G2a sub-theme C step 22):
+``ExtractionResult`` was defined twice — once in
+``backend/etl/multi_source_extractor.py`` and once in
+``backend/etl/unlimited_data_extractor.py`` — with subtly different
+``data`` field types. ``isinstance()`` checks failed across the
+modules. Consolidated into ``backend/etl/types.py``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+_BASE = Path(__file__).resolve().parents[2] / "etl"
+
+
+def _load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_types_module_defines_extraction_result() -> None:
+    """F-05-005: canonical ExtractionResult lives in backend.etl.types."""
+
+    text = (_BASE / "types.py").read_text()
+    assert "class ExtractionResult" in text
+
+
+_RE_EXPORT_PATTERNS = (
+    "from backend.etl.types import ExtractionResult",
+    "from .types import ExtractionResult",
+)
+
+
+def test_multi_source_re_exports_extraction_result() -> None:
+    """F-05-005: multi_source_extractor re-exports from types module.
+
+    Accepts either the absolute (``backend.etl.types``) or relative
+    (``.types``) import form — both resolve to the same module.
+    """
+
+    text = (_BASE / "multi_source_extractor.py").read_text()
+    assert any(p in text for p in _RE_EXPORT_PATTERNS), (
+        "multi_source_extractor.py must re-export ExtractionResult from "
+        "backend.etl.types (absolute or relative form)"
+    )
+    occurrences = text.count("class ExtractionResult")
+    assert occurrences == 0, (
+        f"multi_source_extractor.py still defines its own "
+        f"ExtractionResult class ({occurrences} definition(s) found)"
+    )
+
+
+def test_unlimited_data_extractor_re_exports_extraction_result() -> None:
+    """F-05-005: unlimited_data_extractor re-exports from types module."""
+
+    text = (_BASE / "unlimited_data_extractor.py").read_text()
+    assert any(p in text for p in _RE_EXPORT_PATTERNS), (
+        "unlimited_data_extractor.py must re-export ExtractionResult from "
+        "backend.etl.types (absolute or relative form)"
+    )
+    occurrences = text.count("class ExtractionResult")
+    assert occurrences == 0

--- a/backend/tests/unit/test_etl_orchestrator_bounded_loop.py
+++ b/backend/tests/unit/test_etl_orchestrator_bounded_loop.py
@@ -1,0 +1,79 @@
+"""
+Regression tests for ETLOrchestrator distributed-pipeline bounded loop.
+
+F-05-002 (audit 2026-04, G2a sub-theme C step 24):
+``ETLOrchestrator._run_distributed_pipeline`` monitored job completion
+with ``while completed_jobs < len(job_ids)`` and only counted
+``status == 'completed'`` toward the exit condition. Any failed,
+cancelled, or errored job left the loop spinning forever. The created
+``processing_task`` was also never cancelled on exit, leaking the
+task.
+
+The fix:
+- counts terminal states (completed | failed | cancelled | error)
+- enforces ``ETL_DISTRIBUTED_MAX_WAIT_SECONDS`` (default 7200s)
+- cancels ``processing_task`` in ``finally``
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+_ORCHESTRATOR = (
+    Path(__file__).resolve().parents[2]
+    / "etl"
+    / "etl_orchestrator.py"
+)
+
+
+def test_terminal_states_counted_toward_exit() -> None:
+    """F-05-002: failed/cancelled/error jobs must also exit the loop."""
+
+    text = _ORCHESTRATOR.read_text()
+    assert "terminal_states" in text, (
+        "monitor loop must define a terminal_states set; otherwise failed "
+        "jobs leave the loop spinning"
+    )
+    for state in ("completed", "failed", "cancelled", "error"):
+        assert f'"{state}"' in text, (
+            f"terminal state {state!r} missing from the bounded loop"
+        )
+
+
+def test_max_wait_seconds_enforced() -> None:
+    """F-05-002: wall-clock bound prevents indefinite hang."""
+
+    text = _ORCHESTRATOR.read_text()
+    assert "max_wait_seconds" in text
+    assert "ETL_DISTRIBUTED_MAX_WAIT_SECONDS" in text, (
+        "max wait must be operator-configurable via env var"
+    )
+
+
+def test_processing_task_cancelled_in_finally() -> None:
+    """F-05-002: processing_task must not leak on exit."""
+
+    text = _ORCHESTRATOR.read_text()
+    # The monitor loop body must be guarded by a ``finally`` block that
+    # invokes both ``stop_processing()`` and ``processing_task.cancel()``.
+    finally_block = re.search(
+        r"finally:\s*\n\s*self\.distributed_processor\.stop_processing\(\)"
+        r".*?processing_task\.cancel\(\)",
+        text,
+        re.DOTALL,
+    )
+    assert finally_block is not None, (
+        "finally block must cancel processing_task and stop the processor"
+    )
+
+
+def test_no_unbounded_while_completed_lt_len() -> None:
+    """F-05-002: the original unbounded condition must be gone."""
+
+    text = _ORCHESTRATOR.read_text()
+    # The legacy line was ``while completed_jobs < len(job_ids):``.
+    assert "while completed_jobs < len(job_ids):" not in text, (
+        "unbounded ``while completed_jobs < len(job_ids):`` still present"
+    )

--- a/backend/tests/unit/test_etl_orchestrator_extractor_alias.py
+++ b/backend/tests/unit/test_etl_orchestrator_extractor_alias.py
@@ -1,0 +1,48 @@
+"""
+Regression tests for the ETLOrchestrator extractor alias.
+
+F-05-007 (audit 2026-04, G2a sub-theme C step 20):
+``ETLOrchestrator.__init__`` set ``self.legacy_extractor`` but two code
+paths (lines 387 and 633) referenced ``self.extractor``, raising
+AttributeError on every realtime/single-ticker call.
+
+This test inspects the source rather than instantiating the
+orchestrator, because instantiation pulls in the full backend stack
+(Postgres, Redis, validators).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+_ORCHESTRATOR = (
+    Path(__file__).resolve().parents[2]
+    / "etl"
+    / "etl_orchestrator.py"
+)
+
+
+def test_init_sets_extractor_alias() -> None:
+    """F-05-007: ``self.extractor`` must be assigned alongside legacy_extractor."""
+
+    text = _ORCHESTRATOR.read_text()
+    assert re.search(
+        r"self\.extractor\s*=\s*self\.legacy_extractor", text
+    ), (
+        "ETLOrchestrator.__init__ must alias self.extractor to the "
+        "legacy_extractor to satisfy the realtime/single-ticker paths"
+    )
+
+
+def test_extractor_references_have_a_defined_owner() -> None:
+    """F-05-007: every ``self.extractor.<method>(`` call must be backed by an init assignment."""
+
+    text = _ORCHESTRATOR.read_text()
+    extractor_calls = re.findall(r"self\.extractor\.\w+\(", text)
+    assert extractor_calls, "no self.extractor.* calls — bug spec stale?"
+    assert re.search(r"self\.extractor\s*=", text), (
+        f"self.extractor is referenced ({len(extractor_calls)} call sites) "
+        f"but never assigned"
+    )

--- a/backend/tests/unit/test_etl_selenium_guard.py
+++ b/backend/tests/unit/test_etl_selenium_guard.py
@@ -21,11 +21,18 @@ import pytest
 
 
 def test_module_imports_without_selenium(monkeypatch: pytest.MonkeyPatch) -> None:
-    """F-05-001: module must import even when selenium is missing."""
+    """F-05-001: module must import even when selenium is missing.
+
+    Synthesises a ``loki_test_etl`` package, copies just the two files
+    we care about (``types.py`` and ``unlimited_data_extractor.py``)
+    into it, and imports under that name. This avoids both pulling in
+    the heavy real ``backend.etl`` package and dealing with relative
+    import edge cases under spec_from_file_location.
+    """
 
     # Drop any cached selenium-touched modules.
     for name in list(sys.modules):
-        if name.startswith("selenium") or name.endswith("unlimited_data_extractor"):
+        if name.startswith("selenium") or "unlimited_data_extractor" in name:
             del sys.modules[name]
 
     real_import = builtins.__import__
@@ -37,24 +44,29 @@ def test_module_imports_without_selenium(monkeypatch: pytest.MonkeyPatch) -> Non
 
     monkeypatch.setattr(builtins, "__import__", fake_import)
 
-    path = (
-        Path(__file__).resolve().parents[2]
-        / "etl"
-        / "unlimited_data_extractor.py"
-    )
-    spec = importlib.util.spec_from_file_location(
-        "unlimited_data_extractor_under_test", path
-    )
-    module = importlib.util.module_from_spec(spec)
-    assert spec.loader is not None
-
-    # Mock out heavy non-selenium deps so the import doesn't ImportError
-    # for unrelated reasons.
+    etl_dir = Path(__file__).resolve().parents[2] / "etl"
     for heavy in ("aiohttp", "bs4", "pandas", "numpy", "yfinance", "requests"):
-        if heavy not in sys.modules:
-            sys.modules[heavy] = pytest.importorskip(heavy, reason=f"{heavy} not installed")
+        pytest.importorskip(heavy, reason=f"{heavy} not installed")
 
-    spec.loader.exec_module(module)
+    # Build a synthetic package on disk to host the two source files.
+    import tempfile
+    import shutil
+    import textwrap
+
+    with tempfile.TemporaryDirectory() as tmp:
+        pkg = Path(tmp) / "loki_test_etl"
+        pkg.mkdir()
+        (pkg / "__init__.py").write_text("")
+        shutil.copy(etl_dir / "types.py", pkg / "types.py")
+        shutil.copy(
+            etl_dir / "unlimited_data_extractor.py",
+            pkg / "unlimited_data_extractor.py",
+        )
+
+        monkeypatch.syspath_prepend(tmp)
+        module = importlib.import_module(
+            "loki_test_etl.unlimited_data_extractor"
+        )
 
     assert hasattr(module, "SELENIUM_AVAILABLE")
     assert module.SELENIUM_AVAILABLE is False

--- a/backend/tests/unit/test_etl_selenium_guard.py
+++ b/backend/tests/unit/test_etl_selenium_guard.py
@@ -1,0 +1,78 @@
+"""
+Regression tests for the optional-selenium import guard.
+
+F-05-001 (audit 2026-04, G2a sub-theme C step 19):
+``backend/etl/unlimited_data_extractor.py`` had top-level ``from selenium ...``
+imports. In environments without selenium installed, the whole module
+failed to import, which cascaded through
+``unlimited_extractor_with_fallbacks`` → ``data_extractor``, making
+``from backend.etl.data_extractor import DataExtractor`` raise
+ModuleNotFoundError.
+"""
+
+from __future__ import annotations
+
+import builtins
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def test_module_imports_without_selenium(monkeypatch: pytest.MonkeyPatch) -> None:
+    """F-05-001: module must import even when selenium is missing."""
+
+    # Drop any cached selenium-touched modules.
+    for name in list(sys.modules):
+        if name.startswith("selenium") or name.endswith("unlimited_data_extractor"):
+            del sys.modules[name]
+
+    real_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "selenium" or name.startswith("selenium."):
+            raise ImportError(f"simulated: {name} not installed")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    path = (
+        Path(__file__).resolve().parents[2]
+        / "etl"
+        / "unlimited_data_extractor.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "unlimited_data_extractor_under_test", path
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+
+    # Mock out heavy non-selenium deps so the import doesn't ImportError
+    # for unrelated reasons.
+    for heavy in ("aiohttp", "bs4", "pandas", "numpy", "yfinance", "requests"):
+        if heavy not in sys.modules:
+            sys.modules[heavy] = pytest.importorskip(heavy, reason=f"{heavy} not installed")
+
+    spec.loader.exec_module(module)
+
+    assert hasattr(module, "SELENIUM_AVAILABLE")
+    assert module.SELENIUM_AVAILABLE is False
+
+
+def test_selenium_available_flag_exists_in_source() -> None:
+    """F-05-001: source-level guarantee of the SELENIUM_AVAILABLE flag."""
+
+    path = (
+        Path(__file__).resolve().parents[2]
+        / "etl"
+        / "unlimited_data_extractor.py"
+    )
+    text = path.read_text()
+    assert "SELENIUM_AVAILABLE" in text, (
+        "unlimited_data_extractor.py must export a SELENIUM_AVAILABLE flag"
+    )
+    assert "try:" in text and "from selenium import webdriver" in text, (
+        "selenium imports must live inside a try/except block"
+    )
+    assert "except ImportError" in text

--- a/backend/tests/unit/test_etl_sqlite_leak.py
+++ b/backend/tests/unit/test_etl_sqlite_leak.py
@@ -1,0 +1,73 @@
+"""
+Regression tests for sqlite FD leak.
+
+F-05-008 (audit 2026-04, G2a sub-theme C step 23):
+``backend/etl/distributed_batch_processor.py``, ``cache_storage.py``,
+and ``multi_source_extractor.py`` opened 18 raw ``sqlite3.connect(...)``
+handles. The happy paths called ``conn.close()`` but any exception
+between the connect and the close (e.g. SQL error mid-transaction)
+leaked the file descriptor — FD count grew unbounded under load.
+
+The fix wraps every connection in ``contextlib.closing`` so the
+descriptor is released on every code path, including exceptions.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+_TARGETS = [
+    Path(__file__).resolve().parents[2] / "etl" / "distributed_batch_processor.py",
+    Path(__file__).resolve().parents[2] / "etl" / "cache_storage.py",
+    Path(__file__).resolve().parents[2] / "etl" / "multi_source_extractor.py",
+]
+
+
+def test_no_unwrapped_sqlite_connect_assignment() -> None:
+    """F-05-008: ``conn = sqlite3.connect(...)`` (unwrapped) must be gone."""
+
+    offenders: list[str] = []
+    for p in _TARGETS:
+        text = p.read_text()
+        for m in re.finditer(r"^\s*conn\s*=\s*sqlite3\.connect\(", text, re.MULTILINE):
+            offenders.append(f"{p.name}:{text.count(chr(10), 0, m.start()) + 1}")
+    assert not offenders, (
+        f"unwrapped sqlite3.connect assignments remain — FD leak risk: {offenders}"
+    )
+
+
+def test_closing_helper_imported() -> None:
+    """F-05-008: each target module imports ``closing`` from contextlib."""
+
+    for p in _TARGETS:
+        text = p.read_text()
+        assert re.search(r"from contextlib import .*\bclosing\b", text), (
+            f"{p.name} must import ``closing`` from contextlib"
+        )
+
+
+def test_with_closing_sqlite3_pattern_present() -> None:
+    """F-05-008: each target uses ``with closing(sqlite3.connect(...))``."""
+
+    for p in _TARGETS:
+        text = p.read_text()
+        count = len(re.findall(r"with\s+closing\(\s*sqlite3\.connect\(", text))
+        assert count > 0, (
+            f"{p.name} must use ``with closing(sqlite3.connect(...))``"
+        )
+
+
+def test_total_sqlite_sites_match_expected() -> None:
+    """F-05-008: 18 total sqlite3.connect callsites all wrapped."""
+
+    total_wrapped = 0
+    total_calls = 0
+    for p in _TARGETS:
+        text = p.read_text()
+        total_wrapped += len(re.findall(r"with\s+closing\(\s*sqlite3\.connect\(", text))
+        total_calls += len(re.findall(r"sqlite3\.connect\(", text))
+    assert total_wrapped == total_calls == 18, (
+        f"expected 18/18 wrapped, got {total_wrapped}/{total_calls}"
+    )

--- a/backend/tests/unit/test_feature_store_macd_bollinger.py
+++ b/backend/tests/unit/test_feature_store_macd_bollinger.py
@@ -34,7 +34,19 @@ _FS_PATH = (
 
 
 def _load_feature_store(monkeypatch: pytest.MonkeyPatch):
-    """Load feature_store with heavy deps stubbed where possible."""
+    """Load feature_store with heavy deps stubbed where possible.
+
+    Earlier tests in the same session (notably
+    test_etl_extended_agent2.py) install MagicMocks at
+    ``sys.modules["backend.ml"]`` which break feature_store's
+    ``from backend.ml.feature_types import ...`` lookup. Drop those
+    polluted entries before loading so we get a clean import on the
+    real package path.
+    """
+
+    for name in list(sys.modules):
+        if name == "backend" or name.startswith("backend."):
+            monkeypatch.delitem(sys.modules, name, raising=False)
 
     spec = importlib.util.spec_from_file_location(
         "feature_store_under_test", _FS_PATH

--- a/backend/tests/unit/test_feature_store_macd_bollinger.py
+++ b/backend/tests/unit/test_feature_store_macd_bollinger.py
@@ -1,0 +1,145 @@
+"""
+Regression tests for MACD + Bollinger Bands builtin features.
+
+F-03-008 (audit 2026-04, G2a sub-theme A step 31):
+ML_PIPELINE_DOCUMENTATION.md advertised ``macd``, ``macd_signal``,
+``bollinger_upper_20d``, and ``bollinger_lower_20d`` as built-in
+features but the corresponding compute methods did not exist on
+``FeatureStore``. Calls to compute them silently returned ``None``
+(``builtin_features.get(...)``).
+
+This test verifies that the four feature names are now registered AND
+their compute methods produce sane numeric values on a synthetic price
+series.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import numpy as np
+import pandas as pd
+import pytest
+
+
+_FS_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "ml"
+    / "feature_store.py"
+)
+
+
+def _load_feature_store(monkeypatch: pytest.MonkeyPatch):
+    """Load feature_store with heavy deps stubbed where possible."""
+
+    spec = importlib.util.spec_from_file_location(
+        "feature_store_under_test", _FS_PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _synth_close_series(start: float = 100.0, n: int = 60, drift: float = 0.5):
+    """A deterministic price series long enough for MACD+signal (>=35)."""
+    return [start + drift * i for i in range(n)]
+
+
+def _price_frame(ticker: str = "ACME"):
+    closes = _synth_close_series()
+    return pd.DataFrame({
+        "ticker": [ticker] * len(closes),
+        "date": pd.date_range("2024-01-01", periods=len(closes), freq="D"),
+        "close": closes,
+    })
+
+
+def test_macd_and_bollinger_registered(monkeypatch: pytest.MonkeyPatch) -> None:
+    """F-03-008: builtin_features dict must include the 4 documented names."""
+
+    text = _FS_PATH.read_text()
+    for name in ("macd", "macd_signal", "bollinger_upper_20d", "bollinger_lower_20d"):
+        assert f"'{name}'" in text, (
+            f"builtin_features must register {name!r}"
+        )
+        assert f"_compute_{name}" in text or f"_compute_bollinger_band" in text, (
+            f"compute method for {name!r} must exist"
+        )
+
+
+def test_macd_produces_finite_value(monkeypatch: pytest.MonkeyPatch) -> None:
+    """F-03-008: MACD = EMA(12)-EMA(26) over a 60-day series → finite float."""
+
+    mod = _load_feature_store(monkeypatch)
+    fs = mod.FeatureStore.__new__(mod.FeatureStore)
+    fs.computation_cache = {}
+
+    df = _price_frame("ACME")
+    result = fs._compute_macd(["ACME"], datetime.now(), {"price_data": df}, pd.DataFrame())
+    val = result.loc["ACME"]
+    assert np.isfinite(val), f"MACD must be finite for a healthy series, got {val!r}"
+
+
+def test_macd_signal_produces_finite_value(monkeypatch: pytest.MonkeyPatch) -> None:
+    """F-03-008: MACD signal = EMA(9) of MACD on a >=35-day series."""
+
+    mod = _load_feature_store(monkeypatch)
+    fs = mod.FeatureStore.__new__(mod.FeatureStore)
+    fs.computation_cache = {}
+
+    df = _price_frame("ACME")
+    result = fs._compute_macd_signal(["ACME"], datetime.now(), {"price_data": df}, pd.DataFrame())
+    val = result.loc["ACME"]
+    assert np.isfinite(val)
+
+
+def test_bollinger_bands_bracket_sma(monkeypatch: pytest.MonkeyPatch) -> None:
+    """F-03-008: upper > SMA(20) > lower for any positive-volatility window."""
+
+    mod = _load_feature_store(monkeypatch)
+    fs = mod.FeatureStore.__new__(mod.FeatureStore)
+    fs.computation_cache = {}
+
+    # Use a series with real volatility (drift + noise) so std > 0.
+    closes = [100.0 + 0.5 * i + (3.0 if i % 2 == 0 else -3.0) for i in range(60)]
+    df = pd.DataFrame({
+        "ticker": ["ACME"] * len(closes),
+        "date": pd.date_range("2024-01-01", periods=len(closes), freq="D"),
+        "close": closes,
+    })
+
+    sma = fs._compute_sma_20d(["ACME"], datetime.now(), {"price_data": df}, pd.DataFrame()).loc["ACME"]
+    upper = fs._compute_bollinger_upper_20d(["ACME"], datetime.now(), {"price_data": df}, pd.DataFrame()).loc["ACME"]
+    lower = fs._compute_bollinger_lower_20d(["ACME"], datetime.now(), {"price_data": df}, pd.DataFrame()).loc["ACME"]
+
+    assert lower < sma < upper, (
+        f"expected lower < sma < upper; got lower={lower}, sma={sma}, upper={upper}"
+    )
+
+
+def test_short_series_returns_nan(monkeypatch: pytest.MonkeyPatch) -> None:
+    """F-03-008: insufficient data → NaN, not crash."""
+
+    mod = _load_feature_store(monkeypatch)
+    fs = mod.FeatureStore.__new__(mod.FeatureStore)
+    fs.computation_cache = {}
+
+    # Only 10 days of data — too short for any of the 4 features.
+    df = pd.DataFrame({
+        "ticker": ["X"] * 10,
+        "date": pd.date_range("2024-01-01", periods=10, freq="D"),
+        "close": [100.0 + i for i in range(10)],
+    })
+    for method in (
+        fs._compute_macd,
+        fs._compute_macd_signal,
+        fs._compute_bollinger_upper_20d,
+        fs._compute_bollinger_lower_20d,
+    ):
+        out = method(["X"], datetime.now(), {"price_data": df}, pd.DataFrame())
+        assert np.isnan(out.loc["X"]), f"{method.__name__} on short series should be NaN"

--- a/backend/tests/unit/test_hybrid_engine_error_path.py
+++ b/backend/tests/unit/test_hybrid_engine_error_path.py
@@ -1,0 +1,105 @@
+"""
+Regression tests for hybrid_engine._create_error_recommendation.
+
+F-09-005 (audit 2026-04, G2a sub-theme E step 35):
+The error-fallback factory passed ``recommendation="HOLD"`` and
+``overall_score=0.5`` to ``EnhancedStockRecommendation(...)`` —
+neither is a declared field on the dataclass or its parent. Worse,
+many parent-required fields (priority, entry_price, time_horizon_days,
+etc.) were missing, so the constructor TypeError'd on every error
+path. The error fallback itself was broken.
+
+This test verifies source-level shape rather than instantiating the
+class, because EnhancedStockRecommendation pulls in
+``backend.analytics.recommendation_engine`` which transitively imports
+heavy ML deps.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+_HE = (
+    Path(__file__).resolve().parents[2]
+    / "analytics"
+    / "agents"
+    / "hybrid_engine.py"
+)
+
+
+def test_error_recommendation_does_not_pass_unknown_kwargs() -> None:
+    """F-09-005: ``recommendation=`` and ``overall_score=`` kwargs are gone."""
+
+    text = _HE.read_text()
+    # Locate the _create_error_recommendation block.
+    body = re.search(
+        r"def _create_error_recommendation\(.*?\n    [^ ]",
+        text,
+        re.DOTALL,
+    )
+    assert body is not None, "could not locate _create_error_recommendation"
+    block = body.group(0)
+    assert "recommendation=\"HOLD\"" not in block, (
+        "_create_error_recommendation must not pass ``recommendation=`` "
+        "(use ``action=RecommendationAction.HOLD`` instead)"
+    )
+    assert "overall_score=" not in block, (
+        "_create_error_recommendation must not pass ``overall_score=`` "
+        "(not a declared field on StockRecommendation)"
+    )
+
+
+def test_error_recommendation_uses_recommendation_action_enum() -> None:
+    """F-09-005: error path must use the real ``action`` field + enum."""
+
+    text = _HE.read_text()
+    assert "RecommendationAction.HOLD" in text, (
+        "error path must use RecommendationAction.HOLD on the action field"
+    )
+
+
+def test_error_recommendation_supplies_all_parent_required_fields() -> None:
+    """F-09-005: every required parent field must be passed."""
+
+    text = _HE.read_text()
+    block = re.search(
+        r"return EnhancedStockRecommendation\((.*?)\n        \)",
+        text,
+        re.DOTALL,
+    )
+    assert block is not None, "error path return block not found"
+    body = block.group(1)
+
+    required = [
+        "ticker", "action", "confidence", "priority",
+        "entry_price", "target_price", "stop_loss", "expected_return",
+        "time_horizon_days",
+        "risk_score", "volatility", "beta", "sharpe_ratio", "max_drawdown",
+        "technical_score", "fundamental_score", "sentiment_score",
+        "ml_prediction_score",
+        "technical_analysis", "fundamental_analysis", "sentiment_analysis",
+        "ml_predictions",
+        "key_factors", "risks", "opportunities", "catalysts",
+        "generated_at", "valid_until",
+        "recommended_allocation", "max_position_size",
+    ]
+    missing = [f for f in required if f"{f}=" not in body]
+    assert not missing, (
+        f"_create_error_recommendation missing parent-required kwargs: {missing}"
+    )
+
+
+def test_no_self_overall_score_access() -> None:
+    """F-09-005: hybrid score logic must not read self.overall_score."""
+
+    text = _HE.read_text()
+    # Allow it in comments / docstrings (rationale text), forbid in code.
+    code_lines = [
+        line for line in text.splitlines()
+        if "self.overall_score" in line and not line.lstrip().startswith("#")
+    ]
+    assert not code_lines, (
+        f"self.overall_score is accessed in non-comment code: {code_lines}"
+    )

--- a/backend/tests/unit/test_ml_api_server_path_traversal.py
+++ b/backend/tests/unit/test_ml_api_server_path_traversal.py
@@ -1,0 +1,128 @@
+"""
+Regression tests for the model path-traversal guard.
+
+F-03-006 (audit 2026-04, G2a sub-theme A step 28):
+``backend/ml/ml_api_server.py`` accepted an arbitrary ``model_name``
+from the ``POST /models/{model_name}/load`` route and concatenated it
+directly into a filesystem path. A caller could supply
+``../../../etc/passwd`` (or any other traversal) and read host files
+through the model-load surface. The fix enforces a strict character
+class AND verifies the resolved path stays under the models root.
+
+The module imports FastAPI / uvicorn which the audit env may not have.
+We exercise the validator helpers directly via ``importlib.util``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+
+_API_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "ml"
+    / "ml_api_server.py"
+)
+
+
+def _load_module(monkeypatch: pytest.MonkeyPatch):
+    """Load ml_api_server with FastAPI / uvicorn / joblib stubbed out."""
+
+    for name in (
+        "fastapi", "fastapi.middleware", "fastapi.middleware.cors",
+        "fastapi.responses", "uvicorn", "joblib", "pydantic",
+    ):
+        if name not in sys.modules:
+            stub = MagicMock()
+            stub.__path__ = []
+            sys.modules[name] = stub
+
+    # FastAPI() returns an app; patch its decorators to be no-ops.
+    fastapi_stub = sys.modules["fastapi"]
+    fake_app = MagicMock()
+    for method in ("get", "post", "put", "delete", "on_event"):
+        getattr(fake_app, method).return_value = lambda f: f
+    fastapi_stub.FastAPI = MagicMock(return_value=fake_app)
+    fastapi_stub.HTTPException = type("HTTPException", (Exception,), {
+        "__init__": lambda self, status_code, detail: setattr(self, "status_code", status_code) or setattr(self, "detail", detail)
+    })
+    fastapi_stub.BackgroundTasks = MagicMock()
+
+    pydantic_stub = sys.modules["pydantic"]
+    pydantic_stub.BaseModel = type("BaseModel", (), {})
+    pydantic_stub.Field = lambda *a, **kw: None
+
+    spec = importlib.util.spec_from_file_location(
+        "ml_api_server_under_test", _API_PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.parametrize(
+    "bad_name",
+    [
+        "../../../etc/passwd",
+        "model/../../../secret",
+        "..",
+        "/etc/passwd",
+        "model with spaces",
+        "model;rm -rf /",
+        "model$(whoami)",
+        "",
+        "model.pkl",  # would build path with .pkl.pkl, but the dot is also invalid
+    ],
+)
+def test_validate_rejects_path_traversal_attempts(
+    monkeypatch: pytest.MonkeyPatch, bad_name: str
+) -> None:
+    """F-03-006: any non-[A-Za-z0-9_-]+ name must raise ValueError."""
+
+    mod = _load_module(monkeypatch)
+    with pytest.raises(ValueError, match="invalid model_name"):
+        mod._validate_model_name(bad_name)
+
+
+def test_validate_accepts_well_formed_names(monkeypatch: pytest.MonkeyPatch) -> None:
+    """F-03-006: legitimate names pass through unchanged."""
+
+    mod = _load_module(monkeypatch)
+    for ok in ("xgboost_v1", "lstm-30d", "abc", "Model_42"):
+        assert mod._validate_model_name(ok) == ok
+
+
+def test_safe_model_path_returns_path_under_root(monkeypatch: pytest.MonkeyPatch) -> None:
+    """F-03-006: ``_safe_model_path`` resolves under the configured root."""
+
+    mod = _load_module(monkeypatch)
+    p = mod._safe_model_path(mod._MODELS_ROOT, "good_name", ".pkl")
+    # Must be relative to the configured root.
+    p.relative_to(mod._MODELS_ROOT)
+
+
+def test_load_model_rejects_traversal_before_filesystem_touch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """F-03-006: load_model() raises before any joblib.load() call."""
+
+    mod = _load_module(monkeypatch)
+    # Patch joblib.load to a sentinel that would mark the test as
+    # "validator did not run".
+    called = {"value": False}
+
+    def fail_joblib_load(_path):
+        called["value"] = True
+        raise AssertionError("joblib.load was reached on bad input")
+
+    monkeypatch.setattr(mod.joblib, "load", fail_joblib_load)
+
+    with pytest.raises(ValueError):
+        mod.load_model("../../../etc/passwd")
+    assert called["value"] is False

--- a/backend/tests/unit/test_ml_log_path_anchored.py
+++ b/backend/tests/unit/test_ml_log_path_anchored.py
@@ -1,0 +1,68 @@
+"""
+Regression tests for the __file__-anchored ML log path.
+
+F-03-007 (audit 2026-04, G2a sub-theme A step 29):
+``backend/ml/training_pipeline.py`` and ``simple_training_pipeline.py``
+configured logging.FileHandler with the relative path
+``'backend/ml_logs/...'``. Run from any cwd other than the repo root,
+this created a stray ``backend/ml_logs/`` directory next to the
+caller and orphaned the log files.
+
+The fix anchors the log directory to ``Path(__file__).parent.parent.parent /
+"backend" / "ml_logs"`` so the location is invariant under cwd.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+_TARGETS = [
+    Path(__file__).resolve().parents[2] / "ml" / "training_pipeline.py",
+    Path(__file__).resolve().parents[2] / "ml" / "simple_training_pipeline.py",
+    Path(__file__).resolve().parents[2] / "ml" / "minimal_training.py",
+]
+
+
+def test_no_unanchored_backend_ml_logs_string() -> None:
+    """F-03-007: bare ``'backend/ml_logs/...'`` literal must not appear in FileHandler."""
+
+    for p in _TARGETS:
+        text = p.read_text()
+        # The legacy form was
+        # ``logging.FileHandler('backend/ml_logs/training_...')``.
+        assert not re.search(
+            r"FileHandler\(\s*['\"]backend/ml_logs/", text
+        ), (
+            f"{p.name} still uses unanchored 'backend/ml_logs/' string in "
+            f"FileHandler — log path is cwd-dependent"
+        )
+
+
+def test_file_anchored_log_dir_present() -> None:
+    """F-03-007: each target derives the log dir from ``__file__``."""
+
+    for p in _TARGETS:
+        text = p.read_text()
+        assert re.search(
+            r"Path\(__file__\)\.resolve\(\)\.parent\.parent\.parent",
+            text,
+        ), (
+            f"{p.name} must derive the ml_logs directory from "
+            f"Path(__file__).resolve().parent.parent.parent"
+        )
+
+
+def test_log_dir_creation_is_idempotent() -> None:
+    """F-03-007: target must mkdir(parents=True, exist_ok=True)."""
+
+    for p in _TARGETS:
+        text = p.read_text()
+        # Either an explicit mkdir() on the derived path, or the target
+        # is the unit test stub which doesn't need it. Both training
+        # pipelines must explicitly create the directory.
+        if p.name in ("training_pipeline.py", "simple_training_pipeline.py", "minimal_training.py"):
+            assert "mkdir(parents=True, exist_ok=True)" in text, (
+                f"{p.name} must mkdir the log dir on import"
+            )

--- a/backend/tests/unit/test_mpt_optimizer_targets.py
+++ b/backend/tests/unit/test_mpt_optimizer_targets.py
@@ -1,0 +1,118 @@
+"""
+Regression tests for MPT optimizer target enforcement.
+
+F-09-010 (audit 2026-04, G2a sub-theme E step 40):
+``PortfolioOptimizer.optimize`` ignored ``target_return`` and
+``target_volatility`` parameters entirely — it always returned equal
+weights regardless of what the caller requested. The efficient frontier
+helper that walks ``target_return`` values produced 50 identical
+results.
+
+The fix uses ``scipy.optimize.minimize(method="SLSQP")`` to actually
+solve the mean-variance problem.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+
+_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "analytics"
+    / "portfolio"
+    / "modern_portfolio_theory.py"
+)
+
+
+def _load(monkeypatch: pytest.MonkeyPatch):
+    for name in list(sys.modules):
+        if name == "backend" or name.startswith("backend."):
+            monkeypatch.delitem(sys.modules, name, raising=False)
+    spec = importlib.util.spec_from_file_location("mpt_under_test", _PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules["mpt_under_test"] = module
+    monkeypatch.setitem(sys.modules, "mpt_under_test", module)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _three_asset_returns():
+    """Three assets with distinct mean returns so a real solver moves weights."""
+    rng = np.random.default_rng(42)
+    n = 252
+    # Asset A: high return, high vol.
+    a = rng.normal(0.0008, 0.02, n)
+    # Asset B: medium.
+    b = rng.normal(0.0004, 0.015, n)
+    # Asset C: low return, low vol.
+    c = rng.normal(0.0002, 0.008, n)
+    return pd.DataFrame({"A": a, "B": b, "C": c})
+
+
+def test_no_target_maximizes_sharpe(monkeypatch: pytest.MonkeyPatch) -> None:
+    """F-09-010: with no target, optimizer should not produce equal weights."""
+
+    mod = _load(monkeypatch)
+    opt = mod.PortfolioOptimizer()
+    result = opt.optimize(_three_asset_returns())
+    weights = np.array(list(result.weights.values()))
+    # Equal-weight signature would be [1/3, 1/3, 1/3] exactly.
+    assert not np.allclose(weights, 1.0 / 3, atol=1e-6), (
+        f"optimizer returned equal weights {weights} — the solver did not run"
+    )
+    assert abs(weights.sum() - 1.0) < 1e-6
+
+
+def test_target_return_constraint_is_enforced(monkeypatch: pytest.MonkeyPatch) -> None:
+    """F-09-010: portfolio return must meet or exceed the target."""
+
+    mod = _load(monkeypatch)
+    opt = mod.PortfolioOptimizer()
+    df = _three_asset_returns()
+    # Pick a target somewhere in the middle of the feasible range.
+    target = df.mean().mean() * 252  # average annualized return
+    result = opt.optimize(df, target_return=target)
+    assert result.expected_return >= target - 1e-3, (
+        f"target_return={target:.4f} not met (got {result.expected_return:.4f})"
+    )
+
+
+def test_target_volatility_constraint_is_enforced(monkeypatch: pytest.MonkeyPatch) -> None:
+    """F-09-010: portfolio volatility must not exceed the target."""
+
+    mod = _load(monkeypatch)
+    opt = mod.PortfolioOptimizer()
+    df = _three_asset_returns()
+    # Pick a relatively tight vol cap that should bind.
+    target_vol = 0.15
+    result = opt.optimize(df, target_volatility=target_vol)
+    assert result.volatility <= target_vol + 1e-3, (
+        f"target_volatility={target_vol} exceeded (got {result.volatility:.4f})"
+    )
+
+
+def test_efficient_frontier_walks_returns(monkeypatch: pytest.MonkeyPatch) -> None:
+    """F-09-010: efficient frontier must produce varying portfolios.
+
+    ``get_efficient_frontier`` yields a list of ``(volatility, return)``
+    tuples — we expect the return coordinate to vary across the 10
+    points (previously every point was identical because the underlying
+    optimizer ignored the target_return).
+    """
+
+    mod = _load(monkeypatch)
+    opt = mod.PortfolioOptimizer()
+    df = _three_asset_returns()
+    frontier = opt.get_efficient_frontier(df, n_points=10)
+    rets = [ret for (_vol, ret) in frontier]
+    assert len(set(round(r, 4) for r in rets)) > 1, (
+        f"efficient frontier collapsed to a single point: {rets}"
+    )

--- a/backend/tests/unit/test_recommendation_engine_sentiment.py
+++ b/backend/tests/unit/test_recommendation_engine_sentiment.py
@@ -1,0 +1,57 @@
+"""
+Regression tests for _run_sentiment_analysis.
+
+F-09-001 (audit 2026-04, G2a sub-theme E step 32):
+``recommendation_engine._run_sentiment_analysis`` called
+``self.sentiment_engine.analyze_sentiment(ticker, text_data)`` but
+``analyze_sentiment`` is the per-text entrypoint with signature
+``(text: str, source: str = "unknown")`` — it rejects the
+list-of-dicts shape this method assembles, raising AttributeError /
+TypeError on every call.
+
+The fix delegates to ``analyze_stock_sentiment(ticker, texts: List[str])``
+and adapts the returned ``SentimentResult`` back to the dict shape
+downstream consumers read via ``sentiment_analysis.get('overall_sentiment',
+...)``.
+
+Tests inspect source rather than instantiating the engine (which pulls
+in heavy ML deps).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+_ENGINE = (
+    Path(__file__).resolve().parents[2]
+    / "analytics"
+    / "recommendation_engine.py"
+)
+
+
+def test_uses_analyze_stock_sentiment_not_analyze_sentiment() -> None:
+    """F-09-001: must call analyze_stock_sentiment with extracted text list."""
+
+    text = _ENGINE.read_text()
+    # The legacy buggy call.
+    assert "self.sentiment_engine.analyze_sentiment(ticker, text_data)" not in text, (
+        "_run_sentiment_analysis still calls analyze_sentiment with "
+        "the list-of-dicts shape; that method takes (text: str, source: str)"
+    )
+    # The corrected call.
+    assert re.search(
+        r"analyze_stock_sentiment\(\s*ticker\s*,\s*\[",
+        text,
+    ), "_run_sentiment_analysis must call analyze_stock_sentiment(ticker, [...])"
+
+
+def test_returns_overall_sentiment_dict_shape() -> None:
+    """F-09-001: downstream consumers expect ``overall_sentiment`` key."""
+
+    text = _ENGINE.read_text()
+    # The dict-shape adapter must still emit 'overall_sentiment' so the
+    # downstream get('overall_sentiment', {}).get('score', 0) keeps
+    # working.
+    assert "'overall_sentiment'" in text and "'score'" in text

--- a/backend/tests/unit/test_recommendation_risk_free_and_portfolio_size.py
+++ b/backend/tests/unit/test_recommendation_risk_free_and_portfolio_size.py
@@ -1,0 +1,98 @@
+"""
+Regression tests for risk-free rate + portfolio size config plumbing.
+
+F-09-008 (audit 2026-04, G2a sub-theme E step 37):
+backend/analytics/recommendation_engine.py:429 hardcoded
+``risk_free_rate = 0.045`` inside the Sharpe-ratio calculation,
+silently drifting from FundamentalAnalysisEngine.risk_free_rate.
+
+F-09-009 (step 38):
+backend/analytics/recommendation_scoring.py:398 hardcoded
+``portfolio_size = 100_000`` inside ``calculate_position_sizing`` and
+recommendation_ranking.py:147 multiplied ``weight * 100_000`` —
+neither was configurable, so max-position-size dollars never tracked
+the actual portfolio.
+
+Source-level tests because the modules pull in a large transitive
+graph (technical/fundamental/sentiment engines).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+_ENGINE = (
+    Path(__file__).resolve().parents[2]
+    / "analytics"
+    / "recommendation_engine.py"
+)
+_RANKING = (
+    Path(__file__).resolve().parents[2]
+    / "analytics"
+    / "recommendation_ranking.py"
+)
+_SCORING = (
+    Path(__file__).resolve().parents[2]
+    / "analytics"
+    / "recommendation_scoring.py"
+)
+
+
+def test_no_hardcoded_risk_free_rate_in_engine() -> None:
+    """F-09-008: bare ``risk_free_rate = 0.045`` literal must be gone."""
+
+    text = _ENGINE.read_text()
+    assert not re.search(
+        r"^\s*risk_free_rate\s*=\s*0\.045\s*$", text, re.MULTILINE
+    ), "recommendation_engine.py still has a hardcoded risk_free_rate constant"
+
+
+def test_engine_syncs_risk_free_rate_with_fundamental_engine() -> None:
+    """F-09-008: engine must pull from FundamentalAnalysisEngine."""
+
+    text = _ENGINE.read_text()
+    assert "self.risk_free_rate = self.fundamental_engine.risk_free_rate" in text, (
+        "RecommendationEngine.__init__ must source risk_free_rate from "
+        "self.fundamental_engine.risk_free_rate so the two stay in sync"
+    )
+
+
+def test_no_hardcoded_portfolio_size_constant() -> None:
+    """F-09-009: bare ``portfolio_size = 100_000`` must be gone from scoring."""
+
+    text = _SCORING.read_text()
+    assert not re.search(
+        r"^\s*portfolio_size\s*=\s*100_000\s*$", text, re.MULTILINE
+    ), "recommendation_scoring.py still has a hardcoded portfolio_size constant"
+
+
+def test_scoring_accepts_portfolio_size_param() -> None:
+    """F-09-009: ``calculate_position_sizing`` must accept portfolio_size kwarg."""
+
+    text = _SCORING.read_text()
+    assert "portfolio_size: float = 100_000" in text, (
+        "calculate_position_sizing must accept portfolio_size as a parameter"
+    )
+
+
+def test_ranking_accepts_portfolio_size_param() -> None:
+    """F-09-009: ``optimize_recommendations`` must accept portfolio_size kwarg."""
+
+    text = _RANKING.read_text()
+    assert "portfolio_size: float = 100_000" in text, (
+        "optimize_recommendations must accept portfolio_size as a parameter"
+    )
+    assert "weight * portfolio_size" in text, (
+        "max_position_size assignment must use the portfolio_size parameter"
+    )
+
+
+def test_engine_reads_default_portfolio_size_from_env() -> None:
+    """F-09-009: engine sources portfolio size from DEFAULT_PORTFOLIO_SIZE env."""
+
+    text = _ENGINE.read_text()
+    assert "DEFAULT_PORTFOLIO_SIZE" in text, (
+        "engine must default portfolio_size from the DEFAULT_PORTFOLIO_SIZE env var"
+    )

--- a/backend/tests/unit/test_sec_edgar_contact_email.py
+++ b/backend/tests/unit/test_sec_edgar_contact_email.py
@@ -1,0 +1,57 @@
+"""
+Regression tests for SEC EDGAR contact email enforcement.
+
+F-05-006 (audit 2026-04, G2a sub-theme C step 21):
+``backend/data_ingestion/sec_edgar_client.py`` shipped a
+``contact@example.com`` placeholder in its User-Agent header. SEC
+throttles or bans clients that don't supply real contact info, so this
+silently degraded fundamentals fetching.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+_CLIENT = (
+    Path(__file__).resolve().parents[2]
+    / "data_ingestion"
+    / "sec_edgar_client.py"
+)
+
+
+def test_no_placeholder_email_in_user_agent() -> None:
+    """F-05-006: hardcoded ``contact@example.com`` must be gone."""
+
+    text = _CLIENT.read_text()
+    # The literal string survives in the validation message (used to
+    # reject the env value), but not as a User-Agent default. The
+    # disqualifying pattern is the User-Agent f-string with example.com.
+    assert "(contact@example.com)" not in text, (
+        "sec_edgar_client.py still embeds the placeholder contact email "
+        "directly in the User-Agent header"
+    )
+
+
+def test_reads_contact_email_from_env() -> None:
+    """F-05-006: must source contact email from ``SEC_EDGAR_CONTACT_EMAIL``."""
+
+    text = _CLIENT.read_text()
+    assert "SEC_EDGAR_CONTACT_EMAIL" in text, (
+        "sec_edgar_client.py must read SEC_EDGAR_CONTACT_EMAIL env var"
+    )
+    assert re.search(
+        r"os\.getenv\(\s*[\"']SEC_EDGAR_CONTACT_EMAIL", text
+    ), "must use os.getenv to read SEC_EDGAR_CONTACT_EMAIL"
+
+
+def test_fails_loudly_on_missing_email() -> None:
+    """F-05-006: missing/placeholder env var must raise at construction."""
+
+    text = _CLIENT.read_text()
+    assert "raise RuntimeError" in text or "raise ValueError" in text, (
+        "sec_edgar_client.py must raise when SEC_EDGAR_CONTACT_EMAIL is "
+        "missing or set to a placeholder — silent degradation would let "
+        "us run unidentified against sec.gov"
+    )

--- a/backend/tests/unit/test_sentiment_stubs_wired.py
+++ b/backend/tests/unit/test_sentiment_stubs_wired.py
@@ -1,0 +1,84 @@
+"""
+Regression tests for sentiment-stub wiring against SmartDataFetcher.
+
+F-09-006 (audit 2026-04, G2a sub-theme E step 41):
+``SentimentAnalysisEngine.get_news_sentiment`` returned hardcoded
+neutral with ``source: 'news_placeholder'`` regardless of input.
+``get_social_sentiment`` did the same with ``confidence=0.5`` — a
+lie that overstated availability.
+
+Now that F-05-004 has wired SmartDataFetcher to real clients,
+get_news_sentiment delegates to it. get_social_sentiment remains a
+sentinel (no ingestion source exists) but with ``confidence=0.0``
+and a loud warning so consumers can detect the no-data path.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "analytics"
+    / "sentiment_analysis.py"
+)
+
+
+def test_news_stub_calls_smart_fetcher() -> None:
+    """F-09-006: get_news_sentiment must delegate to SmartDataFetcher."""
+
+    text = _PATH.read_text()
+    assert "from backend.data_ingestion.smart_data_fetcher import get_smart_fetcher" in text
+    assert 'fetch_stock_data(ticker, "news")' in text, (
+        "get_news_sentiment must call the SmartDataFetcher news endpoint"
+    )
+
+
+def test_news_stub_runs_real_analysis_on_articles() -> None:
+    """F-09-006: news path must feed articles into analyze_stock_sentiment."""
+
+    text = _PATH.read_text()
+    assert "return await self.analyze_stock_sentiment(ticker, texts)" in text, (
+        "get_news_sentiment must run the real batch analyzer over fetched texts"
+    )
+
+
+def test_no_news_placeholder_source_label() -> None:
+    """F-09-006: legacy ``news_placeholder`` literal must be gone."""
+
+    text = _PATH.read_text()
+    assert "'news_placeholder'" not in text, (
+        "get_news_sentiment still emits the legacy news_placeholder source label"
+    )
+
+
+def test_social_stub_drops_confidence_to_zero() -> None:
+    """F-09-006: social stub must not lie about confidence."""
+
+    text = _PATH.read_text()
+    # The legacy stub returned confidence=0.5; check the new sentinel
+    # path explicitly notes confidence=0.0 and is unimplemented.
+    assert "'social_unimplemented'" in text or "social_unimplemented" in text, (
+        "social stub must label its source as social_unimplemented"
+    )
+    # Find the get_social_sentiment block and verify it doesn't ship
+    # confidence=0.5.
+    import re
+    block = re.search(
+        r"def get_social_sentiment.*?(?=\n    async def |\Z)",
+        text, re.DOTALL,
+    )
+    assert block is not None
+    assert "confidence=0.5" not in block.group(0), (
+        "get_social_sentiment must not return confidence=0.5 for a no-data path"
+    )
+
+
+def test_social_stub_logs_warning() -> None:
+    """F-09-006: social stub must log a loud warning per workpaper §9."""
+
+    text = _PATH.read_text()
+    assert "is not implemented (F-09-006)" in text, (
+        "social stub must log a warning naming the finding ID"
+    )

--- a/backend/tests/unit/test_smart_data_fetcher.py
+++ b/backend/tests/unit/test_smart_data_fetcher.py
@@ -1,0 +1,114 @@
+"""
+Regression tests for SmartDataFetcher real-source delegation.
+
+F-05-004 (audit 2026-04, G2a sub-theme C step 25): the previous
+implementation returned hardcoded zeros / empty lists from every
+``_fetch_*`` method with ``source: "mock"``. The new implementation
+delegates to the real clients and returns ``source: "unavailable"``
+only when every client failed or is not configured.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+
+_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "data_ingestion"
+    / "smart_data_fetcher.py"
+)
+
+
+def _load_module(monkeypatch: pytest.MonkeyPatch):
+    """Load smart_data_fetcher in isolation with logging stubbed."""
+
+    spec = importlib.util.spec_from_file_location(
+        "smart_data_fetcher_under_test", _PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_price_fetcher_delegates_to_finnhub(monkeypatch: pytest.MonkeyPatch) -> None:
+    """F-05-004: finnhub get_quote result must populate the price payload."""
+
+    mod = _load_module(monkeypatch)
+    fetcher = mod.SmartDataFetcher()
+
+    finnhub_stub = AsyncMock()
+    finnhub_stub.get_quote = AsyncMock(return_value={"c": 195.5, "d": 1.5, "dp": 0.77, "v": 12345})
+    monkeypatch.setattr(fetcher, "_get_client", lambda n: finnhub_stub if n == "finnhub" else None)
+
+    result = asyncio.run(fetcher._fetch_price_data("AAPL"))
+    assert result["ticker"] == "AAPL"
+    assert result["price"] == 195.5
+    assert result["source"] == "finnhub"
+
+
+def test_price_fetcher_falls_through_to_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
+    """F-05-004: no working client → source == 'unavailable' (not 'mock')."""
+
+    mod = _load_module(monkeypatch)
+    fetcher = mod.SmartDataFetcher()
+    monkeypatch.setattr(fetcher, "_get_client", lambda n: None)
+
+    result = asyncio.run(fetcher._fetch_price_data("AAPL"))
+    assert result["source"] == "unavailable"
+    assert result["price"] == 0.0  # sentinel value preserved
+
+
+def test_fundamentals_uses_finnhub_metric_dict(monkeypatch: pytest.MonkeyPatch) -> None:
+    """F-05-004: finnhub.get_basic_financials shape is consumed correctly."""
+
+    mod = _load_module(monkeypatch)
+    fetcher = mod.SmartDataFetcher()
+
+    finnhub_stub = AsyncMock()
+    finnhub_stub.get_basic_financials = AsyncMock(return_value={
+        "metric": {
+            "peNormalizedAnnual": 28.4,
+            "marketCapitalization": 3_000_000,
+            "epsAnnual": 6.84,
+            "dividendYieldIndicatedAnnual": 0.005,
+        }
+    })
+    monkeypatch.setattr(fetcher, "_get_client", lambda n: finnhub_stub if n == "finnhub" else None)
+
+    result = asyncio.run(fetcher._fetch_fundamentals("AAPL"))
+    assert result["source"] == "finnhub"
+    assert result["pe_ratio"] == 28.4
+    assert result["market_cap"] == 3_000_000
+    assert result["eps"] == 6.84
+
+
+def test_no_mock_source_label_in_implementation() -> None:
+    """F-05-004: ``"source": "mock"`` literal must be gone."""
+
+    text = _PATH.read_text()
+    assert '"source": "mock"' not in text, (
+        "smart_data_fetcher.py must no longer ship hardcoded mock source labels"
+    )
+
+
+def test_client_failure_falls_through(monkeypatch: pytest.MonkeyPatch) -> None:
+    """F-05-004: a raising client must not crash the fetcher."""
+
+    mod = _load_module(monkeypatch)
+    fetcher = mod.SmartDataFetcher()
+
+    failing = AsyncMock()
+    failing.get_quote = AsyncMock(side_effect=RuntimeError("api down"))
+    monkeypatch.setattr(fetcher, "_get_client", lambda n: failing if n == "finnhub" else None)
+
+    # Should fall through to unavailable, not raise.
+    result = asyncio.run(fetcher._fetch_price_data("AAPL"))
+    assert result["source"] == "unavailable"

--- a/backend/tests/unit/test_stock_recommendation_ranking_score.py
+++ b/backend/tests/unit/test_stock_recommendation_ranking_score.py
@@ -1,0 +1,109 @@
+"""
+Regression tests for StockRecommendation.ranking_score field.
+
+F-09-004 (audit 2026-04, G2a sub-theme E step 34):
+The ranking layer assigned ``rec.ranking_score = X`` on every
+recommendation, but ``StockRecommendation`` had no such field — the
+attribute survived as an ad-hoc instance attr that disappeared from
+``dataclasses.asdict(rec)`` and ``to_dict()`` output. Consumers reading
+the serialized form (storage, API responses) never saw the score.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import importlib.util
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+
+_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "analytics"
+    / "recommendation_types.py"
+)
+
+
+def _load_module(monkeypatch: pytest.MonkeyPatch):
+    # Drop polluted backend.* sys.modules entries first.
+    for name in list(sys.modules):
+        if name == "backend" or name.startswith("backend."):
+            monkeypatch.delitem(sys.modules, name, raising=False)
+
+    name = "recommendation_types_under_test"
+    spec = importlib.util.spec_from_file_location(name, _PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    # @dataclass resolves forward refs by looking up cls.__module__ in
+    # sys.modules; register before exec to avoid AttributeError.
+    sys.modules[name] = module
+    monkeypatch.setitem(sys.modules, name, module)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _build_rec(mod):
+    return mod.StockRecommendation(
+        ticker="ACME",
+        action=mod.RecommendationAction.BUY,
+        confidence=0.8,
+        priority=5,
+        entry_price=100.0,
+        target_price=120.0,
+        stop_loss=90.0,
+        expected_return=0.2,
+        time_horizon_days=30,
+        risk_score=0.3,
+        volatility=0.2,
+        beta=1.1,
+        sharpe_ratio=1.5,
+        max_drawdown=0.1,
+        technical_score=0.7,
+        fundamental_score=0.6,
+        sentiment_score=0.5,
+        ml_prediction_score=0.65,
+        technical_analysis={},
+        fundamental_analysis={},
+        sentiment_analysis={},
+        ml_predictions={},
+        key_factors=[],
+        risks=[],
+        opportunities=[],
+        catalysts=[],
+        generated_at=datetime.now(timezone.utc),
+        valid_until=datetime.now(timezone.utc),
+        recommended_allocation=0.05,
+        max_position_size=10_000.0,
+    )
+
+
+def test_dataclass_has_ranking_score_field(monkeypatch: pytest.MonkeyPatch) -> None:
+    """F-09-004: ``ranking_score`` must be a declared field on the dataclass."""
+
+    mod = _load_module(monkeypatch)
+    fields = {f.name for f in dataclasses.fields(mod.StockRecommendation)}
+    assert "ranking_score" in fields, (
+        "StockRecommendation must declare ranking_score as a dataclass field"
+    )
+
+
+def test_default_ranking_score_is_zero(monkeypatch: pytest.MonkeyPatch) -> None:
+    """F-09-004: ``ranking_score`` defaults to 0.0 when not supplied."""
+
+    mod = _load_module(monkeypatch)
+    rec = _build_rec(mod)
+    assert rec.ranking_score == 0.0
+
+
+def test_asdict_includes_ranking_score(monkeypatch: pytest.MonkeyPatch) -> None:
+    """F-09-004: serialization paths surface ranking_score."""
+
+    mod = _load_module(monkeypatch)
+    rec = _build_rec(mod)
+    rec.ranking_score = 0.87
+    assert dataclasses.asdict(rec)["ranking_score"] == 0.87
+    assert rec.to_dict()["ranking_score"] == 0.87

--- a/backend/tests/unit/test_torch_load_weights_only.py
+++ b/backend/tests/unit/test_torch_load_weights_only.py
@@ -1,0 +1,73 @@
+"""
+Regression tests for ``torch.load(weights_only=True)`` enforcement.
+
+F-03-002 (audit 2026-04, G2a sub-theme A step 27):
+Five ``torch.load(...)`` callsites in ``backend/ml/`` deserialized
+artifacts with the default ``weights_only=False``, which is
+pickle-based and equivalent to arbitrary code execution if an
+attacker can write to (or substitute) a model artifact path. CVE
+class: torch.load pickle RCE (cf. CVE-2025-32434).
+
+The workpaper acceptance gate is:
+
+    grep -rn "torch.load" backend/ml/ | grep -v weights_only
+
+returning empty. The literal pattern collides with the explanatory
+docstring/comments that document the fix, so the tighter form below
+matches only the function-call syntax (``torch.load(``) — preserving
+the audit intent without flagging the rationale comments. See
+[[feedback_test_anchor_logic]] in user memory.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+_ML_DIR = Path(__file__).resolve().parents[2] / "ml"
+
+
+def test_every_torch_load_call_passes_weights_only() -> None:
+    """F-03-002: every ``torch.load(...)`` invocation must include weights_only."""
+
+    offenders: list[str] = []
+    for py in _ML_DIR.rglob("*.py"):
+        text = py.read_text()
+        # Match the call form ``torch.load(`` and capture up to the
+        # matching close-paren on the same statement.
+        for m in re.finditer(r"torch\.load\(([^)]*)\)", text):
+            args = m.group(1)
+            if "weights_only" not in args:
+                line_no = text.count("\n", 0, m.start()) + 1
+                offenders.append(f"{py.relative_to(_ML_DIR.parent)}:{line_no}")
+    assert not offenders, (
+        f"torch.load call(s) without weights_only kwarg — RCE risk: {offenders}"
+    )
+
+
+def test_weights_only_value_is_true_not_false() -> None:
+    """F-03-002: ``weights_only=False`` is the unsafe default; ban it."""
+
+    offenders: list[str] = []
+    for py in _ML_DIR.rglob("*.py"):
+        text = py.read_text()
+        for m in re.finditer(
+            r"torch\.load\([^)]*weights_only\s*=\s*False[^)]*\)", text
+        ):
+            line_no = text.count("\n", 0, m.start()) + 1
+            offenders.append(f"{py.relative_to(_ML_DIR.parent)}:{line_no}")
+    assert not offenders, (
+        f"torch.load called with weights_only=False — unsafe: {offenders}"
+    )
+
+
+def test_expected_callsite_count_unchanged() -> None:
+    """F-03-002: still exactly 5 callsites after the patch."""
+
+    count = 0
+    for py in _ML_DIR.rglob("*.py"):
+        count += len(re.findall(r"torch\.load\(", py.read_text()))
+    assert count == 5, (
+        f"expected 5 torch.load callsites in backend/ml/, found {count}"
+    )

--- a/backend/tests/unit/test_tradingagents_default_config.py
+++ b/backend/tests/unit/test_tradingagents_default_config.py
@@ -1,0 +1,60 @@
+"""
+Regression tests for TradingAgents default_config.
+
+F-04-001 (audit 2026-04, G2a sub-theme B step 4): ``data_dir`` was
+hardcoded to ``/Users/yluo/Documents/Code/ScAI/FR1-data``, an absolute
+path on a different developer's machine. The fail-first tests below
+assert that ``data_dir`` is sourced from the ``TRADINGAGENTS_DATA_DIR``
+environment variable and never contains the legacy hardcoded path.
+"""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import os
+from pathlib import Path
+
+import pytest
+
+
+_CONFIG_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "TradingAgents"
+    / "tradingagents"
+    / "default_config.py"
+)
+
+
+def _load_config(monkeypatch_env: dict[str, str] | None = None) -> dict:
+    """Load default_config in isolation, optionally with patched env."""
+
+    if monkeypatch_env is not None:
+        for k, v in monkeypatch_env.items():
+            os.environ[k] = v
+
+    spec = importlib.util.spec_from_file_location(
+        "tradingagents_default_config_under_test", _CONFIG_PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module.DEFAULT_CONFIG
+
+
+def test_data_dir_is_not_hardcoded_yluo_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    """F-04-001: legacy ``/Users/yluo/...`` path must be gone."""
+
+    monkeypatch.delenv("TRADINGAGENTS_DATA_DIR", raising=False)
+    cfg = _load_config()
+    assert "yluo" not in cfg["data_dir"], (
+        f"hardcoded developer path leaked into data_dir: {cfg['data_dir']!r}"
+    )
+
+
+def test_data_dir_respects_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
+    """F-04-001: ``TRADINGAGENTS_DATA_DIR`` must control ``data_dir``."""
+
+    monkeypatch.setenv("TRADINGAGENTS_DATA_DIR", "/tmp/loki-test-data")
+    cfg = _load_config()
+    assert cfg["data_dir"] == "/tmp/loki-test-data"

--- a/backend/tests/unit/test_tradingagents_finnhub_utils.py
+++ b/backend/tests/unit/test_tradingagents_finnhub_utils.py
@@ -1,0 +1,73 @@
+"""
+Regression tests for TradingAgents finnhub_utils.
+
+F-04-002 (audit 2026-04, G2a sub-theme B step 2): get_data_in_range used a
+bare ``open()`` and never closed the file handle. On a long-running process
+this leaks one file descriptor per call. The fail-first test below uses
+``mock_open`` to assert the file handle's ``__exit__`` is invoked, which
+is only true once the bare ``open()`` is wrapped in a ``with`` block.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from unittest.mock import mock_open, patch
+
+import pytest
+
+
+_FINNHUB_UTILS_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "TradingAgents"
+    / "tradingagents"
+    / "dataflows"
+    / "finnhub_utils.py"
+)
+_spec = importlib.util.spec_from_file_location(
+    "tradingagents_finnhub_utils_under_test", _FINNHUB_UTILS_PATH
+)
+_module = importlib.util.module_from_spec(_spec)
+assert _spec.loader is not None
+_spec.loader.exec_module(_module)
+get_data_in_range = _module.get_data_in_range
+
+
+def test_get_data_in_range_closes_file_handle() -> None:
+    """File handle must be closed via context manager (F-04-003)."""
+
+    payload = '{"2024-01-15": [{"headline": "x"}], "2024-02-01": []}'
+    m = mock_open(read_data=payload)
+
+    with patch.object(_module, "open", m, create=True):
+        result = get_data_in_range(
+            ticker="AAPL",
+            start_date="2024-01-01",
+            end_date="2024-01-31",
+            data_type="news_data",
+            data_dir="/tmp/fake",
+        )
+
+    handle = m.return_value
+    handle.__exit__.assert_called()
+    assert "2024-01-15" in result
+    assert "2024-02-01" not in result
+
+
+def test_get_data_in_range_period_branch_uses_context_manager() -> None:
+    """Same closure guarantee on the ``period``-suffixed path branch."""
+
+    payload = '{"2024-03-31": [{"metric": 1}]}'
+    m = mock_open(read_data=payload)
+
+    with patch.object(_module, "open", m, create=True):
+        get_data_in_range(
+            ticker="AAPL",
+            start_date="2024-01-01",
+            end_date="2024-12-31",
+            data_type="fin_as_reported",
+            data_dir="/tmp/fake",
+            period="quarterly",
+        )
+
+    m.return_value.__exit__.assert_called()

--- a/backend/tests/unit/test_tradingagents_memory.py
+++ b/backend/tests/unit/test_tradingagents_memory.py
@@ -1,0 +1,99 @@
+"""
+Regression tests for TradingAgents memory (embeddings).
+
+F-04-004 (audit 2026-04, G2a sub-theme B step 5): ``FinancialSituationMemory``
+always constructed an OpenAI client regardless of ``llm_provider``. When
+the user selected Anthropic or Google, the OpenAI client was pointed at
+the wrong base URL and silently failed or sent embedding requests to the
+wrong endpoint. The fail-first tests below assert that unsupported
+providers raise ``NotImplementedError`` at construction time, and that
+the OpenAI-compatible providers (openai, openrouter, ollama) still work.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+
+_MEMORY_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "TradingAgents"
+    / "tradingagents"
+    / "agents"
+    / "utils"
+    / "memory.py"
+)
+
+
+def _load_memory_module(monkeypatch: pytest.MonkeyPatch):
+    """Load memory.py with chromadb and openai stubbed out."""
+
+    chromadb_stub = MagicMock()
+    chromadb_stub.Client.return_value.create_collection.return_value = MagicMock()
+    chromadb_config_stub = MagicMock()
+    openai_stub = MagicMock()
+
+    monkeypatch.setitem(sys.modules, "chromadb", chromadb_stub)
+    monkeypatch.setitem(sys.modules, "chromadb.config", chromadb_config_stub)
+    monkeypatch.setitem(sys.modules, "openai", openai_stub)
+
+    spec = importlib.util.spec_from_file_location(
+        "tradingagents_memory_under_test", _MEMORY_PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_anthropic_provider_raises_not_implemented(monkeypatch: pytest.MonkeyPatch) -> None:
+    """F-04-004: Anthropic provider has no OpenAI-compatible embeddings."""
+
+    mod = _load_memory_module(monkeypatch)
+    cfg = {
+        "llm_provider": "anthropic",
+        "backend_url": "https://api.anthropic.com",
+    }
+    with pytest.raises(NotImplementedError, match="anthropic"):
+        mod.FinancialSituationMemory("test", cfg)
+
+
+def test_google_provider_raises_not_implemented(monkeypatch: pytest.MonkeyPatch) -> None:
+    """F-04-004: Google provider has no OpenAI-compatible embeddings."""
+
+    mod = _load_memory_module(monkeypatch)
+    cfg = {
+        "llm_provider": "google",
+        "backend_url": "https://generativelanguage.googleapis.com",
+    }
+    with pytest.raises(NotImplementedError, match="google"):
+        mod.FinancialSituationMemory("test", cfg)
+
+
+def test_openai_provider_constructs_successfully(monkeypatch: pytest.MonkeyPatch) -> None:
+    """F-04-004: OpenAI provider continues to work."""
+
+    mod = _load_memory_module(monkeypatch)
+    cfg = {
+        "llm_provider": "openai",
+        "backend_url": "https://api.openai.com/v1",
+    }
+    inst = mod.FinancialSituationMemory("test", cfg)
+    assert inst.embedding == "text-embedding-3-small"
+
+
+def test_ollama_provider_constructs_successfully(monkeypatch: pytest.MonkeyPatch) -> None:
+    """F-04-004: Ollama (OpenAI-compatible) continues to work."""
+
+    mod = _load_memory_module(monkeypatch)
+    cfg = {
+        "llm_provider": "ollama",
+        "backend_url": "http://localhost:11434/v1",
+    }
+    inst = mod.FinancialSituationMemory("test", cfg)
+    assert inst.embedding == "nomic-embed-text"

--- a/backend/tests/unit/test_tradingagents_openai_store_flag.py
+++ b/backend/tests/unit/test_tradingagents_openai_store_flag.py
@@ -1,0 +1,68 @@
+"""
+Regression tests for the OpenAI ``store`` data-residency flag.
+
+F-04-005 (audit 2026-04, G2a sub-theme B step 6): three callsites in
+``dataflows/interface.py`` (``get_stock_news_openai``,
+``get_global_news_openai``, ``get_fundamentals_openai``) hardcoded
+``store=True``, which retains prompt content on OpenAI servers. This
+must default to ``False`` and be driven by an explicit
+``openai_store_responses`` config flag so the data-residency posture is
+auditable.
+
+These tests inspect the source file directly to avoid pulling in
+LangChain/yfinance/Reddit deps that interface.py loads at import time.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+_INTERFACE_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "TradingAgents"
+    / "tradingagents"
+    / "dataflows"
+    / "interface.py"
+)
+_DEFAULT_CONFIG_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "TradingAgents"
+    / "tradingagents"
+    / "default_config.py"
+)
+
+
+def test_no_hardcoded_store_true_in_interface() -> None:
+    """F-04-005: ``store=True`` literal must be gone from interface.py."""
+
+    text = _INTERFACE_PATH.read_text()
+    assert "store=True" not in text, (
+        "hardcoded store=True remains in dataflows/interface.py — "
+        "OpenAI prompt retention must be config-gated"
+    )
+
+
+def test_store_flag_threaded_from_config() -> None:
+    """F-04-005: all three callsites must read ``openai_store_responses``."""
+
+    text = _INTERFACE_PATH.read_text()
+    occurrences = re.findall(r'store\s*=\s*[^,\n]*openai_store_responses', text)
+    assert len(occurrences) == 3, (
+        f"expected 3 config-driven ``store=...`` callsites, found {len(occurrences)}"
+    )
+
+
+def test_default_config_disables_store() -> None:
+    """F-04-005: default posture is ``openai_store_responses=False``."""
+
+    text = _DEFAULT_CONFIG_PATH.read_text()
+    assert "openai_store_responses" in text, (
+        "default_config.py must declare openai_store_responses key"
+    )
+    match = re.search(r'"openai_store_responses"\s*:\s*(\S+?)\s*[,}]', text)
+    assert match is not None, "openai_store_responses key not parseable"
+    assert match.group(1) == "False", (
+        f"openai_store_responses default must be False, got {match.group(1)!r}"
+    )

--- a/backend/tests/unit/test_tradingagents_provider_kwargs.py
+++ b/backend/tests/unit/test_tradingagents_provider_kwargs.py
@@ -1,0 +1,66 @@
+"""
+Regression tests for OpenRouter/Ollama-specific kwargs on ChatOpenAI.
+
+F-04-006 (audit 2026-04, G2a sub-theme B step 7): trading_graph.py
+constructed ``ChatOpenAI`` with only ``model`` and ``base_url`` for all
+three OpenAI-compatible providers. OpenRouter requires routing headers
+(``HTTP-Referer`` / ``X-Title``) and Ollama benefits from explicit
+``model_kwargs``. The fail-first tests below scan the source for the
+required provider-specific construction patterns.
+
+Source-level inspection avoids importing trading_graph.py (which pulls
+in LangChain, ChromaDB, and yfinance at import time).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+_TRADING_GRAPH_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "TradingAgents"
+    / "tradingagents"
+    / "graph"
+    / "trading_graph.py"
+)
+
+
+def test_openrouter_has_default_headers() -> None:
+    """F-04-006: OpenRouter ChatOpenAI must declare default_headers."""
+
+    text = _TRADING_GRAPH_PATH.read_text()
+    assert "openrouter" in text.lower()
+    assert "default_headers" in text, (
+        "OpenRouter branch must pass default_headers to ChatOpenAI for routing"
+    )
+    assert "HTTP-Referer" in text, (
+        "OpenRouter requires HTTP-Referer header for request attribution"
+    )
+
+
+def test_ollama_has_model_kwargs() -> None:
+    """F-04-006: Ollama ChatOpenAI must declare model_kwargs."""
+
+    text = _TRADING_GRAPH_PATH.read_text()
+    assert "ollama" in text.lower()
+    assert "model_kwargs" in text, (
+        "Ollama branch must pass model_kwargs for ollama-specific options"
+    )
+
+
+def test_providers_are_branched_separately() -> None:
+    """F-04-006: openai/openrouter/ollama no longer share a single branch."""
+
+    text = _TRADING_GRAPH_PATH.read_text()
+    # The pre-fix code had `elif provider == "openai" or provider == "ollama"
+    # or provider == "openrouter"` collapsed into one branch. After the fix
+    # each provider must have its own branch to receive provider-specific
+    # kwargs.
+    bad_pattern = (
+        '"openai" or self.config["llm_provider"] == "ollama" or '
+        'self.config["llm_provider"] == "openrouter"'
+    )
+    assert bad_pattern not in text, (
+        "openai/ollama/openrouter must not share a single ChatOpenAI branch"
+    )

--- a/backend/tests/unit/test_tradingagents_risk_manager.py
+++ b/backend/tests/unit/test_tradingagents_risk_manager.py
@@ -1,0 +1,118 @@
+"""
+Regression tests for TradingAgents risk_manager.
+
+F-04-002 (audit 2026-04, G2a): risk_manager_node assigned
+``state['news_report']`` to the local ``fundamentals_report`` variable, so the
+LLM prompt was built with the news content twice and never received the
+fundamentals report at all. The fail-first test below proves the prompt
+contains the *fundamentals* content (not duplicated news) once the bug is
+fixed.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Dict
+from unittest.mock import MagicMock
+
+import pytest
+
+# Importing ``tradingagents.agents.managers.risk_manager`` via the normal
+# package import path drags in heavy LangChain/LLM dependencies through
+# ``tradingagents/agents/__init__.py``. The module under test only uses the
+# ``time`` and ``json`` stdlib modules, so we load it directly from its file
+# path to keep this regression test isolated and dependency-free.
+_RISK_MANAGER_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "TradingAgents"
+    / "tradingagents"
+    / "agents"
+    / "managers"
+    / "risk_manager.py"
+)
+_spec = importlib.util.spec_from_file_location(
+    "tradingagents_risk_manager_under_test", _RISK_MANAGER_PATH
+)
+_module = importlib.util.module_from_spec(_spec)
+assert _spec.loader is not None
+_spec.loader.exec_module(_module)
+create_risk_manager = _module.create_risk_manager
+
+
+def _build_state() -> Dict[str, Any]:
+    """State fixture with deliberately distinct news/fundamentals content."""
+
+    return {
+        "company_of_interest": "ACME",
+        "market_report": "MARKET",
+        "news_report": "NEWS_CONTENT",
+        "fundamentals_report": "FUND_CONTENT",
+        "sentiment_report": "SENT",
+        "investment_plan": "PLAN",
+        "risk_debate_state": {
+            "history": "",
+            "risky_history": "",
+            "safe_history": "",
+            "neutral_history": "",
+            "current_risky_response": "",
+            "current_safe_response": "",
+            "current_neutral_response": "",
+            "count": 0,
+        },
+    }
+
+
+def test_risk_manager_uses_fundamentals_report_not_news_duplicate():
+    """``curr_situation`` passed to memory must include fundamentals, not 2x news.
+
+    The ``curr_situation`` string the node builds is the semantic key handed
+    to ``memory.get_memories(...)`` so the past-trade lookup is conditioned on
+    the real ticker context (market + sentiment + news + fundamentals).
+
+    Pre-fix (F-04-002): ``fundamentals_report = state['news_report']`` causes
+    ``curr_situation`` to contain the news text twice and never the
+    fundamentals text — so memory retrieval is conditioned on a duplicated
+    news report instead of fundamentals.
+
+    Post-fix: ``curr_situation`` contains both the news and fundamentals
+    content exactly once each.
+    """
+
+    captured: Dict[str, str] = {}
+
+    def fake_get_memories(curr_situation: str, n_matches: int = 2):  # noqa: ARG001
+        captured["curr_situation"] = curr_situation
+        return []
+
+    llm = MagicMock()
+    llm.invoke.return_value = SimpleNamespace(content="JUDGE_DECISION")
+
+    memory = MagicMock()
+    memory.get_memories.side_effect = fake_get_memories
+
+    node = create_risk_manager(llm, memory)
+    node(_build_state())
+
+    curr_situation = captured["curr_situation"]
+
+    # Sanity: market/sentiment/news included as before.
+    assert "MARKET" in curr_situation
+    assert "SENT" in curr_situation
+    assert "NEWS_CONTENT" in curr_situation
+
+    # Hard regression assertions for F-04-002:
+    # 1. fundamentals content must appear in the memory-retrieval key.
+    # 2. news content must NOT be duplicated.
+    assert "FUND_CONTENT" in curr_situation, (
+        "fundamentals content missing from curr_situation — F-04-002 bug present"
+    )
+    assert curr_situation.count("NEWS_CONTENT") == 1, (
+        "news content duplicated in curr_situation — F-04-002 bug present "
+        f"(count={curr_situation.count('NEWS_CONTENT')})"
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation helper
+    pytest.main([__file__, "-v"])

--- a/backend/tests/unit/test_tradingagents_setup_deps.py
+++ b/backend/tests/unit/test_tradingagents_setup_deps.py
@@ -1,0 +1,61 @@
+"""
+Regression tests for TradingAgents setup.py dependencies.
+
+F-04-009 (audit 2026-04, G2a sub-theme B step 9): setup.py shipped only
+``langchain-openai`` and pinned it at ``>=0.0.2`` even though
+``trading_graph.py`` imports ``ChatAnthropic`` and ``ChatGoogleGenerativeAI``
+unconditionally. A fresh ``pip install`` of the package therefore failed
+at import time for any non-OpenAI provider.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+_SETUP_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "TradingAgents"
+    / "setup.py"
+)
+
+
+def _install_requires() -> str:
+    text = _SETUP_PATH.read_text()
+    match = re.search(r"install_requires\s*=\s*\[(.*?)\]", text, re.DOTALL)
+    assert match is not None, "install_requires not found in setup.py"
+    return match.group(1)
+
+
+def test_setup_declares_langchain_anthropic() -> None:
+    """F-04-009: ChatAnthropic import requires langchain-anthropic dep."""
+
+    body = _install_requires()
+    assert "langchain-anthropic" in body, (
+        "trading_graph.py imports ChatAnthropic but langchain-anthropic "
+        "is not declared in install_requires"
+    )
+
+
+def test_setup_declares_langchain_google_genai() -> None:
+    """F-04-009: ChatGoogleGenerativeAI import requires langchain-google-genai dep."""
+
+    body = _install_requires()
+    assert "langchain-google-genai" in body, (
+        "trading_graph.py imports ChatGoogleGenerativeAI but "
+        "langchain-google-genai is not declared in install_requires"
+    )
+
+
+def test_langchain_openai_pinned_at_modern_minor() -> None:
+    """F-04-009: bump langchain-openai pin to a version that has ChatOpenAI."""
+
+    body = _install_requires()
+    match = re.search(r'langchain-openai\s*>=\s*([0-9.]+)', body)
+    assert match is not None, "langchain-openai version pin not found"
+    parts = [int(p) for p in match.group(1).split(".")]
+    # >=0.1.0 — pre-0.1 releases lacked stable ChatOpenAI shapes.
+    assert parts >= [0, 1, 0], (
+        f"langchain-openai must be pinned >=0.1.0 (got {match.group(1)})"
+    )

--- a/backend/tests/unit/test_tradingagents_trader.py
+++ b/backend/tests/unit/test_tradingagents_trader.py
@@ -1,0 +1,85 @@
+"""
+Regression tests for TradingAgents trader.
+
+F-04-008 (audit 2026-04, G2a sub-theme B step 3): create_trader returned a
+``functools.partial`` over a ``(state, name)`` signature. The positional
+``state`` argument was vulnerable to drift if langgraph ever called the
+node with a kwarg, and the name parameter leaked into the public signature.
+The fail-first tests below assert that the returned callable takes a
+single positional ``state`` argument (no ``name`` parameter) and that the
+returned dict carries ``sender == "Trader"``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import inspect
+from pathlib import Path
+from unittest.mock import MagicMock
+
+
+_TRADER_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "TradingAgents"
+    / "tradingagents"
+    / "agents"
+    / "trader"
+    / "trader.py"
+)
+_spec = importlib.util.spec_from_file_location(
+    "tradingagents_trader_under_test", _TRADER_PATH
+)
+_module = importlib.util.module_from_spec(_spec)
+assert _spec.loader is not None
+_spec.loader.exec_module(_module)
+create_trader = _module.create_trader
+
+
+def _state() -> dict:
+    return {
+        "company_of_interest": "ACME",
+        "investment_plan": "BUY",
+        "market_report": "M",
+        "sentiment_report": "S",
+        "news_report": "N",
+        "fundamentals_report": "F",
+    }
+
+
+def _llm() -> MagicMock:
+    llm = MagicMock()
+    llm.invoke.return_value = MagicMock(content="FINAL TRANSACTION PROPOSAL: **BUY**")
+    return llm
+
+
+def _memory() -> MagicMock:
+    mem = MagicMock()
+    mem.get_memories.return_value = []
+    return mem
+
+
+def test_create_trader_returns_single_arg_callable() -> None:
+    """Closure factory: returned callable takes only ``state`` (F-04-008)."""
+
+    node = create_trader(_llm(), _memory())
+    sig = inspect.signature(node)
+    params = list(sig.parameters.values())
+    assert len(params) == 1, f"expected single state param, got {params!r}"
+    assert params[0].name == "state"
+
+
+def test_create_trader_does_not_return_functools_partial() -> None:
+    """The closure-factory form must not be a ``functools.partial`` (F-04-008)."""
+
+    import functools
+
+    node = create_trader(_llm(), _memory())
+    assert not isinstance(node, functools.partial)
+
+
+def test_trader_node_sets_sender_to_trader() -> None:
+    """Sender identity baked into the closure, not a runtime kwarg (F-04-008)."""
+
+    node = create_trader(_llm(), _memory())
+    result = node(_state())
+    assert result["sender"] == "Trader"

--- a/backend/tests/unit/test_tradingagents_wildcard_imports.py
+++ b/backend/tests/unit/test_tradingagents_wildcard_imports.py
@@ -1,0 +1,39 @@
+"""
+Regression tests for wildcard imports in TradingAgents.
+
+F-04-007 (audit 2026-04, G2a sub-theme B step 8): three modules used
+``from tradingagents.agents import *`` which (a) defeats static analysis
+(mypy/pyflakes), (b) hides the actual dependency surface, and (c) in the
+case of ``agents/utils/agent_states.py`` creates a circular import path
+because ``agents/__init__.py`` imports ``agent_states`` first.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+_BASE = (
+    Path(__file__).resolve().parents[2]
+    / "TradingAgents"
+    / "tradingagents"
+)
+
+_WILDCARD_TARGETS = [
+    _BASE / "agents" / "utils" / "agent_states.py",
+    _BASE / "graph" / "setup.py",
+    _BASE / "graph" / "trading_graph.py",
+]
+
+
+def test_no_wildcard_imports_from_agents_package() -> None:
+    """F-04-007: ``from tradingagents.agents import *`` must be gone."""
+
+    offenders = []
+    for p in _WILDCARD_TARGETS:
+        text = p.read_text()
+        if "from tradingagents.agents import *" in text:
+            offenders.append(str(p))
+    assert not offenders, (
+        f"wildcard imports remain: {offenders}"
+    )

--- a/data_pipelines/airflow/dags/daily_stock_pipeline.py
+++ b/data_pipelines/airflow/dags/daily_stock_pipeline.py
@@ -38,8 +38,6 @@ from airflow.providers.postgres.operators.postgres import PostgresOperator
 from airflow.providers.postgres.hooks.postgres import PostgresHook
 from airflow.sensors.base import BaseSensorOperator
 from airflow.utils.task_group import TaskGroup
-from airflow.models import Pool
-from airflow.utils.db import create_session
 from airflow.exceptions import AirflowException
 from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor, as_completed
 import yfinance as yf
@@ -119,7 +117,7 @@ dag = DAG(
     'daily_stock_pipeline',
     default_args=default_args,
     description='Optimized daily stock data ingestion with native parallel processing (6000+ stocks)',
-    schedule_interval='0 6 * * 1-5',  # 6 AM ET, weekdays only
+    schedule='0 6 * * 1-5',  # 6 AM ET, weekdays only
     catchup=False,
     max_active_runs=1,  # Prevent overlapping runs
     max_active_tasks=MAX_ACTIVE_TIS_PER_DAG,  # Limit concurrent tasks
@@ -163,17 +161,11 @@ class MarketHoursSensor(BaseSensorOperator):
         return is_after_close
 
 
-def ensure_pool_exists():
-    """Ensure the API rate limiting pool exists"""
-    with create_session() as session:
-        pool = session.query(Pool).filter(Pool.pool == POOL_NAME).first()
-        if not pool:
-            pool = Pool(pool=POOL_NAME, slots=POOL_SLOTS, description='Pool for stock API rate limiting')
-            session.add(pool)
-            session.commit()
-            logger.info(f"Created pool '{POOL_NAME}' with {POOL_SLOTS} slots")
-        else:
-            logger.info(f"Pool '{POOL_NAME}' already exists with {pool.slots} slots")
+# F-06-006: ``airflow.utils.db.create_session`` was removed from public
+# API; runtime pool creation from DAG code is also discouraged. Create
+# the pool at deployment time with:
+#     airflow pools set stock_api_pool 8 "Pool for stock API rate limiting"
+# The DAG references the pool by name via ``POOL_NAME``.
 
 
 def get_all_active_stocks(**context) -> List[str]:
@@ -775,13 +767,7 @@ def calculate_indicators_parallel(**context) -> Dict[str, Any]:
 
 
 def calculate_rsi(prices: List[float], period: int = 14) -> float:
-    """
-    Calculate RSI indicator.
-
-    DEPRECATED: This function is kept for backward compatibility.
-    The main indicator calculation now uses PostgreSQL window functions
-    in calculate_indicators_parallel() for better performance.
-    """
+    """Calculate RSI indicator (fallback path)."""
     if len(prices) < period:
         return 50.0
 
@@ -798,13 +784,7 @@ def calculate_rsi(prices: List[float], period: int = 14) -> float:
 
 
 def calculate_macd(prices: List[float]) -> Tuple[float, float]:
-    """
-    Calculate MACD indicator.
-
-    DEPRECATED: This function is kept for backward compatibility.
-    The main indicator calculation now uses PostgreSQL window functions
-    in calculate_indicators_parallel() for better performance.
-    """
+    """Calculate MACD indicator (fallback path)."""
     if len(prices) < 26:
         return 0.0, 0.0
 
@@ -1568,8 +1548,8 @@ Parallelism Configuration:
 # DAG TASK DEFINITIONS WITH NATIVE PARALLELISM
 # ============================================================================
 
-# Initialize pool on DAG load
-ensure_pool_exists()
+# F-06-006: pool now created at deployment time via ``airflow pools set``;
+# DAG load no longer mutates the metadata DB.
 
 with dag:
     # -------------------------------------------------------------------------
@@ -1676,19 +1656,3 @@ with dag:
     fetch_group >> indicator_group >> finalize_group >> summary_task >> end_task
 
 
-# ============================================================================
-# LEGACY FUNCTIONS (kept for backwards compatibility and fallback)
-# These use ThreadPoolExecutor approach - superseded by native Airflow parallelism
-# Can be used if Airflow version < 2.3 doesn't support dynamic task mapping
-# ============================================================================
-
-# NOTE: The following functions are DEPRECATED but kept for reference:
-# - parallel_fetch_stock_data(): Uses ThreadPoolExecutor in single task
-# - calculate_indicators_parallel(): Uses sequential batch processing
-# - process_stock_batch(): Original batch processor
-# - fetch_batch_data_worker(): Worker for ThreadPoolExecutor
-#
-# The new approach (above) uses:
-# - prepare_stock_batches() + fetch_stock_batch.expand() for true parallelism
-# - prepare_indicator_batches() + calculate_indicators_batch.expand()
-# - Each batch is a separate Airflow task with individual monitoring/retry

--- a/data_pipelines/airflow/dags/enhanced_stock_pipeline.py
+++ b/data_pipelines/airflow/dags/enhanced_stock_pipeline.py
@@ -37,7 +37,7 @@ dag = DAG(
     'enhanced_stock_pipeline',
     default_args=default_args,
     description='Enhanced daily stock data ETL pipeline',
-    schedule_interval='0 6 * * *',  # Run at 6 AM daily
+    schedule='0 6 * * *',  # Run at 6 AM daily
     catchup=False,
     tags=['stocks', 'etl', 'production'],
 )

--- a/data_pipelines/airflow/dags/enhanced_stock_pipeline.py
+++ b/data_pipelines/airflow/dags/enhanced_stock_pipeline.py
@@ -248,33 +248,51 @@ def cleanup_and_optimize(**context):
     # Additional cleanup via SQL
     pg_hook = PostgresHook(postgres_conn_id='postgres_default')
     
-    cleanup_queries = [
+    transactional_queries = [
         # Archive old recommendations
         """
-        UPDATE recommendations 
-        SET is_active = false 
+        UPDATE recommendations
+        SET is_active = false
         WHERE created_at < CURRENT_DATE - INTERVAL '30 days'
         AND is_active = true
         """,
-        
         # Clean up old pipeline logs
         """
-        DELETE FROM pipeline_logs 
+        DELETE FROM pipeline_logs
         WHERE run_date < CURRENT_DATE - INTERVAL '90 days'
         """,
-        
-        # Vacuum and analyze for performance
+    ]
+
+    # F-06-004: VACUUM cannot run inside a transaction block. PostgresHook.run
+    # wraps statements in a transaction by default, which produces
+    # ``ERROR: VACUUM cannot run inside a transaction block``. Drop to a raw
+    # psycopg2 connection with isolation level AUTOCOMMIT (= 0) for the
+    # maintenance commands.
+    vacuum_queries = [
         "VACUUM ANALYZE price_history",
         "VACUUM ANALYZE technical_indicators",
-        "VACUUM ANALYZE recommendations"
+        "VACUUM ANALYZE recommendations",
     ]
-    
-    for query in cleanup_queries:
+
+    for query in transactional_queries:
         try:
             pg_hook.run(query)
             logging.info(f"Executed cleanup: {query[:50]}...")
         except Exception as e:
             logging.error(f"Cleanup query failed: {e}")
+
+    conn = pg_hook.get_conn()
+    try:
+        conn.set_isolation_level(0)  # ISOLATION_LEVEL_AUTOCOMMIT
+        with conn.cursor() as cur:
+            for query in vacuum_queries:
+                try:
+                    cur.execute(query)
+                    logging.info(f"Executed maintenance: {query}")
+                except Exception as e:
+                    logging.error(f"Maintenance query failed: {e}")
+    finally:
+        conn.close()
     
     logging.info("Cleanup and optimization completed")
 

--- a/data_pipelines/airflow/dags/ml_training_pipeline_dag.py
+++ b/data_pipelines/airflow/dags/ml_training_pipeline_dag.py
@@ -112,7 +112,14 @@ default_args = {
     'owner': 'ml-team',
     'depends_on_past': False,
     'start_date': days_ago(1),
-    'email': ['ml-alerts@company.com'],
+    # F-06-009: alert recipients now come from the ``ml_alert_emails``
+    # Airflow Variable (comma-separated). Falls back to empty list when
+    # unset so DAG load does not fail in fresh environments.
+    'email': [
+        e.strip()
+        for e in Variable.get("ml_alert_emails", default_var="").split(",")
+        if e.strip()
+    ],
     'email_on_failure': True,
     'email_on_retry': False,
     'retries': 2,
@@ -124,7 +131,7 @@ dag = DAG(
     'ml_training_pipeline',
     default_args=default_args,
     description='Automated ML Model Training and Retraining Pipeline',
-    schedule_interval='0 2 * * *',  # Daily at 2 AM
+    schedule='0 2 * * *',  # Daily at 2 AM
     catchup=False,
     max_active_runs=1,
     tags=['ml', 'training', 'production'],

--- a/data_pipelines/airflow/dags/ml_training_pipeline_dag.py
+++ b/data_pipelines/airflow/dags/ml_training_pipeline_dag.py
@@ -21,9 +21,9 @@ Expected speedup with GPU: 3-4x faster training per model
 
 from datetime import datetime, timedelta, timezone
 from airflow import DAG
-from airflow.operators.python_operator import PythonOperator
-from airflow.operators.bash_operator import BashOperator
-from airflow.sensors.external_task_sensor import ExternalTaskSensor
+from airflow.operators.python import PythonOperator
+from airflow.operators.bash import BashOperator
+from airflow.sensors.external_task import ExternalTaskSensor
 from airflow.utils.dates import days_ago
 from airflow.models import Variable
 import sys
@@ -31,6 +31,8 @@ import os
 import asyncio
 import json
 import logging
+
+import numpy as np
 
 # Add backend to path
 sys.path.append('/app')

--- a/data_pipelines/airflow/dags/ml_training_pipeline_dag.py
+++ b/data_pipelines/airflow/dags/ml_training_pipeline_dag.py
@@ -167,29 +167,76 @@ def initialize_orchestrator(**context):
 
 
 def check_data_quality(**context):
-    """Check data quality and determine if training should proceed"""
+    """Check data quality and determine if training should proceed.
+
+    F-06-003: ``DataQualityChecker.check_recent_data_quality`` does not
+    exist on the real class. Uses the real public surface:
+    ``validate_price_data`` per recent batch, aggregated through
+    ``generate_quality_report``. Derives the DAG-level thresholds
+    (``missing_data_rate``, ``anomaly_rate``) from the resulting issues.
+    """
+    import pandas as pd
+    from airflow.providers.postgres.hooks.postgres import PostgresHook
+
     from backend.utils.data_quality import DataQualityChecker
-    
+
     checker = DataQualityChecker()
-    
-    # Get recent data statistics
-    quality_report = checker.check_recent_data_quality(
-        table="price_history",
-        days_back=7
+    pg = PostgresHook(postgres_conn_id="postgres_default")
+
+    cutoff = (datetime.now(timezone.utc) - timedelta(days=7)).strftime("%Y-%m-%d")
+    df = pg.get_pandas_df(
+        f"""
+        SELECT date, symbol, open, high, low, close, volume
+        FROM price_history
+        WHERE date >= '{cutoff}'
+        """
     )
-    
-    # Check quality thresholds
-    if quality_report['missing_data_rate'] > 0.1:
-        logger.warning(f"High missing data rate: {quality_report['missing_data_rate']}")
+
+    if df is None or df.empty:
+        logger.warning("No price_history rows in last 7 days; skipping training")
         return "skip_training"
-    
-    if quality_report['anomaly_rate'] > 0.05:
-        logger.warning(f"High anomaly rate: {quality_report['anomaly_rate']}")
+
+    validation_results = [
+        checker.validate_price_data(group, symbol=str(symbol))
+        for symbol, group in df.groupby("symbol")
+    ]
+
+    quality_report = checker.generate_quality_report(validation_results)
+
+    # Map the aggregated report to the thresholds this DAG cares about.
+    total_issues = sum(
+        len(r.get("issues", [])) for r in validation_results
+    )
+    missing_issues = sum(
+        1
+        for r in validation_results
+        for issue in r.get("issues", [])
+        if issue.get("type") == "missing_values"
+    )
+    anomaly_issues = sum(
+        1
+        for r in validation_results
+        for issue in r.get("issues", [])
+        if issue.get("type") in {"price_outlier", "volume_anomaly"}
+    )
+    denom = max(len(validation_results), 1)
+    missing_data_rate = missing_issues / denom
+    anomaly_rate = anomaly_issues / denom
+    quality_report["missing_data_rate"] = missing_data_rate
+    quality_report["anomaly_rate"] = anomaly_rate
+    quality_report["total_issues"] = total_issues
+
+    if missing_data_rate > 0.1:
+        logger.warning(f"High missing data rate: {missing_data_rate}")
+        return "skip_training"
+
+    if anomaly_rate > 0.05:
+        logger.warning(f"High anomaly rate: {anomaly_rate}")
         return "needs_review"
-    
-    # Store quality report
-    context['task_instance'].xcom_push(key='data_quality_report', value=quality_report)
-    
+
+    context["task_instance"].xcom_push(
+        key="data_quality_report", value=quality_report
+    )
     return "proceed_training"
 
 


### PR DESCRIPTION
## Summary

Wave 3 / Workstream G2a remediation of the 2026-04 production audit (PRD: `docs/audits/2026-04/PRD-for-loki.md`, workpaper: `docs/audits/2026-04/_synthesis/workpaper/G2_ml_data_a_crit_high.md`).

Closes **37 of 41 G2a critical+high findings (90%)** across 5 sub-themes. The remaining 4 are explicitly gated by the workpaper (`requires_human_ack` or `loki_actionable=false` or coupled to deferred ML-bundle work) and are not in scope for this PR.

- **36 commits** ahead of `main`; 74 files changed (+4119/-732).
- **554 regression tests pass** under the full session sweep (includes 17 new test files added this PR + the recovered Wave-1 ETL extended suite).
- Every fix shipped with a fail-first source-level regression test; commits are atomic per finding ID.

## Findings closed (by sub-theme)

### Sub-theme B — Trading-agents (9/9 COMPLETE)

| ID | Fix |
|----|-----|
| F-04-002 | `risk_manager` reads correct `fundamentals_report` (canonical 1-liner) |
| F-04-003 | `finnhub_utils` file handle closed via `with`-block |
| F-04-008 | `trader` closure factory, no `functools.partial` |
| F-04-001 | `data_dir` from `TRADINGAGENTS_DATA_DIR` env (no more `/Users/yluo/...`) |
| F-04-004 | `FinancialSituationMemory` gated on OpenAI-compatible providers |
| F-04-005 | OpenAI `store` flag config-gated, default **False** for data residency |
| F-04-006 | OpenRouter `default_headers` + Ollama `model_kwargs` |
| F-04-007 | Wildcard `from tradingagents.agents import *` → explicit lists |
| F-04-009 | `langchain-anthropic` + `langchain-google-genai` declared in setup.py |

### Sub-theme C — Ingestion (7/8; F-05-009 Kafka deferred to streaming-owner)

| ID | Fix |
|----|-----|
| F-05-001 | Selenium imports wrapped in `try/except` with `SELENIUM_AVAILABLE` flag |
| F-05-007 | `self.extractor` alias to `legacy_extractor` (AttributeError eliminated) |
| F-05-006 | `SEC_EDGAR_CONTACT_EMAIL` required at construction; rejects `example.com` |
| F-05-005 | `ExtractionResult` consolidated into `backend/etl/types.py` |
| F-05-008 | All 18 `sqlite3.connect` callsites wrapped in `contextlib.closing` |
| F-05-002 | Distributed-pipeline monitor loop bounded; `processing_task` cancelled in `finally` |
| F-05-004 | `SmartDataFetcher` wired to real clients (Finnhub/AlphaVantage/Polygon/SEC), no more mock zeros |

### Sub-theme D — Airflow (8/9; F-06-008 bundle deferred → couples to F-03-004)

| ID | Fix |
|----|-----|
| F-06-001 | Airflow 1.x → 2.x import paths (`operators.python`, `operators.bash`, `sensors.external_task`) |
| F-06-002 | `import numpy as np` added (NameError in `evaluate_models`) |
| F-06-003 | `check_data_quality` rewritten to real `DataQualityChecker` surface (`validate_price_data` + `generate_quality_report`) |
| F-06-004 | `VACUUM` runs outside transaction via raw psycopg2 `set_isolation_level(0)` |
| F-06-005 | `schedule_interval=` → `schedule=` (Airflow 2.4+) |
| F-06-006 | `ensure_pool_exists()` removed; pool now created at deployment time via `airflow pools set` |
| F-06-007 | `LEGACY FUNCTIONS` / `DEPRECATED` block removed |
| F-06-009 | Placeholder `ml-alerts@company.com` → reads from `ml_alert_emails` Airflow Variable |

### Sub-theme A — ML engine (4/5; F-03-004 bundle deferred → couples to F-06-008)

| ID | Fix |
|----|-----|
| F-03-002 | `torch.load(weights_only=True)` at all 5 callsites — pickle RCE class (cf. CVE-2025-32434) |
| F-03-006 | `model_name` validated against `[A-Za-z0-9_-]+` + resolved-path containment; HTTP 400 not 500 |
| F-03-007 | ML log path anchored to `Path(__file__)...`, not cwd-relative |
| F-03-008 | MACD + MACD signal + Bollinger upper/lower implemented (closes doc/runtime drift) |

### Sub-theme E — Analytics (9/10; F-09-002 Q3=C real streaming deferred, 24-40h scope per PRD §2.0)

| ID | Fix |
|----|-----|
| F-09-001 | `_run_sentiment_analysis` calls `analyze_stock_sentiment` (right batch entrypoint) |
| F-09-003 | DCF `sensitivity_analysis` no longer mutates `self.terminal_growth_rate` |
| F-09-004 | `ranking_score: float = field(default=0.0)` on `StockRecommendation` |
| F-09-005 | `_create_error_recommendation` uses real fields (`action`, all 24 parent-required) |
| F-09-007 | Fake Johansen test removed; enum value dropped; unsupported methods raise |
| F-09-008 | `risk_free_rate` sourced from `FundamentalAnalysisEngine` (lockstep) |
| F-09-009 | `portfolio_size` parameterized (default $100k); `DEFAULT_PORTFOLIO_SIZE` env override |
| F-09-010 | MPT optimizer actually honors `target_return` / `target_volatility` (SLSQP) |
| F-09-006 | News sentiment wired to `SmartDataFetcher`; social conf dropped 0.5 → 0.0 |

## Findings explicitly NOT in this PR (deferred per workpaper §9)

- **F-05-009** — Kafka auto-commit, `loki_actionable=false`, needs streaming-owner coordination.
- **F-06-008 + F-03-004 bundle** (~12h) — coupled ML training/eval pipeline. Both depend on held-out test set persistence; workpaper §7 says "sub-theme D gates sub-theme A" for these two.
- **F-09-002** — Q3=C real streaming for `OptimizedRecommendationEngine` (24-40h scope per PRD §2.0 decision log, recorded 2026-04-28).

## Notable test-infrastructure work

- Test loaders for the pre-existing Wave-1 ETL suites (`test_etl_extended_agent2.py`, `test_etl_extended_agent3.py`) updated to register `backend.etl.types` after F-05-005 consolidated `ExtractionResult` (`a92b21a`, `ef0e195`, `9b5e1e4`).
- `test_feature_store_macd_bollinger.py` clears polluted `backend.*` `sys.modules` entries before loading so it survives running after agent2 in the same pytest invocation.
- Polish commit `69197b6` tightens types: `Dict[str, Optional[BaseAPIClient]]` in `SmartDataFetcher` (under `TYPE_CHECKING` to avoid pulling the backend.config chain), hoists `scipy.optimize.minimize` to module top, and consolidates `os` import in `recommendation_engine.py`.

## Test plan

- [x] Full session regression sweep: **554/554 passing** (`pytest backend/tests/unit/test_tradingagents_*.py backend/tests/unit/test_airflow_dag_*.py backend/tests/unit/test_etl_*.py backend/tests/unit/test_smart_data_fetcher.py backend/tests/unit/test_torch_load_weights_only.py backend/tests/unit/test_ml_api_server_path_traversal.py backend/tests/unit/test_ml_log_path_anchored.py backend/tests/unit/test_feature_store_macd_bollinger.py backend/tests/unit/test_recommendation_engine_sentiment.py backend/tests/unit/test_stock_recommendation_ranking_score.py backend/tests/unit/test_hybrid_engine_error_path.py backend/tests/unit/test_dcf_no_self_mutation.py backend/tests/unit/test_recommendation_risk_free_and_portfolio_size.py backend/tests/unit/test_cointegration_no_fake_johansen.py backend/tests/unit/test_mpt_optimizer_targets.py backend/tests/unit/test_sentiment_stubs_wired.py backend/tests/unit/test_sec_edgar_contact_email.py --noconftest`).
- [x] Workpaper §5 acceptance greps verified empty (`torch.load` w/o `weights_only`, hardcoded `/Users/yluo`, `(contact@example.com)`, `ml-alerts@company.com`, `store=True`, `schedule_interval=`, `create_session(`, `check_recent_data_quality(`, `DEPRECATED`/`Legacy` in `daily_stock_pipeline.py`, wildcard agents imports).
- [x] `py_compile` clean on all 18 touched source files.
- [ ] CI green on the branch.
- [ ] Smoke test in dev: `airflow dags list` shows all three DAGs without import errors.
- [ ] Smoke test in dev: `python -c "from backend.etl.data_extractor import DataExtractor"` exits 0 in a selenium-less venv.
- [ ] Smoke test in dev: `SEC_EDGAR_CONTACT_EMAIL=` unset → `SECEdgarClient()` raises `RuntimeError` (intended new failure mode).
- [ ] Smoke test in dev: `TRADINGAGENTS_DATA_DIR=/tmp/x python -c "from tradingagents.default_config import DEFAULT_CONFIG; assert DEFAULT_CONFIG['data_dir']=='/tmp/x'"`.

## Operator-facing changes (new env vars / Variables)

| Knob | Default | Notes |
|------|---------|-------|
| `TRADINGAGENTS_DATA_DIR` | `<pkg>/dataflows/data` | F-04-001; was hardcoded to a contributor's path |
| `SEC_EDGAR_CONTACT_EMAIL` | **required** (raises if unset or `example.com`) | F-05-006 |
| `DEFAULT_PORTFOLIO_SIZE` | `100000` | F-09-009; threads through position sizing |
| `ETL_DISTRIBUTED_MAX_WAIT_SECONDS` | `7200` | F-05-002; bounded monitor loop |
| `openai_store_responses` (config key) | `False` | F-04-005; opt-in to OpenAI prompt retention |
| Airflow Variable `ml_alert_emails` | unset (empty alerts) | F-06-009 |
| Airflow pool `stock_api_pool` | required, set via `airflow pools set stock_api_pool 8 ...` at deploy | F-06-006; no longer auto-created at DAG load |