### PR TITLE
ci: add actions/checkout to stale-pr-check (fix #187 CI red)

### DIFF
--- a/.github/workflows/pr-automation.yml
+++ b/.github/workflows/pr-automation.yml
@@ -326,6 +326,9 @@ jobs:
     timeout-minutes: 5
 
     steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
     - name: Check PR staleness
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Tiny surgical fix: 3-line cherry-pick of `actions/checkout@v4` into the `stale-pr-check` job of `pr-automation.yml`.

## Why

`stale-pr-check` calls `gh pr view`, `gh pr comment`, `gh pr edit`. `gh` invokes `git` internally to resolve repo context. Without an `actions/checkout` step, the runner cwd has no `.git`, so:

```
failed to run git: fatal: not a git repository (or any of the parent directories): .git
Process completed with exit code 1.
```

This blocks the CI green-light on **PR #186** (this branch) and **PR #187** (the ml-bundle follow-up that targets this branch). The fix already exists on `main` (commit `a4c0e99`) but `pull_request` events use the **head branch's** workflow YAML, and `wave3-G2a` forked from `fc948dd` which is BEFORE `a4c0e99`. So every PR opened against this branch hits the legacy broken workflow.

## What

Identical 3-line diff to what already exists on `main`:

```diff
   stale-pr-check:
     ...
     steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
     - name: Check PR staleness
```

## Test plan

- [ ] After merge to `remediation/audit-2026-04-wave3-G2a`, PR #187 re-runs `stale-pr-check` and it goes green.
- [ ] No other check regresses.

## Why a separate PR

Stacking this as a one-line fix-it PR avoids re-running #186's full CI for a workflow-only change. Merge order:
1. Merge this PR into `remediation/audit-2026-04-wave3-G2a` (fixes #186 + #187 CI).
2. Continue review on #186.
3. PR #187 rebases automatically once #186 merges.