### PR TITLE
Wave 3 / G2a (split): 30/41 active-code audit findings

### DIFF
--- a/backend/analytics/agents/hybrid_engine.py
+++ b/backend/analytics/agents/hybrid_engine.py
@@ -6,6 +6,7 @@ from datetime import datetime, timezone
 from enum import Enum
 
 from backend.analytics.recommendation_engine import RecommendationEngine, StockRecommendation
+from backend.analytics.recommendation_types import RecommendationAction
 from backend.utils.llm_budget_manager import LLMBudgetManager, BudgetExceededException, LLMCircuitBreaker
 from backend.utils.cache_manager import CacheManager
 from backend.data_ingestion.smart_data_fetcher import SmartDataFetcher
@@ -39,27 +40,30 @@ class EnhancedStockRecommendation(StockRecommendation):
     def __post_init__(self):
         if self.agents_used is None:
             self.agents_used = []
-        
-        # Calculate hybrid score if agent analysis available
-        if self.agent_analysis and hasattr(self, 'overall_score'):
+
+        # F-09-005: ``overall_score`` was never declared on the parent
+        # StockRecommendation dataclass. Use ``confidence`` as the
+        # traditional-analysis score for the hybrid calculation (the
+        # field that is actually populated for every recommendation).
+        if self.agent_analysis is not None:
             self.hybrid_score = self._calculate_hybrid_score()
-    
+
     def _calculate_hybrid_score(self) -> float:
         """Calculate hybrid score combining traditional and agent analysis"""
         if not self.agent_analysis:
-            return self.overall_score
-        
+            return self.confidence
+
         # Get agent confidence (0-1 scale)
         agent_conf = self.agent_confidence or 0.5
-        
+
         # Weight traditional vs agent analysis based on agent confidence
         agent_weight = min(agent_conf, 0.4)  # Max 40% weight to agents
         traditional_weight = 1.0 - agent_weight
-        
+
         # Assume agent provides a score (this would need to be extracted from actual agent output)
         agent_score = self._extract_agent_score()
-        
-        hybrid = (traditional_weight * self.overall_score + 
+
+        hybrid = (traditional_weight * self.confidence +
                  agent_weight * agent_score)
         
         return max(0.0, min(1.0, hybrid))  # Clamp to [0,1]
@@ -165,7 +169,6 @@ class HybridAnalysisEngine:
             )
             
             logger.debug(f"Traditional analysis complete for {ticker} - "
-                        f"Score: {traditional_result.overall_score:.2f}, "
                         f"Confidence: {traditional_result.confidence:.2f}")
             
             # Step 2: Determine if we should enhance with agents
@@ -413,25 +416,70 @@ class HybridAnalysisEngine:
         return EnhancedStockRecommendation(**enhanced_data)
     
     def _create_error_recommendation(
-        self, 
-        ticker: str, 
+        self,
+        ticker: str,
         error: str,
-        start_time: datetime
+        start_time: datetime,
     ) -> EnhancedStockRecommendation:
-        """Create minimal recommendation when analysis fails"""
-        analysis_duration = (datetime.now(timezone.utc) - start_time).total_seconds()
-        
+        """Create minimal recommendation when analysis fails.
+
+        F-09-005: previously passed ``recommendation="HOLD"`` and
+        ``overall_score=0.5`` — neither is a field on
+        StockRecommendation/EnhancedStockRecommendation, and a slew of
+        parent-required fields were missing, so constructing this
+        TypeError'd on every error path.
+
+        Now constructs a fully-populated dataclass with safe defaults
+        and uses the real fields: ``action=HOLD`` (not
+        ``recommendation``) and ``confidence=0.1`` (with the inherited
+        score columns set to 0.0).
+        """
+        now = datetime.now(timezone.utc)
+        analysis_duration = (now - start_time).total_seconds()
+
         return EnhancedStockRecommendation(
+            # Identity
             ticker=ticker,
-            recommendation="HOLD",
-            overall_score=0.5,
+            action=RecommendationAction.HOLD,
             confidence=0.1,
+            priority=10,  # lowest priority for error path
+            # Price targets (zeroed)
+            entry_price=0.0,
             target_price=0.0,
-            risks=["Analysis failed: " + error],
+            stop_loss=0.0,
+            expected_return=0.0,
+            time_horizon_days=0,
+            # Risk metrics (zeroed)
+            risk_score=0.0,
+            volatility=0.0,
+            beta=0.0,
+            sharpe_ratio=0.0,
+            max_drawdown=0.0,
+            # Analysis scores (zeroed)
+            technical_score=0.0,
+            fundamental_score=0.0,
+            sentiment_score=0.0,
+            ml_prediction_score=0.0,
+            # Detail dicts
+            technical_analysis={},
+            fundamental_analysis={},
+            sentiment_analysis={},
+            ml_predictions={},
+            # Reasoning
+            key_factors=[],
+            risks=[f"Analysis failed: {error}"],
             opportunities=[],
+            catalysts=[],
+            # Metadata
+            generated_at=now,
+            valid_until=now,
+            # Position sizing (zeroed)
+            recommended_allocation=0.0,
+            max_position_size=0.0,
+            # Enhanced fields
             analysis_duration=analysis_duration,
             complexity_level="error",
-            agents_used=[]
+            agents_used=[],
         )
     
     async def _update_stats(self, cost: float, start_time: datetime, used_agents: bool):

--- a/backend/analytics/fundamental/valuation/dcf_model.py
+++ b/backend/analytics/fundamental/valuation/dcf_model.py
@@ -56,7 +56,8 @@ class DCFModel:
         growth_rates: Optional[List[float]] = None,
         discount_rate: Optional[float] = None,
         shares_outstanding: float = 1.0,
-        current_price: float = 0.0
+        current_price: float = 0.0,
+        terminal_growth_rate: Optional[float] = None,
     ) -> DCFResult:
         """
         Calculate intrinsic value using DCF model.
@@ -67,6 +68,11 @@ class DCFModel:
             discount_rate: Discount rate (WACC)
             shares_outstanding: Number of shares outstanding
             current_price: Current stock price
+            terminal_growth_rate: Override the instance-level
+                ``self.terminal_growth_rate`` for this call only.
+                Added for F-09-003 so sensitivity_analysis can vary the
+                terminal growth rate without mutating shared instance
+                state.
 
         Returns:
             DCFResult with valuation metrics
@@ -78,6 +84,15 @@ class DCFModel:
             # Default declining growth assumption
             growth_rates = [0.15, 0.12, 0.10, 0.08, 0.05]
 
+        # F-09-003: prefer the per-call override; fall back to the
+        # instance default. Reading via a local keeps the rest of the
+        # method side-effect-free.
+        _tgr = (
+            terminal_growth_rate
+            if terminal_growth_rate is not None
+            else self.terminal_growth_rate
+        )
+
         # Project future free cash flows
         projected_fcf = []
         fcf = free_cash_flow
@@ -88,12 +103,12 @@ class DCFModel:
 
         # Pad with terminal growth if needed
         while len(projected_fcf) < self.projection_years:
-            fcf = projected_fcf[-1] * (1 + self.terminal_growth_rate)
+            fcf = projected_fcf[-1] * (1 + _tgr)
             projected_fcf.append(fcf)
 
         # Calculate terminal value (Gordon Growth Model)
-        terminal_fcf = projected_fcf[-1] * (1 + self.terminal_growth_rate)
-        terminal_value = terminal_fcf / (discount_rate - self.terminal_growth_rate)
+        terminal_fcf = projected_fcf[-1] * (1 + _tgr)
+        terminal_value = terminal_fcf / (discount_rate - _tgr)
 
         # Calculate present values
         pv_fcfs = 0
@@ -177,14 +192,18 @@ class DCFModel:
             'values': []
         }
 
+        # F-09-003: previously mutated ``self.terminal_growth_rate``
+        # mid-loop which left the instance in a non-deterministic state
+        # after sensitivity_analysis returned. Pass ``gr`` per call
+        # instead so ``self`` is unchanged on exit.
         for dr in discount_rates:
             row = []
             for gr in growth_rates:
-                self.terminal_growth_rate = gr
                 result = self.calculate_intrinsic_value(
                     free_cash_flow=free_cash_flow,
                     discount_rate=dr,
-                    shares_outstanding=shares_outstanding
+                    shares_outstanding=shares_outstanding,
+                    terminal_growth_rate=gr,
                 )
                 row.append(result.intrinsic_value)
             results['values'].append(row)

--- a/backend/analytics/portfolio/modern_portfolio_theory.py
+++ b/backend/analytics/portfolio/modern_portfolio_theory.py
@@ -10,6 +10,8 @@ from typing import Dict, List, Tuple, Optional, Any
 from dataclasses import dataclass
 import logging
 
+from scipy.optimize import minimize  # F-09-010: SLSQP mean-variance solver
+
 logger = logging.getLogger(__name__)
 
 
@@ -76,13 +78,72 @@ class PortfolioOptimizer:
         expected_returns = returns.mean() * 252  # Annualize
         cov_matrix = returns.cov() * 252  # Annualize
 
-        # Simple equal weight as baseline
-        weights = np.array([1.0 / n_assets] * n_assets)
+        # F-09-010: previous implementation always returned equal
+        # weights, ignoring ``target_return`` / ``target_volatility``.
+        # Replace with a real mean-variance optimizer via scipy
+        # (``scipy.optimize.minimize`` imported at module top).
+        er = np.asarray(expected_returns, dtype=float)
+        cov = np.asarray(cov_matrix, dtype=float)
+
+        def _portfolio_var(w: np.ndarray) -> float:
+            return float(np.dot(w.T, np.dot(cov, w)))
+
+        def _portfolio_ret(w: np.ndarray) -> float:
+            return float(np.dot(w, er))
+
+        def _neg_sharpe(w: np.ndarray) -> float:
+            ret = _portfolio_ret(w)
+            vol = np.sqrt(_portfolio_var(w))
+            if vol <= 0:
+                return 0.0
+            return -(ret - self.risk_free_rate) / vol
+
+        # Long-only, fully invested.
+        bounds = tuple((0.0, 1.0) for _ in range(n_assets))
+        sum_to_one = {"type": "eq", "fun": lambda w: float(np.sum(w) - 1.0)}
+        x0 = np.array([1.0 / n_assets] * n_assets)
+
+        if target_return is not None:
+            # Minimize variance subject to ``w·er >= target_return``.
+            constraints = [
+                sum_to_one,
+                {"type": "ineq", "fun": lambda w: _portfolio_ret(w) - float(target_return)},
+            ]
+            res = minimize(_portfolio_var, x0, method="SLSQP",
+                           bounds=bounds, constraints=constraints)
+        elif target_volatility is not None:
+            # Maximize return subject to ``vol <= target_volatility``.
+            constraints = [
+                sum_to_one,
+                {"type": "ineq",
+                 "fun": lambda w: float(target_volatility) - np.sqrt(_portfolio_var(w))},
+            ]
+            res = minimize(lambda w: -_portfolio_ret(w), x0, method="SLSQP",
+                           bounds=bounds, constraints=constraints)
+        else:
+            # No target → maximize Sharpe.
+            res = minimize(_neg_sharpe, x0, method="SLSQP",
+                           bounds=bounds, constraints=[sum_to_one])
+
+        if res.success:
+            weights = np.asarray(res.x, dtype=float)
+        else:
+            # Solver failed → fall back to equal weights with a logger
+            # warning rather than silently returning bad weights.
+            import logging
+            logging.getLogger(__name__).warning(
+                "MPT solver did not converge (%s); falling back to equal weights",
+                getattr(res, "message", "no message"),
+            )
+            weights = x0
 
         # Calculate portfolio metrics
-        portfolio_return = np.dot(weights, expected_returns)
-        portfolio_vol = np.sqrt(np.dot(weights.T, np.dot(cov_matrix, weights)))
-        sharpe = (portfolio_return - self.risk_free_rate) / portfolio_vol if portfolio_vol > 0 else 0
+        portfolio_return = _portfolio_ret(weights)
+        portfolio_vol = float(np.sqrt(_portfolio_var(weights)))
+        sharpe = (
+            (portfolio_return - self.risk_free_rate) / portfolio_vol
+            if portfolio_vol > 0 else 0.0
+        )
 
         weight_dict = dict(zip(assets, weights))
 

--- a/backend/analytics/recommendation_engine.py
+++ b/backend/analytics/recommendation_engine.py
@@ -16,6 +16,7 @@ statements continue to work without modification.
 """
 
 import asyncio
+import os
 import numpy as np
 import pandas as pd
 from typing import Dict, List, Optional, Tuple, Any
@@ -91,6 +92,12 @@ class RecommendationEngine:
         self.market_scanner = MarketScanner()
         self.risk_manager = RiskManager()
         self.portfolio_optimizer = PortfolioOptimizer()
+
+        # F-09-008: source from the fundamental engine so the two
+        # stay in lockstep instead of drifting silently.
+        # F-09-009: portfolio size is now operator-controlled.
+        self.risk_free_rate = self.fundamental_engine.risk_free_rate
+        self.portfolio_size = float(os.getenv("DEFAULT_PORTFOLIO_SIZE", "100000"))
 
         self.thresholds = {
             'strong_buy':  0.8,
@@ -347,7 +354,28 @@ class RecommendationEngine:
         if not text_data:
             return {'overall_sentiment': {'score': 0.0, 'label': 'neutral', 'confidence': 0.0}}
 
-        return await self.sentiment_engine.analyze_sentiment(ticker, text_data)
+        # F-09-001: ``analyze_sentiment(text: str, source: str)`` is the
+        # per-text entrypoint and rejects the list-of-dicts shape this
+        # method assembles. The batch entrypoint is
+        # ``analyze_stock_sentiment(ticker, texts: List[str])``.
+        # Adapter pattern: feed it the extracted ``text`` field, then
+        # map the SentimentResult back to the legacy dict shape that
+        # downstream consumers (line ~480) read via
+        # ``sentiment_analysis.get('overall_sentiment', ...)``.
+        result = await self.sentiment_engine.analyze_stock_sentiment(
+            ticker, [item['text'] for item in text_data if item.get('text')]
+        )
+        return {
+            'overall_sentiment': {
+                'score': result.score,
+                'label': result.label,
+                'confidence': result.confidence,
+            },
+            'breakdown': result.breakdown,
+            'keywords': result.keywords,
+            'sources_analyzed': result.sources_analyzed,
+            'timestamp': result.timestamp,
+        }
 
     async def _run_ml_predictions(
         self, ticker: str, stock_data: Dict
@@ -406,8 +434,10 @@ class RecommendationEngine:
         volatility = returns.std() * np.sqrt(252)
         beta = stock_data.get('beta', 1.0)
 
-        risk_free_rate = 0.045
-        excess_returns = returns - risk_free_rate / 252
+        # F-09-008: use the engine-level risk-free rate (synced with
+        # FundamentalAnalysisEngine.risk_free_rate) instead of a local
+        # 0.045 constant.
+        excess_returns = returns - self.risk_free_rate / 252
         sharpe_ratio = (
             (excess_returns.mean() * 252) / (returns.std() * np.sqrt(252))
             if returns.std() > 0
@@ -520,7 +550,10 @@ class RecommendationEngine:
         )
         catalysts = find_catalysts(stock_data, sentiment_analysis, fundamental_analysis)
 
-        position_sizing = calculate_position_sizing(confidence, risk_metrics, action)
+        position_sizing = calculate_position_sizing(
+            confidence, risk_metrics, action,
+            portfolio_size=self.portfolio_size,  # F-09-009
+        )
 
         priority = calculate_priority(risk_adjusted_score, confidence, opportunities)
 
@@ -590,7 +623,10 @@ class RecommendationEngine:
         return find_catalysts(stock_data, sentiment, fundamental)
 
     def _calculate_position_sizing(self, confidence, risk_metrics, action):
-        return calculate_position_sizing(confidence, risk_metrics, action)
+        return calculate_position_sizing(
+            confidence, risk_metrics, action,
+            portfolio_size=self.portfolio_size,  # F-09-009
+        )
 
     def _calculate_priority(self, score, confidence, opportunities):
         return calculate_priority(score, confidence, opportunities)
@@ -602,7 +638,10 @@ class RecommendationEngine:
         return rank_recommendations(recommendations)
 
     async def _optimize_recommendations(self, recommendations, risk_tolerance):
-        return await optimize_recommendations(recommendations, risk_tolerance, self.portfolio_optimizer)
+        return await optimize_recommendations(
+            recommendations, risk_tolerance, self.portfolio_optimizer,
+            portfolio_size=self.portfolio_size,  # F-09-009
+        )
 
     # Also keep the generate_report helper using summary directly
 

--- a/backend/analytics/recommendation_ranking.py
+++ b/backend/analytics/recommendation_ranking.py
@@ -110,8 +110,15 @@ async def optimize_recommendations(
     recommendations: List[StockRecommendation],
     risk_tolerance: str,
     portfolio_optimizer: "PortfolioOptimizer",
+    portfolio_size: float = 100_000,
 ) -> List[StockRecommendation]:
-    """Apply portfolio optimization to a ranked list of recommendations."""
+    """Apply portfolio optimization to a ranked list of recommendations.
+
+    F-09-009: ``portfolio_size`` is now a parameter (default $100k for
+    backward compatibility) instead of a hardcoded constant. Callers
+    should pass the operator-configured value so position-size dollars
+    track the actual portfolio.
+    """
     if len(recommendations) < 2:
         return recommendations
 
@@ -144,7 +151,7 @@ async def optimize_recommendations(
     for rec, weight in zip(recommendations, optimal_weights):
         if weight > 0.01:
             rec.recommended_allocation = weight
-            rec.max_position_size = weight * 100_000
+            rec.max_position_size = weight * portfolio_size
             optimized_recs.append(rec)
 
     optimized_recs.sort(key=lambda x: x.recommended_allocation, reverse=True)

--- a/backend/analytics/recommendation_scoring.py
+++ b/backend/analytics/recommendation_scoring.py
@@ -371,9 +371,15 @@ def find_catalysts(
 def calculate_position_sizing(
     confidence: float,
     risk_metrics: Dict,
-    action: RecommendationAction
+    action: RecommendationAction,
+    portfolio_size: float = 100_000,
 ) -> Dict[str, float]:
-    """Calculate recommended position sizing via a safety-adjusted Kelly Criterion."""
+    """Calculate recommended position sizing via a safety-adjusted Kelly Criterion.
+
+    F-09-009: ``portfolio_size`` is now a parameter (default $100k for
+    backward compatibility) so the dollar position size scales with
+    the operator-configured portfolio.
+    """
     p = confidence
     q = 1 - p
     b = 2  # Assume 2:1 reward/risk ratio
@@ -395,7 +401,6 @@ def calculate_position_sizing(
     allocation = min(safe_kelly * risk_adjustment, max_allocation)
     allocation = max(0.0, allocation)
 
-    portfolio_size = 100_000
     max_size = allocation * portfolio_size
 
     return {

--- a/backend/analytics/recommendation_types.py
+++ b/backend/analytics/recommendation_types.py
@@ -76,6 +76,11 @@ class StockRecommendation:
     recommended_allocation: float  # Percentage of portfolio
     max_position_size: float       # Dollar amount
 
+    # Ranking score — composite ordering metric assigned by the
+    # ranking layer; consumers expect it on every recommendation dict
+    # but it was previously absent from the dataclass (F-09-004).
+    ranking_score: float = field(default=0.0)
+
     def to_dict(self) -> Dict:
         """Convert to dictionary for storage."""
         return {
@@ -105,4 +110,5 @@ class StockRecommendation:
             'valid_until': self.valid_until.isoformat(),
             'recommended_allocation': self.recommended_allocation,
             'max_position_size': self.max_position_size,
+            'ranking_score': self.ranking_score,
         }

--- a/backend/analytics/sentiment_analysis.py
+++ b/backend/analytics/sentiment_analysis.py
@@ -398,35 +398,85 @@ class SentimentAnalysisEngine:
         return top_words
     
     async def get_news_sentiment(self, ticker: str, limit: int = 10) -> SentimentResult:
+        """Get sentiment from news articles via SmartDataFetcher.
+
+        F-09-006: previously a hardcoded neutral placeholder. Now that
+        F-05-004 has wired SmartDataFetcher to real clients
+        (Finnhub.get_news), this delegates to that surface and runs the
+        existing analyze_stock_sentiment batch path over the headline +
+        summary text. Returns a neutral fallback (with a warning logged)
+        only when the fetcher reports ``source: "unavailable"``.
         """
-        Get sentiment from news articles (simplified - returns neutral for now)
-        In a full implementation, this would fetch and analyze real news data
-        """
-        # Placeholder implementation
-        return SentimentResult(
-            score=0.0,
-            confidence=0.5,
-            label='neutral',
-            breakdown={'source': 'news_placeholder'},
-            keywords=[ticker.lower(), 'news'],
-            sources_analyzed=0,
-            timestamp=datetime.now(timezone.utc)
-        )
-    
+        try:
+            from backend.data_ingestion.smart_data_fetcher import get_smart_fetcher
+            fetcher = await get_smart_fetcher()
+            payload = await fetcher.fetch_stock_data(ticker, "news")
+        except Exception as e:  # noqa: BLE001
+            logger.warning(f"get_news_sentiment: fetcher error for {ticker}: {e}")
+            payload = None
+
+        articles = (payload or {}).get("articles", []) if payload else []
+        if not articles or (payload or {}).get("source") == "unavailable":
+            logger.warning(
+                f"get_news_sentiment: no news available for {ticker}; "
+                "returning neutral fallback"
+            )
+            return SentimentResult(
+                score=0.0,
+                confidence=0.0,
+                label='neutral',
+                breakdown={'source': 'news_unavailable'},
+                keywords=[ticker.lower(), 'news'],
+                sources_analyzed=0,
+                timestamp=datetime.now(timezone.utc),
+            )
+
+        texts: List[str] = []
+        for art in articles[:limit]:
+            headline = art.get("headline") or art.get("title") or ""
+            summary = art.get("summary") or art.get("description") or ""
+            combined = f"{headline} {summary}".strip()
+            if combined:
+                texts.append(combined)
+
+        if not texts:
+            return SentimentResult(
+                score=0.0,
+                confidence=0.0,
+                label='neutral',
+                breakdown={'source': 'news_empty_texts'},
+                keywords=[ticker.lower(), 'news'],
+                sources_analyzed=0,
+                timestamp=datetime.now(timezone.utc),
+            )
+
+        return await self.analyze_stock_sentiment(ticker, texts)
+
     async def get_social_sentiment(self, ticker: str, limit: int = 50) -> SentimentResult:
+        """Social-media sentiment is not yet wired.
+
+        F-09-006: SmartDataFetcher does not yet expose a social-media
+        endpoint (Reddit/X/StockTwits ingestion is out of scope for
+        the 2026-04 audit cycle). We log a loud warning and return a
+        zero-confidence neutral sentinel so downstream averaging code
+        does not crash, but consumers must check ``confidence == 0.0``
+        / ``sources_analyzed == 0`` to detect the no-data path.
         """
-        Get sentiment from social media (simplified - returns neutral for now)
-        In a full implementation, this would fetch and analyze real social media data
-        """
-        # Placeholder implementation
+        logger.warning(
+            "get_social_sentiment is not implemented (F-09-006): "
+            "no social-media ingestion source. Returning neutral "
+            "sentinel for ticker=%s. Implement after social ingestion "
+            "lands.",
+            ticker,
+        )
         return SentimentResult(
             score=0.0,
-            confidence=0.5,
+            confidence=0.0,  # was 0.5 — that was a lie
             label='neutral',
-            breakdown={'source': 'social_placeholder'},
+            breakdown={'source': 'social_unimplemented'},
             keywords=[ticker.lower(), 'social'],
             sources_analyzed=0,
-            timestamp=datetime.now(timezone.utc)
+            timestamp=datetime.now(timezone.utc),
         )
     
     async def analyze_comprehensive_sentiment(self, ticker: str) -> Dict[str, Any]:

--- a/backend/analytics/statistical/cointegration_analyzer.py
+++ b/backend/analytics/statistical/cointegration_analyzer.py
@@ -16,9 +16,16 @@ logger = logging.getLogger(__name__)
 
 
 class CointegrationMethod(Enum):
-    """Methods for cointegration testing."""
+    """Methods for cointegration testing.
+
+    F-09-007: ``JOHANSEN`` was removed because the previous
+    ``_johansen_test`` silently fell back to Engle-Granger — callers
+    selecting JOHANSEN believed they were getting a different
+    statistical test. If real Johansen support is needed later,
+    implement via ``statsmodels.tsa.vector_ar.vecm.coint_johansen`` and
+    add the enum value back.
+    """
     ENGLE_GRANGER = "engle_granger"
-    JOHANSEN = "johansen"
 
 
 @dataclass
@@ -93,8 +100,15 @@ class CointegrationAnalyzer:
         """
         if method == CointegrationMethod.ENGLE_GRANGER:
             return self._engle_granger_test(series1, series2)
-        else:
-            return self._johansen_test(series1, series2)
+        # F-09-007: only ENGLE_GRANGER is supported. Fail loud rather
+        # than silently routing to a different test (the legacy
+        # behavior).
+        raise NotImplementedError(
+            f"Unsupported cointegration method: {method!r}. "
+            "Only CointegrationMethod.ENGLE_GRANGER is implemented; "
+            "Johansen was removed because the prior implementation "
+            "silently delegated to Engle-Granger."
+        )
 
     def _engle_granger_test(
         self,
@@ -185,17 +199,11 @@ class CointegrationAnalyzer:
             half_life=half_life
         )
 
-    def _johansen_test(
-        self,
-        series1: pd.Series,
-        series2: pd.Series
-    ) -> CointegrationResult:
-        """
-        Perform Johansen cointegration test.
-        (Simplified implementation - for full version use statsmodels)
-        """
-        # For now, fall back to Engle-Granger
-        return self._engle_granger_test(series1, series2)
+    # F-09-007: _johansen_test removed — it silently returned
+    # Engle-Granger results, which gave callers false confidence that
+    # they had run a different test. If Johansen is ever needed,
+    # implement properly via statsmodels.tsa.vector_ar.vecm.coint_johansen
+    # and add the enum value back.
 
     def _calculate_half_life(self, spread: np.ndarray) -> float:
         """Calculate mean reversion half-life using OLS."""

--- a/backend/data_ingestion/sec_edgar_client.py
+++ b/backend/data_ingestion/sec_edgar_client.py
@@ -8,6 +8,7 @@ import aiohttp
 from typing import Dict, Optional, List, Any
 from datetime import datetime, timedelta, timezone
 import logging
+import os
 import xml.etree.ElementTree as ET
 from bs4 import BeautifulSoup
 import re
@@ -25,10 +26,23 @@ class SECEdgarClient(BaseAPIClient):
     """
     
     def __init__(self):
-        # SEC requires user agent with contact info
+        # SEC requires a User-Agent with real contact info; placeholder
+        # addresses (``contact@example.com``) get the platform throttled
+        # or banned from sec.gov. Operators must set
+        # ``SEC_EDGAR_CONTACT_EMAIL`` to a real, monitored mailbox
+        # (F-05-006).
+        contact_email = os.getenv("SEC_EDGAR_CONTACT_EMAIL", "").strip()
+        if not contact_email or "example.com" in contact_email.lower():
+            raise RuntimeError(
+                "SEC_EDGAR_CONTACT_EMAIL must be set to a real contact email "
+                "address (not example.com). SEC EDGAR requires identifying "
+                "contact info in the User-Agent header and will rate-limit "
+                "or ban clients that omit it."
+            )
+
         super().__init__("sec_edgar", api_key=None)
         self.headers = {
-            'User-Agent': 'InvestmentAnalysisPlatform/1.0 (contact@example.com)'
+            'User-Agent': f'InvestmentAnalysisPlatform/1.0 ({contact_email})'
         }
         self.cik_map = {}  # Cache CIK mappings
     

--- a/backend/data_ingestion/smart_data_fetcher.py
+++ b/backend/data_ingestion/smart_data_fetcher.py
@@ -3,46 +3,87 @@ Smart Data Fetcher - Intelligent data fetching with caching and rate limiting.
 
 This module provides a unified interface for fetching stock data from
 multiple sources with intelligent caching and rate limit management.
+
+F-05-004 (audit 2026-04, G2a sub-theme C step 25): the previous
+implementation returned hardcoded zeros / empty lists from every
+``_fetch_*`` method, which silently degraded any downstream analytics
+that consumed it. Each fetcher now delegates to the existing real
+clients (``FinnhubClient``, ``AlphaVantageClient``, ``PolygonClient``,
+``SECEdgarClient``) and only falls back to a ``source: "unavailable"``
+sentinel when every client either failed or is not configured.
 """
 
 import logging
-from typing import Dict, Any, List, Optional
-from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional, TYPE_CHECKING
+from datetime import datetime, timezone
+
+if TYPE_CHECKING:
+    # ``BaseAPIClient`` is used only for type annotations. Importing it
+    # at runtime would drag in the backend.config chain (Pydantic
+    # Settings, secrets manager, etc.) which is too heavy for the
+    # surface this module presents.
+    from backend.data_ingestion.base_client import BaseAPIClient
 
 logger = logging.getLogger(__name__)
 
 
 class SmartDataFetcher:
-    """
-    Smart data fetcher that combines multiple data sources with intelligent caching.
-    
-    This class provides a unified interface for fetching various types of stock
-    data while managing API rate limits and implementing intelligent caching.
-    """
-    
+    """Unified data fetcher backed by real API clients with graceful fallback."""
+
     def __init__(self, cache_manager=None, rate_limiter=None):
-        """
-        Initialize the smart data fetcher.
-        
+        """Initialize the smart data fetcher.
+
         Args:
-            cache_manager: Optional cache manager for caching data
-            rate_limiter: Optional rate limiter for managing API calls
+            cache_manager: Optional cache manager for caching data.
+            rate_limiter: Optional rate limiter for managing API calls.
         """
         self.cache_manager = cache_manager
         self.rate_limiter = rate_limiter
-        self._clients: Dict[str, Any] = {}
-        
+        # ``None`` values are cached for clients that failed to
+        # initialize (e.g. missing API key) so we don't retry them
+        # on every fetch.
+        self._clients: Dict[str, Optional["BaseAPIClient"]] = {}
+
+    # ------------------------------------------------------------------
+    # Client lazy init
+    # ------------------------------------------------------------------
+
+    def _get_client(self, name: str) -> Optional["BaseAPIClient"]:
+        """Lazily build the requested client, swallowing config errors.
+
+        Returns ``None`` if the client is missing required configuration
+        (e.g. unset API key) so callers can move on to the next source.
+        """
+        if name in self._clients:
+            return self._clients[name]
+
+        client: Optional["BaseAPIClient"] = None
+        try:
+            if name == "finnhub":
+                from backend.data_ingestion.finnhub_client import FinnhubClient
+                client = FinnhubClient()
+            elif name == "alpha_vantage":
+                from backend.data_ingestion.alpha_vantage_client import AlphaVantageClient
+                client = AlphaVantageClient()
+            elif name == "polygon":
+                from backend.data_ingestion.polygon_client import PolygonClient
+                client = PolygonClient()
+            elif name == "sec_edgar":
+                from backend.data_ingestion.sec_edgar_client import SECEdgarClient
+                client = SECEdgarClient()
+        except Exception as e:  # noqa: BLE001 - log and degrade
+            logger.warning(f"Smart fetcher: client {name!r} unavailable: {e}")
+            client = None
+
+        self._clients[name] = client
+        return client
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
     async def fetch_stock_data(self, ticker: str, data_type: str) -> Dict[str, Any]:
-        """
-        Fetch stock data with intelligent source selection.
-        
-        Args:
-            ticker: Stock ticker symbol
-            data_type: Type of data to fetch (price, fundamentals, news, etc.)
-            
-        Returns:
-            Dictionary containing the requested data
-        """
+        """Fetch stock data with intelligent source selection."""
         data_fetchers = {
             "price": self._fetch_price_data,
             "fundamentals": self._fetch_fundamentals,
@@ -51,86 +92,195 @@ class SmartDataFetcher:
             "earnings": self._fetch_earnings,
             "sentiment": self._fetch_sentiment,
         }
-        
         fetcher = data_fetchers.get(data_type, self._fetch_generic)
         return await fetcher(ticker)
-        
-    async def _fetch_price_data(self, ticker: str) -> Dict[str, Any]:
-        """Fetch current price data."""
-        return {
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _unavailable(self, ticker: str, **extra: Any) -> Dict[str, Any]:
+        """Sentinel response when no source can satisfy the request."""
+        payload = {
             "ticker": ticker,
-            "price": 0.0,
-            "change": 0.0,
-            "change_percent": 0.0,
-            "volume": 0,
+            "source": "unavailable",
             "timestamp": datetime.now(timezone.utc).isoformat(),
-            "source": "mock"
         }
-        
+        payload.update(extra)
+        return payload
+
+    async def _try_client(self, name: str, method: str, *args, **kwargs):
+        """Call ``client.method(*args, **kwargs)`` if the client exists."""
+        client = self._get_client(name)
+        if client is None:
+            return None
+        func = getattr(client, method, None)
+        if func is None:
+            return None
+        try:
+            return await func(*args, **kwargs)
+        except Exception as e:  # noqa: BLE001 - log and try next source
+            logger.warning(f"Smart fetcher: {name}.{method}({args!r}) failed: {e}")
+            return None
+
+    # ------------------------------------------------------------------
+    # Concrete fetchers
+    # ------------------------------------------------------------------
+
+    async def _fetch_price_data(self, ticker: str) -> Dict[str, Any]:
+        """Fetch current price data; tries finnhub → alpha_vantage → polygon."""
+        quote = await self._try_client("finnhub", "get_quote", ticker)
+        if quote:
+            return {
+                "ticker": ticker,
+                "price": quote.get("c") or quote.get("current_price") or 0.0,
+                "change": quote.get("d") or 0.0,
+                "change_percent": quote.get("dp") or 0.0,
+                "volume": quote.get("v") or 0,
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "source": "finnhub",
+            }
+
+        av_quote = await self._try_client("alpha_vantage", "get_quote", ticker)
+        if av_quote:
+            return {
+                "ticker": ticker,
+                "price": av_quote.get("price", 0.0),
+                "change": av_quote.get("change", 0.0),
+                "change_percent": av_quote.get("change_percent", 0.0),
+                "volume": av_quote.get("volume", 0),
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "source": "alpha_vantage",
+            }
+
+        last_quote = await self._try_client("polygon", "get_last_quote", ticker)
+        if last_quote:
+            return {
+                "ticker": ticker,
+                "price": last_quote.get("last_price", 0.0),
+                "change": 0.0,
+                "change_percent": 0.0,
+                "volume": last_quote.get("volume", 0),
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "source": "polygon",
+            }
+
+        return self._unavailable(
+            ticker,
+            price=0.0,
+            change=0.0,
+            change_percent=0.0,
+            volume=0,
+        )
+
     async def _fetch_fundamentals(self, ticker: str) -> Dict[str, Any]:
-        """Fetch fundamental data."""
-        return {
-            "ticker": ticker,
-            "pe_ratio": 0.0,
-            "market_cap": 0,
-            "eps": 0.0,
-            "dividend_yield": 0.0,
-            "source": "mock"
-        }
-        
+        """Fetch fundamental metrics; finnhub basic_financials → alpha_vantage overview."""
+        fin = await self._try_client("finnhub", "get_basic_financials", ticker)
+        if fin and isinstance(fin, dict):
+            metrics = fin.get("metric", {}) or {}
+            return {
+                "ticker": ticker,
+                "pe_ratio": metrics.get("peNormalizedAnnual") or metrics.get("peBasicExclExtraTTM", 0.0),
+                "market_cap": metrics.get("marketCapitalization", 0),
+                "eps": metrics.get("epsAnnual") or metrics.get("epsBasicExclExtraItemsTTM", 0.0),
+                "dividend_yield": metrics.get("dividendYieldIndicatedAnnual", 0.0),
+                "source": "finnhub",
+            }
+
+        overview = await self._try_client("alpha_vantage", "get_company_overview", ticker)
+        if overview:
+            return {
+                "ticker": ticker,
+                "pe_ratio": float(overview.get("PERatio", 0.0) or 0.0),
+                "market_cap": int(float(overview.get("MarketCapitalization", 0) or 0)),
+                "eps": float(overview.get("EPS", 0.0) or 0.0),
+                "dividend_yield": float(overview.get("DividendYield", 0.0) or 0.0),
+                "source": "alpha_vantage",
+            }
+
+        return self._unavailable(
+            ticker, pe_ratio=0.0, market_cap=0, eps=0.0, dividend_yield=0.0
+        )
+
     async def _fetch_news(self, ticker: str) -> Dict[str, Any]:
-        """Fetch news data."""
-        return {
-            "ticker": ticker,
-            "articles": [],
-            "source": "mock"
-        }
-        
+        """Fetch news headlines; finnhub get_news is the canonical source."""
+        articles = await self._try_client("finnhub", "get_news", ticker)
+        if articles is not None:
+            return {"ticker": ticker, "articles": articles, "source": "finnhub"}
+        return self._unavailable(ticker, articles=[])
+
     async def _fetch_financials(self, ticker: str) -> Dict[str, Any]:
-        """Fetch financial statements."""
-        return {
-            "ticker": ticker,
-            "income_statement": {},
-            "balance_sheet": {},
-            "cash_flow": {},
-            "source": "mock"
-        }
-        
+        """Fetch financial statements; SEC EDGAR is the authoritative source."""
+        sec = self._get_client("sec_edgar")
+        if sec is not None and hasattr(sec, "get_company_facts"):
+            try:
+                facts = await sec.get_company_facts(ticker)
+                if facts:
+                    return {"ticker": ticker, **facts, "source": "sec_edgar"}
+            except Exception as e:  # noqa: BLE001
+                logger.warning(f"SEC EDGAR facts for {ticker} failed: {e}")
+
+        return self._unavailable(
+            ticker,
+            income_statement={},
+            balance_sheet={},
+            cash_flow={},
+        )
+
     async def _fetch_earnings(self, ticker: str) -> Dict[str, Any]:
-        """Fetch earnings data."""
-        return {
-            "ticker": ticker,
-            "next_earnings_date": None,
-            "eps_history": [],
-            "source": "mock"
-        }
-        
+        """Fetch earnings data via Finnhub recommendations / price targets."""
+        recs = await self._try_client("finnhub", "get_recommendations", ticker)
+        target = await self._try_client("finnhub", "get_price_target", ticker)
+        if recs is not None or target is not None:
+            return {
+                "ticker": ticker,
+                "recommendations": recs or [],
+                "price_target": target or {},
+                "source": "finnhub",
+            }
+        return self._unavailable(
+            ticker, next_earnings_date=None, eps_history=[],
+        )
+
     async def _fetch_sentiment(self, ticker: str) -> Dict[str, Any]:
-        """Fetch sentiment data."""
-        return {
-            "ticker": ticker,
-            "sentiment_score": 0.0,
-            "sentiment_label": "neutral",
-            "source": "mock"
-        }
-        
+        """Fetch sentiment via Finnhub."""
+        sent = await self._try_client("finnhub", "get_sentiment", ticker)
+        if sent:
+            return {
+                "ticker": ticker,
+                "sentiment_score": sent.get("sentiment", 0.0),
+                "sentiment_label": sent.get("label", "neutral"),
+                "source": "finnhub",
+            }
+        return self._unavailable(
+            ticker, sentiment_score=0.0, sentiment_label="neutral",
+        )
+
     async def _fetch_generic(self, ticker: str) -> Dict[str, Any]:
-        """Fetch generic data as fallback."""
-        return {
-            "ticker": ticker,
-            "data": {},
-            "source": "mock"
-        }
-        
+        """Unknown data_type — explicit unavailability."""
+        return self._unavailable(ticker, data={})
+
+    # ------------------------------------------------------------------
+    # Diagnostics
+    # ------------------------------------------------------------------
+
     async def get_available_sources(self) -> List[str]:
-        """Get list of available data sources."""
-        return ["alpha_vantage", "finnhub", "polygon", "sec_edgar"]
-        
+        """Get list of available data sources (only those that initialized)."""
+        return [
+            name
+            for name in ("alpha_vantage", "finnhub", "polygon", "sec_edgar")
+            if self._get_client(name) is not None
+        ]
+
     async def get_source_status(self) -> Dict[str, Dict[str, Any]]:
         """Get status of all data sources."""
+        available = await self.get_available_sources()
         return {
-            source: {"available": True, "rate_limit_remaining": 100}
-            for source in await self.get_available_sources()
+            name: {
+                "available": name in available,
+                "rate_limit_remaining": None,
+            }
+            for name in ("alpha_vantage", "finnhub", "polygon", "sec_edgar")
         }
 
 

--- a/backend/etl/cache_storage.py
+++ b/backend/etl/cache_storage.py
@@ -12,6 +12,7 @@ import json
 import logging
 import os
 import sqlite3
+from contextlib import closing
 import threading
 from datetime import datetime, timedelta
 from typing import Any, Dict, Optional
@@ -199,75 +200,71 @@ class DiskTierCache:
 
     def _init_index_db(self):
         """Initialize SQLite index database"""
-        conn = sqlite3.connect(self.index_db_path)
-        cursor = conn.cursor()
+        with closing(sqlite3.connect(self.index_db_path)) as conn:
+            cursor = conn.cursor()
 
-        cursor.execute("""
-            CREATE TABLE IF NOT EXISTS cache_index (
-                key TEXT PRIMARY KEY,
-                file_path TEXT NOT NULL,
-                created_at TEXT NOT NULL,
-                expires_at TEXT NOT NULL,
-                access_count INTEGER DEFAULT 0,
-                last_accessed TEXT,
-                size_bytes INTEGER DEFAULT 0,
-                compression_method TEXT DEFAULT 'gzip',
-                compression_ratio REAL DEFAULT 1.0
-            )
-        """)
+            cursor.execute("""
+                CREATE TABLE IF NOT EXISTS cache_index (
+                    key TEXT PRIMARY KEY,
+                    file_path TEXT NOT NULL,
+                    created_at TEXT NOT NULL,
+                    expires_at TEXT NOT NULL,
+                    access_count INTEGER DEFAULT 0,
+                    last_accessed TEXT,
+                    size_bytes INTEGER DEFAULT 0,
+                    compression_method TEXT DEFAULT 'gzip',
+                    compression_ratio REAL DEFAULT 1.0
+                )
+            """)
 
-        cursor.execute("CREATE INDEX IF NOT EXISTS idx_expires_at ON cache_index(expires_at)")
-        cursor.execute("CREATE INDEX IF NOT EXISTS idx_last_accessed ON cache_index(last_accessed)")
+            cursor.execute("CREATE INDEX IF NOT EXISTS idx_expires_at ON cache_index(expires_at)")
+            cursor.execute("CREATE INDEX IF NOT EXISTS idx_last_accessed ON cache_index(last_accessed)")
 
-        conn.commit()
-        conn.close()
+            conn.commit()
 
     def get(self, key: str) -> Optional[Any]:
         """Get item from disk cache"""
         with self.lock:
-            conn = sqlite3.connect(self.index_db_path)
-            cursor = conn.cursor()
-
-            try:
-                cursor.execute("""
-                    SELECT file_path, compression_method, expires_at
-                    FROM cache_index
-                    WHERE key = ? AND expires_at > ?
-                """, (key, datetime.now().isoformat()))
-
-                result = cursor.fetchone()
-                if not result:
-                    return None
-
-                file_path, compression_method, _ = result
+            with closing(sqlite3.connect(self.index_db_path)) as conn:
+                cursor = conn.cursor()
 
                 try:
-                    with open(file_path, 'rb') as f:
-                        compressed_data = f.read()
-
-                    data = self.compression_manager.decompress_data(compressed_data, compression_method)
-
                     cursor.execute("""
-                        UPDATE cache_index
-                        SET access_count = access_count + 1, last_accessed = ?
-                        WHERE key = ?
-                    """, (datetime.now().isoformat(), key))
+                        SELECT file_path, compression_method, expires_at
+                        FROM cache_index
+                        WHERE key = ? AND expires_at > ?
+                    """, (key, datetime.now().isoformat()))
 
-                    conn.commit()
-                    return data
+                    result = cursor.fetchone()
+                    if not result:
+                        return None
 
-                except (IOError, OSError) as e:
-                    logger.warning(f"Failed to read cache file {file_path}: {e}")
-                    cursor.execute("DELETE FROM cache_index WHERE key = ?", (key,))
-                    conn.commit()
+                    file_path, compression_method, _ = result
+
+                    try:
+                        with open(file_path, 'rb') as f:
+                            compressed_data = f.read()
+
+                        data = self.compression_manager.decompress_data(compressed_data, compression_method)
+
+                        cursor.execute("""
+                            UPDATE cache_index
+                            SET access_count = access_count + 1, last_accessed = ?
+                            WHERE key = ?
+                        """, (datetime.now().isoformat(), key))
+
+                        conn.commit()
+                        return data
+
+                    except (IOError, OSError) as e:
+                        logger.warning(f"Failed to read cache file {file_path}: {e}")
+                        cursor.execute("DELETE FROM cache_index WHERE key = ?", (key,))
+                        conn.commit()
+                        return None
+
+                except Exception as e:
+                    logger.error(f"Disk cache get error for {key}: {e}")
                     return None
-
-            except Exception as e:
-                logger.error(f"Disk cache get error for {key}: {e}")
-                return None
-
-            finally:
-                conn.close()
 
     def set(self, key: str, data: Any, ttl_hours: Optional[int] = None) -> bool:
         """Set item in disk cache"""
@@ -287,19 +284,18 @@ class DiskTierCache:
 
                 expires_at = datetime.now() + timedelta(hours=ttl_hours or self.ttl_hours)
 
-                conn = sqlite3.connect(self.index_db_path)
-                cursor = conn.cursor()
+                with closing(sqlite3.connect(self.index_db_path)) as conn:
+                    cursor = conn.cursor()
 
-                cursor.execute("""
-                    INSERT OR REPLACE INTO cache_index
-                    (key, file_path, created_at, expires_at, size_bytes,
-                     compression_method, compression_ratio, last_accessed)
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-                """, (key, file_path, datetime.now().isoformat(), expires_at.isoformat(),
-                      len(compressed_data), 'gzip', compression_ratio, datetime.now().isoformat()))
+                    cursor.execute("""
+                        INSERT OR REPLACE INTO cache_index
+                        (key, file_path, created_at, expires_at, size_bytes,
+                         compression_method, compression_ratio, last_accessed)
+                        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                    """, (key, file_path, datetime.now().isoformat(), expires_at.isoformat(),
+                          len(compressed_data), 'gzip', compression_ratio, datetime.now().isoformat()))
 
-                conn.commit()
-                conn.close()
+                    conn.commit()
 
                 return True
 
@@ -310,132 +306,120 @@ class DiskTierCache:
     def delete(self, key: str) -> bool:
         """Delete item from disk cache"""
         with self.lock:
-            conn = sqlite3.connect(self.index_db_path)
-            cursor = conn.cursor()
+            with closing(sqlite3.connect(self.index_db_path)) as conn:
+                cursor = conn.cursor()
 
-            try:
-                cursor.execute("SELECT file_path FROM cache_index WHERE key = ?", (key,))
-                result = cursor.fetchone()
+                try:
+                    cursor.execute("SELECT file_path FROM cache_index WHERE key = ?", (key,))
+                    result = cursor.fetchone()
 
-                if result:
-                    file_path = result[0]
+                    if result:
+                        file_path = result[0]
 
-                    try:
-                        if os.path.exists(file_path):
-                            os.unlink(file_path)
-                    except OSError as e:
-                        logger.warning(f"Failed to delete cache file {file_path}: {e}")
+                        try:
+                            if os.path.exists(file_path):
+                                os.unlink(file_path)
+                        except OSError as e:
+                            logger.warning(f"Failed to delete cache file {file_path}: {e}")
 
-                    cursor.execute("DELETE FROM cache_index WHERE key = ?", (key,))
-                    conn.commit()
+                        cursor.execute("DELETE FROM cache_index WHERE key = ?", (key,))
+                        conn.commit()
 
-                    return True
+                        return True
 
-                return False
+                    return False
 
-            except Exception as e:
-                logger.error(f"Disk cache delete error for {key}: {e}")
-                return False
-
-            finally:
-                conn.close()
+                except Exception as e:
+                    logger.error(f"Disk cache delete error for {key}: {e}")
+                    return False
 
     def _ensure_disk_space(self, needed_bytes: int) -> bool:
         """Ensure sufficient disk space by cleaning up if needed"""
-        conn = sqlite3.connect(self.index_db_path)
-        cursor = conn.cursor()
+        with closing(sqlite3.connect(self.index_db_path)) as conn:
+            cursor = conn.cursor()
 
-        try:
-            cursor.execute("SELECT SUM(size_bytes) FROM cache_index")
-            current_usage = cursor.fetchone()[0] or 0
+            try:
+                cursor.execute("SELECT SUM(size_bytes) FROM cache_index")
+                current_usage = cursor.fetchone()[0] or 0
 
-            if current_usage + needed_bytes <= self.max_size_bytes:
-                return True
+                if current_usage + needed_bytes <= self.max_size_bytes:
+                    return True
 
-            bytes_to_free = (current_usage + needed_bytes) - self.max_size_bytes
+                bytes_to_free = (current_usage + needed_bytes) - self.max_size_bytes
 
-            cursor.execute("""
-                SELECT key, size_bytes
-                FROM cache_index
-                ORDER BY last_accessed ASC
-            """)
+                cursor.execute("""
+                    SELECT key, size_bytes
+                    FROM cache_index
+                    ORDER BY last_accessed ASC
+                """)
 
-            freed_bytes = 0
-            for key, size_bytes in cursor.fetchall():
-                if freed_bytes >= bytes_to_free:
-                    break
+                freed_bytes = 0
+                for key, size_bytes in cursor.fetchall():
+                    if freed_bytes >= bytes_to_free:
+                        break
 
-                self.delete(key)
-                freed_bytes += size_bytes
+                    self.delete(key)
+                    freed_bytes += size_bytes
 
-            return freed_bytes >= bytes_to_free
+                return freed_bytes >= bytes_to_free
 
-        except Exception as e:
-            logger.error(f"Error ensuring disk space: {e}")
-            return False
-
-        finally:
-            conn.close()
+            except Exception as e:
+                logger.error(f"Error ensuring disk space: {e}")
+                return False
 
     def _cleanup_expired(self):
         """Remove expired cache entries"""
-        conn = sqlite3.connect(self.index_db_path)
-        cursor = conn.cursor()
+        with closing(sqlite3.connect(self.index_db_path)) as conn:
+            cursor = conn.cursor()
 
-        try:
-            cursor.execute("""
-                SELECT key, file_path
-                FROM cache_index
-                WHERE expires_at < ?
-            """, (datetime.now().isoformat(),))
+            try:
+                cursor.execute("""
+                    SELECT key, file_path
+                    FROM cache_index
+                    WHERE expires_at < ?
+                """, (datetime.now().isoformat(),))
 
-            expired_entries = cursor.fetchall()
+                expired_entries = cursor.fetchall()
 
-            for key, file_path in expired_entries:
-                try:
-                    if os.path.exists(file_path):
-                        os.unlink(file_path)
-                except OSError:
-                    pass
+                for key, file_path in expired_entries:
+                    try:
+                        if os.path.exists(file_path):
+                            os.unlink(file_path)
+                    except OSError:
+                        pass
 
-            cursor.execute("DELETE FROM cache_index WHERE expires_at < ?",
-                           (datetime.now().isoformat(),))
+                cursor.execute("DELETE FROM cache_index WHERE expires_at < ?",
+                               (datetime.now().isoformat(),))
 
-            conn.commit()
+                conn.commit()
 
-            if expired_entries:
-                logger.info(f"Cleaned up {len(expired_entries)} expired cache entries")
+                if expired_entries:
+                    logger.info(f"Cleaned up {len(expired_entries)} expired cache entries")
 
-        except Exception as e:
-            logger.error(f"Error during cache cleanup: {e}")
-
-        finally:
-            conn.close()
+            except Exception as e:
+                logger.error(f"Error during cache cleanup: {e}")
 
     def get_stats(self) -> Dict:
         """Get disk cache statistics"""
-        conn = sqlite3.connect(self.index_db_path)
-        cursor = conn.cursor()
+        with closing(sqlite3.connect(self.index_db_path)) as conn:
+            cursor = conn.cursor()
 
-        try:
-            cursor.execute("SELECT COUNT(*), SUM(size_bytes), AVG(compression_ratio) FROM cache_index")
-            count, total_size, avg_compression = cursor.fetchone()
+            try:
+                cursor.execute("SELECT COUNT(*), SUM(size_bytes), AVG(compression_ratio) FROM cache_index")
+                count, total_size, avg_compression = cursor.fetchone()
 
-            return {
-                'entries': count or 0,
-                'size_bytes': total_size or 0,
-                'size_mb': (total_size or 0) / (1024 * 1024),
-                'max_size_mb': self.max_size_bytes / (1024 * 1024),
-                'utilization': (total_size or 0) / self.max_size_bytes,
-                'avg_compression_ratio': avg_compression or 1.0,
-                'compression_saved_mb': (
-                    (total_size or 0) * (1 - (avg_compression or 1.0)) / (1024 * 1024)
-                )
-            }
+                return {
+                    'entries': count or 0,
+                    'size_bytes': total_size or 0,
+                    'size_mb': (total_size or 0) / (1024 * 1024),
+                    'max_size_mb': self.max_size_bytes / (1024 * 1024),
+                    'utilization': (total_size or 0) / self.max_size_bytes,
+                    'avg_compression_ratio': avg_compression or 1.0,
+                    'compression_saved_mb': (
+                        (total_size or 0) * (1 - (avg_compression or 1.0)) / (1024 * 1024)
+                    )
+                }
 
-        except Exception as e:
-            logger.error(f"Error getting disk cache stats: {e}")
-            return {}
-
-        finally:
-            conn.close()
+            except Exception as e:
+                logger.error(f"Error getting disk cache stats: {e}")
+                return {}

--- a/backend/etl/distributed_batch_processor.py
+++ b/backend/etl/distributed_batch_processor.py
@@ -8,6 +8,7 @@ import json
 import logging
 import os
 import sqlite3
+from contextlib import closing
 from datetime import datetime, timedelta
 from typing import List, Dict, Any, Optional, Tuple, Set
 from dataclasses import dataclass, asdict
@@ -96,51 +97,50 @@ class DistributedBatchProcessor:
     
     def _init_job_db(self):
         """Initialize job tracking database"""
-        conn = sqlite3.connect(self.job_db_path)
-        cursor = conn.cursor()
+        with closing(sqlite3.connect(self.job_db_path)) as conn:
+            cursor = conn.cursor()
         
-        cursor.execute("""
-            CREATE TABLE IF NOT EXISTS batch_jobs (
-                job_id TEXT PRIMARY KEY,
-                status TEXT NOT NULL,
-                priority INTEGER,
-                created_at TIMESTAMP,
-                started_at TIMESTAMP,
-                completed_at TIMESTAMP,
-                progress INTEGER DEFAULT 0,
-                total_tickers INTEGER,
-                successful_extractions INTEGER DEFAULT 0,
-                failed_extractions INTEGER DEFAULT 0,
-                error_message TEXT,
-                config_json TEXT
-            )
-        """)
+            cursor.execute("""
+                CREATE TABLE IF NOT EXISTS batch_jobs (
+                    job_id TEXT PRIMARY KEY,
+                    status TEXT NOT NULL,
+                    priority INTEGER,
+                    created_at TIMESTAMP,
+                    started_at TIMESTAMP,
+                    completed_at TIMESTAMP,
+                    progress INTEGER DEFAULT 0,
+                    total_tickers INTEGER,
+                    successful_extractions INTEGER DEFAULT 0,
+                    failed_extractions INTEGER DEFAULT 0,
+                    error_message TEXT,
+                    config_json TEXT
+                )
+            """)
         
-        cursor.execute("""
-            CREATE TABLE IF NOT EXISTS job_tickers (
-                job_id TEXT,
-                ticker TEXT,
-                status TEXT,
-                extraction_source TEXT,
-                extracted_at TIMESTAMP,
-                error_message TEXT,
-                FOREIGN KEY (job_id) REFERENCES batch_jobs (job_id)
-            )
-        """)
+            cursor.execute("""
+                CREATE TABLE IF NOT EXISTS job_tickers (
+                    job_id TEXT,
+                    ticker TEXT,
+                    status TEXT,
+                    extraction_source TEXT,
+                    extracted_at TIMESTAMP,
+                    error_message TEXT,
+                    FOREIGN KEY (job_id) REFERENCES batch_jobs (job_id)
+                )
+            """)
         
-        cursor.execute("""
-            CREATE TABLE IF NOT EXISTS processor_stats (
-                timestamp TIMESTAMP PRIMARY KEY,
-                total_jobs_running INTEGER,
-                tickers_per_minute REAL,
-                success_rate REAL,
-                avg_time_per_ticker REAL,
-                memory_usage_mb REAL
-            )
-        """)
+            cursor.execute("""
+                CREATE TABLE IF NOT EXISTS processor_stats (
+                    timestamp TIMESTAMP PRIMARY KEY,
+                    total_jobs_running INTEGER,
+                    tickers_per_minute REAL,
+                    success_rate REAL,
+                    avg_time_per_ticker REAL,
+                    memory_usage_mb REAL
+                )
+            """)
         
-        conn.commit()
-        conn.close()
+            conn.commit()
     
     def create_job(self, tickers: List[str], priority: int = 1, job_id: str = None) -> str:
         """Create a new batch job"""
@@ -190,36 +190,34 @@ class DistributedBatchProcessor:
     
     def _save_job_to_db(self, job: BatchJob):
         """Save job to database"""
-        conn = sqlite3.connect(self.job_db_path)
-        cursor = conn.cursor()
+        with closing(sqlite3.connect(self.job_db_path)) as conn:
+            cursor = conn.cursor()
         
-        cursor.execute("""
-            INSERT OR REPLACE INTO batch_jobs 
-            (job_id, status, priority, created_at, started_at, completed_at, 
-             progress, total_tickers, successful_extractions, failed_extractions, 
-             error_message, config_json)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-        """, (
-            job.job_id, job.status, job.priority,
-            job.created_at.isoformat() if job.created_at else None,
-            job.started_at.isoformat() if job.started_at else None,
-            job.completed_at.isoformat() if job.completed_at else None,
-            job.progress, job.total_tickers,
-            job.successful_extractions, job.failed_extractions,
-            job.error_message, json.dumps(asdict(self.config), default=str)
-        ))
+            cursor.execute("""
+                INSERT OR REPLACE INTO batch_jobs 
+                (job_id, status, priority, created_at, started_at, completed_at, 
+                 progress, total_tickers, successful_extractions, failed_extractions, 
+                 error_message, config_json)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """, (
+                job.job_id, job.status, job.priority,
+                job.created_at.isoformat() if job.created_at else None,
+                job.started_at.isoformat() if job.started_at else None,
+                job.completed_at.isoformat() if job.completed_at else None,
+                job.progress, job.total_tickers,
+                job.successful_extractions, job.failed_extractions,
+                job.error_message, json.dumps(asdict(self.config), default=str)
+            ))
         
-        conn.commit()
-        conn.close()
+            conn.commit()
     
     def _load_job_from_db(self, job_id: str) -> Optional[BatchJob]:
         """Load job from database"""
-        conn = sqlite3.connect(self.job_db_path)
-        cursor = conn.cursor()
+        with closing(sqlite3.connect(self.job_db_path)) as conn:
+            cursor = conn.cursor()
         
-        cursor.execute("SELECT * FROM batch_jobs WHERE job_id = ?", (job_id,))
-        row = cursor.fetchone()
-        conn.close()
+            cursor.execute("SELECT * FROM batch_jobs WHERE job_id = ?", (job_id,))
+            row = cursor.fetchone()
         
         if not row:
             return None
@@ -259,32 +257,31 @@ class DistributedBatchProcessor:
     
     def list_jobs(self, status_filter: str = None) -> List[Dict]:
         """List all jobs, optionally filtered by status"""
-        conn = sqlite3.connect(self.job_db_path)
-        cursor = conn.cursor()
+        with closing(sqlite3.connect(self.job_db_path)) as conn:
+            cursor = conn.cursor()
         
-        if status_filter:
-            cursor.execute(
-                "SELECT job_id, status, priority, progress, total_tickers, created_at FROM batch_jobs WHERE status = ? ORDER BY priority, created_at",
-                (status_filter,)
-            )
-        else:
-            cursor.execute(
-                "SELECT job_id, status, priority, progress, total_tickers, created_at FROM batch_jobs ORDER BY priority, created_at"
-            )
+            if status_filter:
+                cursor.execute(
+                    "SELECT job_id, status, priority, progress, total_tickers, created_at FROM batch_jobs WHERE status = ? ORDER BY priority, created_at",
+                    (status_filter,)
+                )
+            else:
+                cursor.execute(
+                    "SELECT job_id, status, priority, progress, total_tickers, created_at FROM batch_jobs ORDER BY priority, created_at"
+                )
         
-        jobs = []
-        for row in cursor.fetchall():
-            jobs.append({
-                'job_id': row[0],
-                'status': row[1],
-                'priority': row[2],
-                'progress': row[3],
-                'total_tickers': row[4],
-                'completion_percentage': (row[3] / row[4] * 100) if row[4] > 0 else 0,
-                'created_at': row[5]
-            })
+            jobs = []
+            for row in cursor.fetchall():
+                jobs.append({
+                    'job_id': row[0],
+                    'status': row[1],
+                    'priority': row[2],
+                    'progress': row[3],
+                    'total_tickers': row[4],
+                    'completion_percentage': (row[3] / row[4] * 100) if row[4] > 0 else 0,
+                    'created_at': row[5]
+                })
         
-        conn.close()
         return jobs
     
     async def _process_single_job(self, job: BatchJob) -> BatchJob:
@@ -442,79 +439,77 @@ class DistributedBatchProcessor:
     
     def _load_pending_jobs(self):
         """Load pending jobs from database"""
-        conn = sqlite3.connect(self.job_db_path)
-        cursor = conn.cursor()
+        with closing(sqlite3.connect(self.job_db_path)) as conn:
+            cursor = conn.cursor()
         
-        cursor.execute("""
-            SELECT job_id FROM batch_jobs 
-            WHERE status = 'pending'
-            ORDER BY priority, created_at
-            LIMIT 20
-        """)
+            cursor.execute("""
+                SELECT job_id FROM batch_jobs 
+                WHERE status = 'pending'
+                ORDER BY priority, created_at
+                LIMIT 20
+            """)
         
-        for row in cursor.fetchall():
-            job_id = row[0]
+            for row in cursor.fetchall():
+                job_id = row[0]
             
-            # Load job data from file
-            job_file = self.jobs_dir / f"{job_id}.json"
-            if job_file.exists():
-                try:
-                    with open(job_file, 'r') as f:
-                        job_data = json.load(f)
-                        job = BatchJob(
-                            job_id=job_data['job_id'],
-                            tickers=job_data['tickers'],
-                            status=job_data['status'],
-                            priority=job_data['priority'],
-                            created_at=datetime.fromisoformat(job_data['created_at']),
-                            total_tickers=job_data['total_tickers']
-                        )
-                        self.job_queue.append(job)
-                except Exception as e:
-                    logger.error(f"Error loading job {job_id}: {e}")
+                # Load job data from file
+                job_file = self.jobs_dir / f"{job_id}.json"
+                if job_file.exists():
+                    try:
+                        with open(job_file, 'r') as f:
+                            job_data = json.load(f)
+                            job = BatchJob(
+                                job_id=job_data['job_id'],
+                                tickers=job_data['tickers'],
+                                status=job_data['status'],
+                                priority=job_data['priority'],
+                                created_at=datetime.fromisoformat(job_data['created_at']),
+                                total_tickers=job_data['total_tickers']
+                            )
+                            self.job_queue.append(job)
+                    except Exception as e:
+                        logger.error(f"Error loading job {job_id}: {e}")
         
-        conn.close()
     
     def _update_stats(self):
         """Update processor statistics"""
         try:
-            conn = sqlite3.connect(self.job_db_path)
-            cursor = conn.cursor()
+            with closing(sqlite3.connect(self.job_db_path)) as conn:
+                cursor = conn.cursor()
             
-            # Calculate current metrics
-            current_time = datetime.now()
-            running_jobs = len(self.active_jobs)
+                # Calculate current metrics
+                current_time = datetime.now()
+                running_jobs = len(self.active_jobs)
             
-            # Calculate tickers per minute (last hour)
-            hour_ago = (current_time - timedelta(hours=1)).isoformat()
-            cursor.execute("""
-                SELECT COUNT(*) FROM job_tickers 
-                WHERE extracted_at > ? AND status = 'success'
-            """, (hour_ago,))
+                # Calculate tickers per minute (last hour)
+                hour_ago = (current_time - timedelta(hours=1)).isoformat()
+                cursor.execute("""
+                    SELECT COUNT(*) FROM job_tickers 
+                    WHERE extracted_at > ? AND status = 'success'
+                """, (hour_ago,))
             
-            tickers_last_hour = cursor.fetchone()[0] or 0
-            tickers_per_minute = tickers_last_hour / 60.0 if tickers_last_hour > 0 else 0
+                tickers_last_hour = cursor.fetchone()[0] or 0
+                tickers_per_minute = tickers_last_hour / 60.0 if tickers_last_hour > 0 else 0
             
-            # Calculate success rate (last hour)
-            cursor.execute("""
-                SELECT 
-                    SUM(CASE WHEN status = 'success' THEN 1 ELSE 0 END) * 100.0 / COUNT(*) as success_rate
-                FROM job_tickers 
-                WHERE extracted_at > ?
-            """, (hour_ago,))
+                # Calculate success rate (last hour)
+                cursor.execute("""
+                    SELECT 
+                        SUM(CASE WHEN status = 'success' THEN 1 ELSE 0 END) * 100.0 / COUNT(*) as success_rate
+                    FROM job_tickers 
+                    WHERE extracted_at > ?
+                """, (hour_ago,))
             
-            result = cursor.fetchone()
-            success_rate = result[0] if result and result[0] else 0
+                result = cursor.fetchone()
+                success_rate = result[0] if result and result[0] else 0
             
-            # Insert stats
-            cursor.execute("""
-                INSERT INTO processor_stats 
-                (timestamp, total_jobs_running, tickers_per_minute, success_rate, avg_time_per_ticker)
-                VALUES (?, ?, ?, ?, ?)
-            """, (current_time.isoformat(), running_jobs, tickers_per_minute, success_rate, 0))
+                # Insert stats
+                cursor.execute("""
+                    INSERT INTO processor_stats 
+                    (timestamp, total_jobs_running, tickers_per_minute, success_rate, avg_time_per_ticker)
+                    VALUES (?, ?, ?, ?, ?)
+                """, (current_time.isoformat(), running_jobs, tickers_per_minute, success_rate, 0))
             
-            conn.commit()
-            conn.close()
+                conn.commit()
             
         except Exception as e:
             logger.debug(f"Error updating stats: {e}")
@@ -531,21 +526,19 @@ class DistributedBatchProcessor:
             del self.active_jobs[job_id]
             
             # Update job status
-            conn = sqlite3.connect(self.job_db_path)
-            cursor = conn.cursor()
-            cursor.execute("UPDATE batch_jobs SET status = 'paused' WHERE job_id = ?", (job_id,))
-            conn.commit()
-            conn.close()
+            with closing(sqlite3.connect(self.job_db_path)) as conn:
+                cursor = conn.cursor()
+                cursor.execute("UPDATE batch_jobs SET status = 'paused' WHERE job_id = ?", (job_id,))
+                conn.commit()
             
             logger.info(f"Paused job {job_id}")
     
     def resume_job(self, job_id: str):
         """Resume a paused job"""
-        conn = sqlite3.connect(self.job_db_path)
-        cursor = conn.cursor()
-        cursor.execute("UPDATE batch_jobs SET status = 'pending' WHERE job_id = ?", (job_id,))
-        conn.commit()
-        conn.close()
+        with closing(sqlite3.connect(self.job_db_path)) as conn:
+            cursor = conn.cursor()
+            cursor.execute("UPDATE batch_jobs SET status = 'pending' WHERE job_id = ?", (job_id,))
+            conn.commit()
         
         logger.info(f"Resumed job {job_id}")
     

--- a/backend/etl/etl_orchestrator.py
+++ b/backend/etl/etl_orchestrator.py
@@ -50,6 +50,10 @@ class ETLOrchestrator:
     def __init__(self, use_distributed: bool = True, cache_dir: str = "/tmp/stock_cache"):
         # Legacy components (maintained for backward compatibility)
         self.legacy_extractor = DataExtractor()
+        # F-05-007: realtime / single-ticker code paths reference
+        # ``self.extractor`` (etl_orchestrator.py lines 387, 633). Alias
+        # to the legacy extractor so those paths do not AttributeError.
+        self.extractor = self.legacy_extractor
         self.transformer = DataTransformer()
         self.loader = DataLoader()
         self.batch_loader = BatchLoader(self.loader)
@@ -142,28 +146,69 @@ class ETLOrchestrator:
             
             logger.info(f"Created {len(job_ids)} processing jobs")
             
-            # Start distributed processing
+            # F-05-002: bound the monitor loop. The original version only
+            # counted ``status == 'completed'`` jobs, so any failed/cancelled
+            # job left the loop spinning forever. We now:
+            #   - count terminal states (completed | failed | cancelled |
+            #     error) toward the exit condition
+            #   - enforce ``max_wait_seconds`` so a stuck processor cannot
+            #     hang the pipeline indefinitely
+            #   - cancel ``processing_task`` in ``finally`` so a leaked
+            #     task does not survive the exit
+            max_wait_seconds = int(
+                os.getenv("ETL_DISTRIBUTED_MAX_WAIT_SECONDS", "7200")
+            )
+            poll_interval_seconds = 30
+            terminal_states = {"completed", "failed", "cancelled", "error"}
+
             processing_task = asyncio.create_task(
                 self.distributed_processor.start_processing()
             )
-            
-            # Monitor progress
-            completed_jobs = 0
-            while completed_jobs < len(job_ids):
-                await asyncio.sleep(30)  # Check every 30 seconds
-                
-                completed_count = 0
-                for job_id in job_ids:
-                    status = self.distributed_processor.get_job_status(job_id)
-                    if status and status['status'] == 'completed':
-                        completed_count += 1
-                
-                if completed_count > completed_jobs:
-                    completed_jobs = completed_count
-                    logger.info(f"Progress: {completed_jobs}/{len(job_ids)} jobs completed")
-            
-            # Stop processing and collect results
-            self.distributed_processor.stop_processing()
+
+            start_time = asyncio.get_event_loop().time()
+            try:
+                terminal_jobs = 0
+                while terminal_jobs < len(job_ids):
+                    elapsed = asyncio.get_event_loop().time() - start_time
+                    if elapsed > max_wait_seconds:
+                        logger.warning(
+                            f"Distributed pipeline exceeded "
+                            f"max_wait_seconds={max_wait_seconds}; aborting "
+                            f"with {terminal_jobs}/{len(job_ids)} jobs terminal"
+                        )
+                        self.metrics["errors"].append(
+                            f"distributed_pipeline_timeout after {elapsed:.0f}s"
+                        )
+                        break
+
+                    await asyncio.sleep(poll_interval_seconds)
+
+                    terminal_count = 0
+                    completed_count = 0
+                    failed_count = 0
+                    for job_id in job_ids:
+                        status = self.distributed_processor.get_job_status(job_id)
+                        if status and status["status"] in terminal_states:
+                            terminal_count += 1
+                            if status["status"] == "completed":
+                                completed_count += 1
+                            else:
+                                failed_count += 1
+
+                    if terminal_count > terminal_jobs:
+                        terminal_jobs = terminal_count
+                        logger.info(
+                            f"Progress: {terminal_jobs}/{len(job_ids)} jobs terminal "
+                            f"({completed_count} ok, {failed_count} failed)"
+                        )
+            finally:
+                self.distributed_processor.stop_processing()
+                if not processing_task.done():
+                    processing_task.cancel()
+                    try:
+                        await processing_task
+                    except (asyncio.CancelledError, Exception):
+                        pass
             
             # Update metrics from processor stats
             processor_stats = self.distributed_processor.get_processor_stats()

--- a/backend/etl/multi_source_extractor.py
+++ b/backend/etl/multi_source_extractor.py
@@ -21,6 +21,7 @@ import time
 import random
 from concurrent.futures import ThreadPoolExecutor, as_completed
 import sqlite3
+from contextlib import closing
 import hashlib
 from dataclasses import dataclass
 # SECURITY: Removed pickle - using JSON for safer serialization
@@ -42,18 +43,9 @@ load_dotenv()
 logger = logging.getLogger(__name__)
 
 
-@dataclass
-class ExtractionResult:
-    ticker: str
-    success: bool
-    data: Optional[Dict] = None
-    source: Optional[str] = None
-    error: Optional[str] = None
-    timestamp: datetime = None
-    
-    def __post_init__(self):
-        if self.timestamp is None:
-            self.timestamp = datetime.now()
+# F-05-005: re-export canonical ExtractionResult from backend.etl.types
+# so downstream isinstance() checks pass across both extractor modules.
+from .types import ExtractionResult  # noqa: E402
 
 
 @dataclass
@@ -203,34 +195,33 @@ class MultiSourceStockExtractor:
     
     def _init_progress_db(self):
         """Initialize progress tracking database"""
-        conn = sqlite3.connect(self.progress_db_path)
-        cursor = conn.cursor()
+        with closing(sqlite3.connect(self.progress_db_path)) as conn:
+            cursor = conn.cursor()
         
-        cursor.execute("""
-            CREATE TABLE IF NOT EXISTS extraction_log (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                ticker TEXT,
-                source TEXT,
-                status TEXT,
-                timestamp TIMESTAMP,
-                error_message TEXT,
-                data_quality_score REAL
-            )
-        """)
+            cursor.execute("""
+                CREATE TABLE IF NOT EXISTS extraction_log (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    ticker TEXT,
+                    source TEXT,
+                    status TEXT,
+                    timestamp TIMESTAMP,
+                    error_message TEXT,
+                    data_quality_score REAL
+                )
+            """)
         
-        cursor.execute("""
-            CREATE TABLE IF NOT EXISTS ticker_progress (
-                ticker TEXT PRIMARY KEY,
-                last_successful_extraction TIMESTAMP,
-                successful_sources TEXT,
-                failed_sources TEXT,
-                total_attempts INTEGER DEFAULT 0,
-                data_completeness_score REAL DEFAULT 0.0
-            )
-        """)
+            cursor.execute("""
+                CREATE TABLE IF NOT EXISTS ticker_progress (
+                    ticker TEXT PRIMARY KEY,
+                    last_successful_extraction TIMESTAMP,
+                    successful_sources TEXT,
+                    failed_sources TEXT,
+                    total_attempts INTEGER DEFAULT 0,
+                    data_completeness_score REAL DEFAULT 0.0
+                )
+            """)
         
-        conn.commit()
-        conn.close()
+            conn.commit()
     
     def _can_make_request(self, source: str) -> bool:
         """Check if we can make a request to the source using TokenBucket.
@@ -765,16 +756,15 @@ class MultiSourceStockExtractor:
     def _log_extraction(self, ticker: str, source: str, status: str, error: str):
         """Log extraction attempt to database"""
         try:
-            conn = sqlite3.connect(self.progress_db_path)
-            cursor = conn.cursor()
+            with closing(sqlite3.connect(self.progress_db_path)) as conn:
+                cursor = conn.cursor()
             
-            cursor.execute("""
-                INSERT INTO extraction_log (ticker, source, status, timestamp, error_message)
-                VALUES (?, ?, ?, ?, ?)
-            """, (ticker, source, status, datetime.now().isoformat(), error))
+                cursor.execute("""
+                    INSERT INTO extraction_log (ticker, source, status, timestamp, error_message)
+                    VALUES (?, ?, ?, ?, ?)
+                """, (ticker, source, status, datetime.now().isoformat(), error))
             
-            conn.commit()
-            conn.close()
+                conn.commit()
         except Exception as e:
             logger.debug(f"Error logging extraction: {e}")
     
@@ -877,25 +867,24 @@ class MultiSourceStockExtractor:
     def get_extraction_stats(self) -> Dict:
         """Get statistics about extraction performance"""
         try:
-            conn = sqlite3.connect(self.progress_db_path)
-            cursor = conn.cursor()
+            with closing(sqlite3.connect(self.progress_db_path)) as conn:
+                cursor = conn.cursor()
             
-            # Get overall stats
-            cursor.execute("""
-                SELECT source, status, COUNT(*) as count
-                FROM extraction_log
-                WHERE timestamp > datetime('now', '-24 hours')
-                GROUP BY source, status
-            """)
+                # Get overall stats
+                cursor.execute("""
+                    SELECT source, status, COUNT(*) as count
+                    FROM extraction_log
+                    WHERE timestamp > datetime('now', '-24 hours')
+                    GROUP BY source, status
+                """)
             
-            stats = {'sources': {}}
-            for row in cursor.fetchall():
-                source, status, count = row
-                if source not in stats['sources']:
-                    stats['sources'][source] = {}
-                stats['sources'][source][status] = count
+                stats = {'sources': {}}
+                for row in cursor.fetchall():
+                    source, status, count = row
+                    if source not in stats['sources']:
+                        stats['sources'][source] = {}
+                    stats['sources'][source][status] = count
             
-            conn.close()
             return stats
             
         except Exception as e:

--- a/backend/etl/types.py
+++ b/backend/etl/types.py
@@ -1,0 +1,34 @@
+"""
+Shared ETL types.
+
+F-05-005 (audit 2026-04, G2a sub-theme C): ``ExtractionResult`` was
+previously defined twice — once in ``multi_source_extractor.py`` and
+once in ``unlimited_data_extractor.py`` — with subtly different ``data``
+field types. Consolidated here so both modules re-export the same
+class and downstream isinstance checks behave consistently.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Optional
+
+
+@dataclass
+class ExtractionResult:
+    """Result of a data extraction attempt."""
+
+    ticker: str
+    success: bool
+    data: Any = None
+    source: Optional[str] = None
+    error: Optional[str] = None
+    timestamp: Optional[datetime] = None
+
+    def __post_init__(self) -> None:
+        if self.timestamp is None:
+            self.timestamp = datetime.now()
+
+
+__all__ = ["ExtractionResult"]

--- a/backend/etl/unlimited_data_extractor.py
+++ b/backend/etl/unlimited_data_extractor.py
@@ -18,11 +18,26 @@ from urllib.parse import quote
 import yfinance as yf
 from concurrent.futures import ThreadPoolExecutor
 import requests
-from selenium import webdriver
-from selenium.webdriver.chrome.options import Options
-from selenium.webdriver.common.by import By
-from selenium.webdriver.support.ui import WebDriverWait
-from selenium.webdriver.support import expected_conditions as EC
+# F-05-001: selenium is an optional dependency. Top-level imports made
+# this whole module unimportable in environments without selenium
+# (e.g. CI, minimal containers, fresh-clone smoke tests), which in turn
+# broke ``from backend.etl.data_extractor import DataExtractor``.
+try:
+    from selenium import webdriver
+    from selenium.webdriver.chrome.options import Options
+    from selenium.webdriver.common.by import By
+    from selenium.webdriver.support.ui import WebDriverWait
+    from selenium.webdriver.support import expected_conditions as EC
+
+    SELENIUM_AVAILABLE = True
+except ImportError:  # pragma: no cover - exercised in selenium-less envs
+    webdriver = None  # type: ignore[assignment]
+    Options = None  # type: ignore[assignment]
+    By = None  # type: ignore[assignment]
+    WebDriverWait = None  # type: ignore[assignment]
+    EC = None  # type: ignore[assignment]
+
+    SELENIUM_AVAILABLE = False
 import os
 from dataclasses import dataclass, field
 
@@ -52,19 +67,11 @@ class StockData:
         self.extra = kwargs
 
 
-@dataclass
-class ExtractionResult:
-    """Result of a data extraction attempt"""
-    ticker: str
-    success: bool
-    data: Any = None
-    source: Optional[str] = None
-    error: Optional[str] = None
-    timestamp: datetime = None
-
-    def __post_init__(self):
-        if self.timestamp is None:
-            self.timestamp = datetime.now()
+# F-05-005: re-export canonical ExtractionResult from backend.etl.types
+# so isinstance() checks behave consistently across both extractor
+# modules. Relative import keeps the module loadable standalone for the
+# F-05-001 selenium-guard regression test.
+from .types import ExtractionResult  # noqa: E402
 
 
 # Aliases for classes imported by unlimited_extractor_with_fallbacks
@@ -77,14 +84,20 @@ class UnlimitedDataExtractor:
     """Extract stock data without rate limits using web scraping and free sources"""
     
     def __init__(self):
-        # Configure Selenium for headless scraping
-        self.chrome_options = Options()
-        self.chrome_options.add_argument('--headless')
-        self.chrome_options.add_argument('--no-sandbox')
-        self.chrome_options.add_argument('--disable-dev-shm-usage')
-        self.chrome_options.add_argument('--disable-gpu')
-        self.chrome_options.add_argument('--window-size=1920x1080')
-        self.chrome_options.add_argument('--user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36')
+        # F-05-001: only build Selenium Options when selenium is importable.
+        # Code paths that need a driver must check SELENIUM_AVAILABLE first.
+        if SELENIUM_AVAILABLE:
+            self.chrome_options = Options()
+            self.chrome_options.add_argument('--headless')
+            self.chrome_options.add_argument('--no-sandbox')
+            self.chrome_options.add_argument('--disable-dev-shm-usage')
+            self.chrome_options.add_argument('--disable-gpu')
+            self.chrome_options.add_argument('--window-size=1920x1080')
+            self.chrome_options.add_argument(
+                '--user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36'
+            )
+        else:
+            self.chrome_options = None
         
         # Session management
         self.session = None
@@ -103,6 +116,12 @@ class UnlimitedDataExtractor:
     
     def get_driver(self):
         """Get or create Selenium driver"""
+        if not SELENIUM_AVAILABLE:
+            logger.warning(
+                "Selenium is not installed; driver-based extraction unavailable"
+            )
+            self.driver = None
+            return self.driver
         if not self.driver:
             try:
                 self.driver = webdriver.Chrome(options=self.chrome_options)

--- a/backend/ml/artifact_manager.py
+++ b/backend/ml/artifact_manager.py
@@ -177,7 +177,14 @@ class ModelArtifactManager:
         if format == ModelFormat.PYTORCH:
             if torch is None:
                 raise RuntimeError("torch is not installed")
-            return torch.load(path, map_location='cpu')
+            # F-03-002: torch.load defaults to pickle deserialization which
+            # is RCE-equivalent on untrusted artifacts. ``weights_only=True``
+            # restricts deserialization to tensor primitives. Full-model
+            # artifacts that need non-tensor classes must be allowlisted via
+            # ``torch.serialization.add_safe_globals([Cls, ...])`` before
+            # the load — see workpaper §9 for the safe_globals escalation
+            # path.
+            return torch.load(path, map_location='cpu', weights_only=True)
 
         elif format == ModelFormat.SKLEARN_JOBLIB:
             if joblib is None:

--- a/backend/ml/feature_store.py
+++ b/backend/ml/feature_store.py
@@ -346,6 +346,14 @@ class FeatureStore:
             'rsi_14d': self._compute_rsi_14d,
             'sma_20d': self._compute_sma_20d,
             'ema_20d': self._compute_ema_20d,
+            # F-03-008: ML_PIPELINE_DOCUMENTATION.md advertised MACD and
+            # Bollinger Bands as builtin features but the computations
+            # were never implemented. Adds them so the documented
+            # surface and the runtime surface agree.
+            'macd': self._compute_macd,
+            'macd_signal': self._compute_macd_signal,
+            'bollinger_upper_20d': self._compute_bollinger_upper_20d,
+            'bollinger_lower_20d': self._compute_bollinger_lower_20d,
             'pe_ratio': self._compute_pe_ratio,
             'market_cap': self._compute_market_cap
         }
@@ -574,6 +582,101 @@ class FeatureStore:
         
         return pd.Series(ema_values, index=entity_ids)
     
+    # F-03-008: MACD and Bollinger Bands implementations follow.
+    # All four share a small helper that returns the per-entity close
+    # series, sorted by date.
+
+    def _entity_close_series(
+        self,
+        entity_id: str,
+        price_data: pd.DataFrame,
+    ) -> pd.Series:
+        rows = price_data[price_data['ticker'] == entity_id].sort_values('date')
+        return rows['close'].astype(float)
+
+    def _compute_macd(self, entity_ids: List[str], timestamp: datetime,
+                     data_sources: Dict[str, pd.DataFrame], computed_features: pd.DataFrame) -> pd.Series:
+        """MACD = EMA(12) - EMA(26) on closing prices."""
+        if 'price_data' not in data_sources:
+            return pd.Series(np.nan, index=entity_ids)
+
+        price_data = data_sources['price_data']
+        values: List[float] = []
+        for entity_id in entity_ids:
+            try:
+                closes = self._entity_close_series(entity_id, price_data)
+                if len(closes) >= 26:
+                    ema_fast = closes.ewm(span=12, adjust=False).mean().iloc[-1]
+                    ema_slow = closes.ewm(span=26, adjust=False).mean().iloc[-1]
+                    values.append(float(ema_fast - ema_slow))
+                else:
+                    values.append(np.nan)
+            except Exception as e:
+                logger.error(f"Error computing MACD for {entity_id}: {e}")
+                values.append(np.nan)
+        return pd.Series(values, index=entity_ids)
+
+    def _compute_macd_signal(self, entity_ids: List[str], timestamp: datetime,
+                            data_sources: Dict[str, pd.DataFrame], computed_features: pd.DataFrame) -> pd.Series:
+        """MACD signal line = EMA(9) of the MACD series."""
+        if 'price_data' not in data_sources:
+            return pd.Series(np.nan, index=entity_ids)
+
+        price_data = data_sources['price_data']
+        values: List[float] = []
+        for entity_id in entity_ids:
+            try:
+                closes = self._entity_close_series(entity_id, price_data)
+                if len(closes) >= 26 + 9:
+                    macd_series = (
+                        closes.ewm(span=12, adjust=False).mean()
+                        - closes.ewm(span=26, adjust=False).mean()
+                    )
+                    signal = macd_series.ewm(span=9, adjust=False).mean().iloc[-1]
+                    values.append(float(signal))
+                else:
+                    values.append(np.nan)
+            except Exception as e:
+                logger.error(f"Error computing MACD signal for {entity_id}: {e}")
+                values.append(np.nan)
+        return pd.Series(values, index=entity_ids)
+
+    def _compute_bollinger_upper_20d(self, entity_ids: List[str], timestamp: datetime,
+                                     data_sources: Dict[str, pd.DataFrame], computed_features: pd.DataFrame) -> pd.Series:
+        """20-day Bollinger upper band = SMA(20) + 2 * std(20)."""
+        return self._compute_bollinger_band(entity_ids, data_sources, k=2.0)
+
+    def _compute_bollinger_lower_20d(self, entity_ids: List[str], timestamp: datetime,
+                                     data_sources: Dict[str, pd.DataFrame], computed_features: pd.DataFrame) -> pd.Series:
+        """20-day Bollinger lower band = SMA(20) - 2 * std(20)."""
+        return self._compute_bollinger_band(entity_ids, data_sources, k=-2.0)
+
+    def _compute_bollinger_band(
+        self,
+        entity_ids: List[str],
+        data_sources: Dict[str, pd.DataFrame],
+        k: float,
+    ) -> pd.Series:
+        if 'price_data' not in data_sources:
+            return pd.Series(np.nan, index=entity_ids)
+
+        price_data = data_sources['price_data']
+        values: List[float] = []
+        for entity_id in entity_ids:
+            try:
+                closes = self._entity_close_series(entity_id, price_data)
+                if len(closes) >= 20:
+                    window = closes.tail(20)
+                    mean = float(window.mean())
+                    std = float(window.std(ddof=0))
+                    values.append(mean + k * std)
+                else:
+                    values.append(np.nan)
+            except Exception as e:
+                logger.error(f"Error computing Bollinger band for {entity_id}: {e}")
+                values.append(np.nan)
+        return pd.Series(values, index=entity_ids)
+
     def _compute_pe_ratio(self, entity_ids: List[str], timestamp: datetime,
                         data_sources: Dict[str, pd.DataFrame], computed_features: pd.DataFrame) -> pd.Series:
         """Compute P/E ratio"""

--- a/backend/ml/minimal_training.py
+++ b/backend/ml/minimal_training.py
@@ -14,27 +14,30 @@ import joblib
 def create_sample_model():
     """Create a minimal sample model"""
     print("Creating minimal sample model...")
-    
-    # Create directories
-    os.makedirs('backend/ml_models', exist_ok=True)
-    os.makedirs('backend/ml_logs', exist_ok=True)
-    
+
+    # F-03-007: anchor paths to project root regardless of cwd.
+    _project_root = Path(__file__).resolve().parent.parent.parent
+    _models_dir = _project_root / "backend" / "ml_models"
+    _logs_dir = _project_root / "backend" / "ml_logs"
+    _models_dir.mkdir(parents=True, exist_ok=True)
+    _logs_dir.mkdir(parents=True, exist_ok=True)
+
     # Create simple dummy model (using sklearn)
     from sklearn.linear_model import LinearRegression
-    
+
     # Generate sample data
     X = np.random.randn(100, 5)
     y = np.random.randn(100)
-    
+
     # Train model
     model = LinearRegression()
     model.fit(X, y)
-    
+
     # Save model
     # SECURITY: Use joblib instead of pickle for safer serialization
-    model_path = 'backend/ml_models/sample_model.pkl'
+    model_path = str(_models_dir / "sample_model.pkl")
     joblib.dump(model, model_path)
-    
+
     # Save metadata
     metadata = {
         'timestamp': datetime.now().isoformat(),
@@ -44,8 +47,8 @@ def create_sample_model():
         'samples': 100,
         'score': float(model.score(X, y))
     }
-    
-    metadata_path = 'backend/ml_logs/sample_model_metadata.json'
+
+    metadata_path = str(_logs_dir / "sample_model_metadata.json")
     with open(metadata_path, 'w') as f:
         json.dump(metadata, f, indent=2)
     

--- a/backend/ml/ml_api_server.py
+++ b/backend/ml/ml_api_server.py
@@ -5,6 +5,7 @@ Serves ML models via FastAPI on port 8001
 """
 
 import os
+import re
 import sys
 import logging
 import uvicorn
@@ -67,12 +68,48 @@ class ModelInfo(BaseModel):
     score: float
     loaded_at: str
 
+# F-03-006: model_name is operator-controlled via the
+# ``POST /models/{model_name}/load`` route and the prediction request
+# body. Without validation a caller could pass ``../../../etc/passwd``
+# and read arbitrary paths off the host filesystem. We enforce a
+# strict character class AND a resolved-path containment check.
+_MODEL_NAME_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+_MODELS_ROOT = Path("backend/ml_models").resolve()
+_MODELS_LOGS_ROOT = Path("backend/ml_logs").resolve()
+
+
+def _validate_model_name(model_name: str) -> str:
+    """Reject any model_name that doesn't match ``[A-Za-z0-9_-]+``.
+
+    Raises ``ValueError`` — callers map this to HTTP 400 (not 500) so
+    operators can distinguish "bad input" from "server error" in logs.
+    """
+    if not isinstance(model_name, str) or not _MODEL_NAME_RE.fullmatch(model_name):
+        raise ValueError(
+            f"invalid model_name: must match [A-Za-z0-9_-]+ (got {model_name!r})"
+        )
+    return model_name
+
+
+def _safe_model_path(root: Path, model_name: str, suffix: str) -> Path:
+    """Resolve ``{root}/{model_name}{suffix}`` and assert containment."""
+    candidate = (root / f"{model_name}{suffix}").resolve()
+    try:
+        candidate.relative_to(root)
+    except ValueError as e:
+        raise ValueError(
+            f"resolved path {candidate!s} escapes models root {root!s}"
+        ) from e
+    return candidate
+
+
 def load_model(model_name: str):
     """Load a model from disk"""
     try:
-        model_path = Path(f"backend/ml_models/{model_name}.pkl")
-        metadata_path = Path(f"backend/ml_logs/{model_name}_metadata.json")
-        
+        _validate_model_name(model_name)
+        model_path = _safe_model_path(_MODELS_ROOT, model_name, ".pkl")
+        metadata_path = _safe_model_path(_MODELS_LOGS_ROOT, model_name, "_metadata.json")
+
         if not model_path.exists():
             raise FileNotFoundError(f"Model file not found: {model_path}")
         
@@ -196,8 +233,13 @@ async def load_model_endpoint(model_name: str):
             "message": f"Model {model_name} loaded successfully",
             "timestamp": datetime.now().isoformat()
         }
-    except Exception as e:
+    except ValueError as e:
+        # F-03-006: malformed/path-traversing model_name → 400, not 500.
+        raise HTTPException(status_code=400, detail=str(e))
+    except FileNotFoundError as e:
         raise HTTPException(status_code=404, detail=str(e))
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
 
 @app.delete("/models/{model_name}")
 async def unload_model(model_name: str):

--- a/backend/ml/model_manager.py
+++ b/backend/ml/model_manager.py
@@ -218,7 +218,10 @@ class ModelManager:
     def _load_pytorch_model(self, path: Path):
         """Load PyTorch model with error handling"""
         try:
-            model = torch.load(path, map_location='cpu')
+            # F-03-002: weights_only=True blocks pickle RCE. Full-model
+            # artifacts that fail with WeightsUnpickler must register their
+            # constructor classes via torch.serialization.add_safe_globals.
+            model = torch.load(path, map_location='cpu', weights_only=True)
             model.eval()
             return model
         except Exception as e:
@@ -297,7 +300,9 @@ class ModelManager:
                 num_layers=config['num_layers'],
                 dropout=config['dropout']
             )
-            model.load_state_dict(torch.load(path, map_location='cpu'))
+            # F-03-002: state_dict-only loads are tensor primitives —
+            # weights_only=True is always safe here.
+            model.load_state_dict(torch.load(path, map_location='cpu', weights_only=True))
             model.eval()
 
             # Return wrapper with config and scaler

--- a/backend/ml/model_versioning.py
+++ b/backend/ml/model_versioning.py
@@ -604,7 +604,9 @@ class ModelVersionManager:
             
             # Load model based on type
             if model_version.model_type == ModelType.PYTORCH:
-                model = torch.load(model_path, map_location='cpu')
+                # F-03-002: see artifact_manager.py for the weights_only=True
+                # rationale and the safe_globals escalation path.
+                model = torch.load(model_path, map_location='cpu', weights_only=True)
             elif model_version.model_type in [ModelType.SKLEARN, ModelType.ENSEMBLE]:
                 model = joblib.load(model_path)
             else:

--- a/backend/ml/runtime_models.py
+++ b/backend/ml/runtime_models.py
@@ -307,11 +307,13 @@ class ModelManager:
         
         # Try to load pre-trained weights
         try:
+            # F-03-002: state_dict-only loads are tensor primitives —
+            # weights_only=True is always safe and blocks pickle RCE.
             self.models['lstm'].load_state_dict(
-                torch.load('models/lstm_weights.pth', map_location=self.device)
+                torch.load('models/lstm_weights.pth', map_location=self.device, weights_only=True)
             )
             self.models['transformer'].load_state_dict(
-                torch.load('models/transformer_weights.pth', map_location=self.device)
+                torch.load('models/transformer_weights.pth', map_location=self.device, weights_only=True)
             )
             
             self.models['xgboost'] = joblib.load('models/xgboost_model.pkl')

--- a/backend/ml/simple_training_pipeline.py
+++ b/backend/ml/simple_training_pipeline.py
@@ -18,12 +18,18 @@ import joblib
 # Add parent directory to path
 sys.path.append(str(Path(__file__).parent.parent.parent))
 
+# F-03-007: anchor log path to project root (__file__-relative).
+_ML_LOGS_DIR = Path(__file__).resolve().parent.parent.parent / "backend" / "ml_logs"
+_ML_LOGS_DIR.mkdir(parents=True, exist_ok=True)
+
 # Configure logging
 logging.basicConfig(
     level=logging.INFO,
     format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
     handlers=[
-        logging.FileHandler(f'backend/ml_logs/simple_training_{datetime.now().strftime("%Y%m%d_%H%M%S")}.log'),
+        logging.FileHandler(
+            _ML_LOGS_DIR / f'simple_training_{datetime.now().strftime("%Y%m%d_%H%M%S")}.log'
+        ),
         logging.StreamHandler()
     ]
 )

--- a/backend/ml/training/evaluate_models.py
+++ b/backend/ml/training/evaluate_models.py
@@ -88,7 +88,8 @@ class ModelEvaluator:
                 num_layers=config['num_layers'],
                 dropout=config['dropout']
             )
-            model.load_state_dict(torch.load(model_path, map_location='cpu'))
+            # F-03-002: state_dict-only — weights_only=True is always safe.
+            model.load_state_dict(torch.load(model_path, map_location='cpu', weights_only=True))
             model.eval()
 
             # Load scaler

--- a/backend/ml/training_pipeline.py
+++ b/backend/ml/training_pipeline.py
@@ -18,12 +18,20 @@ from typing import Dict, Any, Optional
 # Add parent directory to path
 sys.path.append(str(Path(__file__).parent.parent.parent))
 
+# F-03-007: anchor log path to the project root (__file__-relative)
+# so that running training from any cwd writes to the same directory
+# instead of creating a stray ``backend/ml_logs/`` next to the caller.
+_ML_LOGS_DIR = Path(__file__).resolve().parent.parent.parent / "backend" / "ml_logs"
+_ML_LOGS_DIR.mkdir(parents=True, exist_ok=True)
+
 # Configure logging
 logging.basicConfig(
     level=logging.INFO,
     format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
     handlers=[
-        logging.FileHandler(f'backend/ml_logs/training_{datetime.now().strftime("%Y%m%d_%H%M%S")}.log'),
+        logging.FileHandler(
+            _ML_LOGS_DIR / f'training_{datetime.now().strftime("%Y%m%d_%H%M%S")}.log'
+        ),
         logging.StreamHandler()
     ]
 )

--- a/backend/tests/unit/test_airflow_dag_cleanup.py
+++ b/backend/tests/unit/test_airflow_dag_cleanup.py
@@ -1,0 +1,63 @@
+"""
+Regression tests for Airflow DAG cleanup (F-06-005, F-06-006, F-06-007, F-06-009).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+_DAGS_DIR = (
+    Path(__file__).resolve().parents[3]
+    / "data_pipelines"
+    / "airflow"
+    / "dags"
+)
+_DAILY = _DAGS_DIR / "daily_stock_pipeline.py"
+_ML = _DAGS_DIR / "ml_training_pipeline_dag.py"
+
+
+def test_no_schedule_interval_kwarg() -> None:
+    """F-06-005: ``schedule_interval=`` deprecated in Airflow 2.4+."""
+
+    for dag_path in _DAGS_DIR.glob("*.py"):
+        text = dag_path.read_text()
+        assert not re.search(r"\bschedule_interval\s*=", text), (
+            f"{dag_path.name} still uses deprecated schedule_interval kwarg"
+        )
+
+
+def test_no_create_session_call_in_dag() -> None:
+    """F-06-006: ``airflow.utils.db.create_session`` removed from public API."""
+
+    text = _DAILY.read_text()
+    assert not re.search(r"\bcreate_session\s*\(", text), (
+        "daily_stock_pipeline.py still calls airflow.utils.db.create_session"
+    )
+    assert "from airflow.utils.db import create_session" not in text
+
+
+def test_no_legacy_deprecated_block_in_daily_pipeline() -> None:
+    """F-06-007: ``DEPRECATED``/``LEGACY`` comment block must be gone."""
+
+    text = _DAILY.read_text()
+    assert "DEPRECATED" not in text, (
+        "daily_stock_pipeline.py still contains DEPRECATED label"
+    )
+    assert "LEGACY FUNCTIONS" not in text, (
+        "daily_stock_pipeline.py still contains LEGACY FUNCTIONS block"
+    )
+
+
+def test_no_placeholder_alert_email() -> None:
+    """F-06-009: ``ml-alerts@company.com`` placeholder must be gone."""
+
+    text = _ML.read_text()
+    assert "ml-alerts@company.com" not in text, (
+        "ml_training_pipeline_dag.py still ships the placeholder alert email"
+    )
+    assert "ml_alert_emails" in text, (
+        "ml_training_pipeline_dag.py must source alert recipients from "
+        "the ``ml_alert_emails`` Airflow Variable"
+    )

--- a/backend/tests/unit/test_airflow_dag_data_quality.py
+++ b/backend/tests/unit/test_airflow_dag_data_quality.py
@@ -1,0 +1,45 @@
+"""
+Regression tests for the check_data_quality DAG task.
+
+F-06-003 (audit 2026-04, G2a sub-theme D step 12): the task called the
+non-existent method ``DataQualityChecker.check_recent_data_quality``,
+raising AttributeError at runtime.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+_DAG = (
+    Path(__file__).resolve().parents[3]
+    / "data_pipelines"
+    / "airflow"
+    / "dags"
+    / "ml_training_pipeline_dag.py"
+)
+
+
+def test_check_data_quality_does_not_call_removed_method() -> None:
+    """F-06-003: ``checker.check_recent_data_quality(...)`` call must be gone."""
+
+    text = _DAG.read_text()
+    assert not re.search(
+        r"\.check_recent_data_quality\s*\(", text
+    ), (
+        "ml_training_pipeline_dag.py still calls the non-existent "
+        "DataQualityChecker.check_recent_data_quality method"
+    )
+
+
+def test_check_data_quality_uses_existing_methods() -> None:
+    """F-06-003: must use real public surface of DataQualityChecker."""
+
+    text = _DAG.read_text()
+    assert "validate_price_data" in text, (
+        "check_data_quality must call validate_price_data on real rows"
+    )
+    assert "generate_quality_report" in text, (
+        "check_data_quality must call generate_quality_report to aggregate"
+    )

--- a/backend/tests/unit/test_airflow_dag_imports.py
+++ b/backend/tests/unit/test_airflow_dag_imports.py
@@ -1,0 +1,49 @@
+"""
+Regression tests for Airflow 1.x → 2.x import migration.
+
+F-06-001 (audit 2026-04, G2a sub-theme D step 10):
+``data_pipelines/airflow/dags/ml_training_pipeline_dag.py`` still imported
+from removed Airflow 1.x module paths:
+- ``airflow.operators.python_operator``
+- ``airflow.operators.bash_operator``
+- ``airflow.sensors.external_task_sensor``
+
+``airflow dags list`` surfaces ImportError for any DAG file containing
+these. The fail-first tests below scan the DAG source for the legacy
+paths.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+_DAGS_DIR = (
+    Path(__file__).resolve().parents[3]
+    / "data_pipelines"
+    / "airflow"
+    / "dags"
+)
+
+_REMOVED_IMPORTS = [
+    "airflow.operators.python_operator",
+    "airflow.operators.bash_operator",
+    "airflow.sensors.external_task_sensor",
+]
+
+
+@pytest.mark.parametrize("removed", _REMOVED_IMPORTS)
+def test_no_removed_airflow_1x_imports_in_dags(removed: str) -> None:
+    """F-06-001: removed Airflow 1.x import paths must not appear in DAGs."""
+
+    offenders = []
+    for dag_path in _DAGS_DIR.glob("*.py"):
+        text = dag_path.read_text()
+        if removed in text:
+            offenders.append(dag_path.name)
+    assert not offenders, (
+        f"DAG(s) still import the removed Airflow 1.x path {removed!r}: "
+        f"{offenders}"
+    )

--- a/backend/tests/unit/test_airflow_dag_numpy.py
+++ b/backend/tests/unit/test_airflow_dag_numpy.py
@@ -1,0 +1,32 @@
+"""
+Regression tests for missing numpy import in ml_training_pipeline_dag.
+
+F-06-002 (audit 2026-04, G2a sub-theme D step 11):
+``evaluate_models`` referenced ``np.random.randn`` without importing
+numpy, raising ``NameError`` at task execution time.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+_DAG = (
+    Path(__file__).resolve().parents[3]
+    / "data_pipelines"
+    / "airflow"
+    / "dags"
+    / "ml_training_pipeline_dag.py"
+)
+
+
+def test_numpy_is_imported() -> None:
+    """F-06-002: numpy must be imported wherever np.* is referenced."""
+
+    text = _DAG.read_text()
+    if "np." not in text:
+        return  # nothing to verify
+    assert re.search(r"^import numpy(\s+as\s+np)?$", text, re.MULTILINE), (
+        "ml_training_pipeline_dag.py uses np.* but does not import numpy"
+    )

--- a/backend/tests/unit/test_airflow_dag_vacuum.py
+++ b/backend/tests/unit/test_airflow_dag_vacuum.py
@@ -1,0 +1,55 @@
+"""
+Regression tests for VACUUM-in-transaction bug.
+
+F-06-004 (audit 2026-04, G2a sub-theme D step 15):
+``enhanced_stock_pipeline.cleanup_and_optimize`` issued
+``VACUUM ANALYZE ...`` through ``PostgresHook.run``, which wraps each
+statement in a transaction — Postgres rejects this with
+``ERROR: VACUUM cannot run inside a transaction block``. VACUUMs must
+go through a raw connection with isolation level AUTOCOMMIT.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+_DAG = (
+    Path(__file__).resolve().parents[3]
+    / "data_pipelines"
+    / "airflow"
+    / "dags"
+    / "enhanced_stock_pipeline.py"
+)
+
+
+def test_vacuum_not_run_through_pg_hook_run() -> None:
+    """F-06-004: VACUUM must not be issued via the transactional run() path."""
+
+    text = _DAG.read_text()
+    # The VACUUM strings live in a dedicated ``vacuum_queries`` list now.
+    assert "vacuum_queries" in text, (
+        "VACUUM statements should be isolated into a vacuum_queries list "
+        "so they bypass the transactional path"
+    )
+    # And the raw-connection autocommit hop must be present.
+    assert "set_isolation_level(0)" in text, (
+        "VACUUM block must use ``conn.set_isolation_level(0)`` "
+        "(AUTOCOMMIT) to satisfy Postgres"
+    )
+
+
+def test_vacuum_strings_not_inside_transactional_block() -> None:
+    """F-06-004: VACUUM statements must not be inside ``transactional_queries``."""
+
+    text = _DAG.read_text()
+    # Slice the file between transactional_queries = [ ... ] and verify no
+    # VACUUM string appears in that slice.
+    match = re.search(
+        r"transactional_queries\s*=\s*\[(.*?)\]", text, re.DOTALL
+    )
+    assert match is not None, "transactional_queries list not found"
+    assert "VACUUM" not in match.group(1).upper(), (
+        "VACUUM statement leaked back into the transactional list"
+    )

--- a/backend/tests/unit/test_cointegration_no_fake_johansen.py
+++ b/backend/tests/unit/test_cointegration_no_fake_johansen.py
@@ -1,0 +1,59 @@
+"""
+Regression tests for the Johansen "fake test" removal.
+
+F-09-007 (audit 2026-04, G2a sub-theme E step 39):
+``CointegrationAnalyzer._johansen_test`` silently delegated to
+Engle-Granger and returned its result. Callers selecting
+``CointegrationMethod.JOHANSEN`` believed they were getting a
+different statistical test but got identical numbers — false
+confidence in a downstream stat-arb strategy.
+
+Per workpaper §3, the cheaper-and-honest fix is to remove the
+JOHANSEN enum value entirely. If real Johansen support is needed
+later, implement properly via
+``statsmodels.tsa.vector_ar.vecm.coint_johansen``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "analytics"
+    / "statistical"
+    / "cointegration_analyzer.py"
+)
+
+
+def test_johansen_enum_value_removed() -> None:
+    """F-09-007: ``JOHANSEN = "johansen"`` enum member must be gone."""
+
+    text = _PATH.read_text()
+    # The actual enum-member line was ``    JOHANSEN = "johansen"``.
+    # Comments documenting the removal may still mention the name —
+    # match only the assignment form.
+    assert "JOHANSEN = " not in text, (
+        "CointegrationMethod still declares the JOHANSEN enum member"
+    )
+
+
+def test_johansen_method_helper_removed() -> None:
+    """F-09-007: ``def _johansen_test`` must be gone."""
+
+    text = _PATH.read_text()
+    assert "def _johansen_test" not in text, (
+        "_johansen_test helper still defined — it silently delegated to "
+        "Engle-Granger which is exactly the false-confidence bug"
+    )
+
+
+def test_test_cointegration_raises_for_unknown_method() -> None:
+    """F-09-007: passing a non-ENGLE_GRANGER method must raise, not fallthrough."""
+
+    text = _PATH.read_text()
+    assert "raise NotImplementedError" in text, (
+        "test_cointegration must raise NotImplementedError for unsupported "
+        "methods so callers cannot silently get the wrong test"
+    )

--- a/backend/tests/unit/test_dcf_no_self_mutation.py
+++ b/backend/tests/unit/test_dcf_no_self_mutation.py
@@ -1,0 +1,97 @@
+"""
+Regression tests for DCF sensitivity_analysis self-mutation.
+
+F-09-003 (audit 2026-04, G2a sub-theme E step 36):
+``DCFModel.sensitivity_analysis`` set ``self.terminal_growth_rate = gr``
+inside a nested loop, leaving the instance's terminal-growth-rate
+attribute set to the *last* growth rate tested after the method
+returned. Subsequent calls to ``calculate_intrinsic_value`` then used
+the wrong terminal growth rate.
+
+The fix threads ``terminal_growth_rate`` as a per-call parameter on
+``calculate_intrinsic_value`` and removes the mutation.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+
+_DCF = (
+    Path(__file__).resolve().parents[2]
+    / "analytics"
+    / "fundamental"
+    / "valuation"
+    / "dcf_model.py"
+)
+
+
+def _load_module(monkeypatch: pytest.MonkeyPatch):
+    for name in list(sys.modules):
+        if name == "backend" or name.startswith("backend."):
+            monkeypatch.delitem(sys.modules, name, raising=False)
+
+    name = "dcf_model_under_test"
+    spec = importlib.util.spec_from_file_location(name, _DCF)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[name] = module
+    monkeypatch.setitem(sys.modules, name, module)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_terminal_growth_rate_unchanged_after_sensitivity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """F-09-003: ``self.terminal_growth_rate`` must be the same value after sensitivity_analysis returns."""
+
+    mod = _load_module(monkeypatch)
+    model = mod.DCFModel(terminal_growth_rate=0.025)
+
+    model.sensitivity_analysis(
+        free_cash_flow=1_000_000,
+        discount_rates=[0.08, 0.10, 0.12],
+        growth_rates=[0.01, 0.02, 0.03, 0.04],
+        shares_outstanding=10_000,
+    )
+
+    assert model.terminal_growth_rate == 0.025, (
+        f"sensitivity_analysis mutated self.terminal_growth_rate "
+        f"(now {model.terminal_growth_rate})"
+    )
+
+
+def test_calculate_intrinsic_value_accepts_terminal_growth_rate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """F-09-003: calculate_intrinsic_value must accept terminal_growth_rate kwarg."""
+
+    mod = _load_module(monkeypatch)
+    model = mod.DCFModel(terminal_growth_rate=0.025)
+
+    r1 = model.calculate_intrinsic_value(
+        free_cash_flow=1_000_000,
+        discount_rate=0.10,
+        shares_outstanding=10_000,
+        terminal_growth_rate=0.01,
+    )
+    r2 = model.calculate_intrinsic_value(
+        free_cash_flow=1_000_000,
+        discount_rate=0.10,
+        shares_outstanding=10_000,
+        terminal_growth_rate=0.04,
+    )
+
+    # Higher terminal growth → higher intrinsic value (everything else equal).
+    assert r2.intrinsic_value > r1.intrinsic_value, (
+        f"expected r2 > r1 (terminal growth 0.04 > 0.01), "
+        f"got r1={r1.intrinsic_value}, r2={r2.intrinsic_value}"
+    )
+
+    # And the override must not have leaked back into the instance.
+    assert model.terminal_growth_rate == 0.025

--- a/backend/tests/unit/test_etl_extended_agent2.py
+++ b/backend/tests/unit/test_etl_extended_agent2.py
@@ -135,7 +135,11 @@ _dl = _load_etl_module("data_loader")
 # data_validator (no relative imports)
 _dv = _load_etl_module("data_validator")
 
-# unlimited_data_extractor (relative: none, but uses selenium etc. -- all stubbed)
+# F-05-005: both extractor modules now do ``from .types import ExtractionResult``.
+# Register the real types module so the relative import resolves.
+_types = _load_etl_module("types")
+
+# unlimited_data_extractor (relative: .types, plus selenium etc. -- all stubbed)
 _ude = _load_etl_module("unlimited_data_extractor")
 
 # intelligent_cache_system (no relative imports)

--- a/backend/tests/unit/test_etl_extended_agent3.py
+++ b/backend/tests/unit/test_etl_extended_agent3.py
@@ -120,6 +120,19 @@ sys.modules["_etl_pkg"] = _fake_pkg
 sys.modules["_etl_pkg.web_scrapers"] = _ws
 sys.modules["_etl_pkg.rate_limiting"] = _rl
 
+# F-05-005: the extractor modules now do ``from .types import
+# ExtractionResult``. Load the real types module under the synthetic
+# package so relative imports resolve.
+_types_spec = importlib.util.spec_from_file_location(
+    "_etl_pkg.types",
+    _etl_dir / "types.py",
+    submodule_search_locations=[],
+)
+_types = importlib.util.module_from_spec(_types_spec)
+_types.__package__ = "_etl_pkg"
+sys.modules["_etl_pkg.types"] = _types
+_types_spec.loader.exec_module(_types)
+
 _mse_spec = importlib.util.spec_from_file_location(
     "_etl_pkg.multi_source_extractor",
     _etl_dir / "multi_source_extractor.py",
@@ -139,12 +152,18 @@ extract_stocks_data = _mse.extract_stocks_data
 # ---------------------------------------------------------------------------
 # 4. Load unlimited_data_extractor
 # ---------------------------------------------------------------------------
+# F-05-005: unlimited_data_extractor now does ``from .types import
+# ExtractionResult``. Load under the synthetic ``_etl_pkg`` so the
+# relative import resolves to the same stub already registered above.
 _ude_spec = importlib.util.spec_from_file_location(
-    "unlimited_data_extractor",
+    "_etl_pkg.unlimited_data_extractor",
     _etl_dir / "unlimited_data_extractor.py",
+    submodule_search_locations=[],
 )
 _ude = importlib.util.module_from_spec(_ude_spec)
-sys.modules["unlimited_data_extractor"] = _ude
+_ude.__package__ = "_etl_pkg"
+sys.modules["_etl_pkg.unlimited_data_extractor"] = _ude
+sys.modules["unlimited_data_extractor"] = _ude  # legacy alias retained
 _ude_spec.loader.exec_module(_ude)
 
 StockData = _ude.StockData

--- a/backend/tests/unit/test_etl_extraction_result.py
+++ b/backend/tests/unit/test_etl_extraction_result.py
@@ -1,0 +1,70 @@
+"""
+Regression tests for the consolidated ExtractionResult type.
+
+F-05-005 (audit 2026-04, G2a sub-theme C step 22):
+``ExtractionResult`` was defined twice — once in
+``backend/etl/multi_source_extractor.py`` and once in
+``backend/etl/unlimited_data_extractor.py`` — with subtly different
+``data`` field types. ``isinstance()`` checks failed across the
+modules. Consolidated into ``backend/etl/types.py``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+_BASE = Path(__file__).resolve().parents[2] / "etl"
+
+
+def _load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_types_module_defines_extraction_result() -> None:
+    """F-05-005: canonical ExtractionResult lives in backend.etl.types."""
+
+    text = (_BASE / "types.py").read_text()
+    assert "class ExtractionResult" in text
+
+
+_RE_EXPORT_PATTERNS = (
+    "from backend.etl.types import ExtractionResult",
+    "from .types import ExtractionResult",
+)
+
+
+def test_multi_source_re_exports_extraction_result() -> None:
+    """F-05-005: multi_source_extractor re-exports from types module.
+
+    Accepts either the absolute (``backend.etl.types``) or relative
+    (``.types``) import form — both resolve to the same module.
+    """
+
+    text = (_BASE / "multi_source_extractor.py").read_text()
+    assert any(p in text for p in _RE_EXPORT_PATTERNS), (
+        "multi_source_extractor.py must re-export ExtractionResult from "
+        "backend.etl.types (absolute or relative form)"
+    )
+    occurrences = text.count("class ExtractionResult")
+    assert occurrences == 0, (
+        f"multi_source_extractor.py still defines its own "
+        f"ExtractionResult class ({occurrences} definition(s) found)"
+    )
+
+
+def test_unlimited_data_extractor_re_exports_extraction_result() -> None:
+    """F-05-005: unlimited_data_extractor re-exports from types module."""
+
+    text = (_BASE / "unlimited_data_extractor.py").read_text()
+    assert any(p in text for p in _RE_EXPORT_PATTERNS), (
+        "unlimited_data_extractor.py must re-export ExtractionResult from "
+        "backend.etl.types (absolute or relative form)"
+    )
+    occurrences = text.count("class ExtractionResult")
+    assert occurrences == 0

--- a/backend/tests/unit/test_etl_orchestrator_bounded_loop.py
+++ b/backend/tests/unit/test_etl_orchestrator_bounded_loop.py
@@ -1,0 +1,79 @@
+"""
+Regression tests for ETLOrchestrator distributed-pipeline bounded loop.
+
+F-05-002 (audit 2026-04, G2a sub-theme C step 24):
+``ETLOrchestrator._run_distributed_pipeline`` monitored job completion
+with ``while completed_jobs < len(job_ids)`` and only counted
+``status == 'completed'`` toward the exit condition. Any failed,
+cancelled, or errored job left the loop spinning forever. The created
+``processing_task`` was also never cancelled on exit, leaking the
+task.
+
+The fix:
+- counts terminal states (completed | failed | cancelled | error)
+- enforces ``ETL_DISTRIBUTED_MAX_WAIT_SECONDS`` (default 7200s)
+- cancels ``processing_task`` in ``finally``
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+_ORCHESTRATOR = (
+    Path(__file__).resolve().parents[2]
+    / "etl"
+    / "etl_orchestrator.py"
+)
+
+
+def test_terminal_states_counted_toward_exit() -> None:
+    """F-05-002: failed/cancelled/error jobs must also exit the loop."""
+
+    text = _ORCHESTRATOR.read_text()
+    assert "terminal_states" in text, (
+        "monitor loop must define a terminal_states set; otherwise failed "
+        "jobs leave the loop spinning"
+    )
+    for state in ("completed", "failed", "cancelled", "error"):
+        assert f'"{state}"' in text, (
+            f"terminal state {state!r} missing from the bounded loop"
+        )
+
+
+def test_max_wait_seconds_enforced() -> None:
+    """F-05-002: wall-clock bound prevents indefinite hang."""
+
+    text = _ORCHESTRATOR.read_text()
+    assert "max_wait_seconds" in text
+    assert "ETL_DISTRIBUTED_MAX_WAIT_SECONDS" in text, (
+        "max wait must be operator-configurable via env var"
+    )
+
+
+def test_processing_task_cancelled_in_finally() -> None:
+    """F-05-002: processing_task must not leak on exit."""
+
+    text = _ORCHESTRATOR.read_text()
+    # The monitor loop body must be guarded by a ``finally`` block that
+    # invokes both ``stop_processing()`` and ``processing_task.cancel()``.
+    finally_block = re.search(
+        r"finally:\s*\n\s*self\.distributed_processor\.stop_processing\(\)"
+        r".*?processing_task\.cancel\(\)",
+        text,
+        re.DOTALL,
+    )
+    assert finally_block is not None, (
+        "finally block must cancel processing_task and stop the processor"
+    )
+
+
+def test_no_unbounded_while_completed_lt_len() -> None:
+    """F-05-002: the original unbounded condition must be gone."""
+
+    text = _ORCHESTRATOR.read_text()
+    # The legacy line was ``while completed_jobs < len(job_ids):``.
+    assert "while completed_jobs < len(job_ids):" not in text, (
+        "unbounded ``while completed_jobs < len(job_ids):`` still present"
+    )

--- a/backend/tests/unit/test_etl_orchestrator_extractor_alias.py
+++ b/backend/tests/unit/test_etl_orchestrator_extractor_alias.py
@@ -1,0 +1,48 @@
+"""
+Regression tests for the ETLOrchestrator extractor alias.
+
+F-05-007 (audit 2026-04, G2a sub-theme C step 20):
+``ETLOrchestrator.__init__`` set ``self.legacy_extractor`` but two code
+paths (lines 387 and 633) referenced ``self.extractor``, raising
+AttributeError on every realtime/single-ticker call.
+
+This test inspects the source rather than instantiating the
+orchestrator, because instantiation pulls in the full backend stack
+(Postgres, Redis, validators).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+_ORCHESTRATOR = (
+    Path(__file__).resolve().parents[2]
+    / "etl"
+    / "etl_orchestrator.py"
+)
+
+
+def test_init_sets_extractor_alias() -> None:
+    """F-05-007: ``self.extractor`` must be assigned alongside legacy_extractor."""
+
+    text = _ORCHESTRATOR.read_text()
+    assert re.search(
+        r"self\.extractor\s*=\s*self\.legacy_extractor", text
+    ), (
+        "ETLOrchestrator.__init__ must alias self.extractor to the "
+        "legacy_extractor to satisfy the realtime/single-ticker paths"
+    )
+
+
+def test_extractor_references_have_a_defined_owner() -> None:
+    """F-05-007: every ``self.extractor.<method>(`` call must be backed by an init assignment."""
+
+    text = _ORCHESTRATOR.read_text()
+    extractor_calls = re.findall(r"self\.extractor\.\w+\(", text)
+    assert extractor_calls, "no self.extractor.* calls — bug spec stale?"
+    assert re.search(r"self\.extractor\s*=", text), (
+        f"self.extractor is referenced ({len(extractor_calls)} call sites) "
+        f"but never assigned"
+    )

--- a/backend/tests/unit/test_etl_selenium_guard.py
+++ b/backend/tests/unit/test_etl_selenium_guard.py
@@ -1,0 +1,90 @@
+"""
+Regression tests for the optional-selenium import guard.
+
+F-05-001 (audit 2026-04, G2a sub-theme C step 19):
+``backend/etl/unlimited_data_extractor.py`` had top-level ``from selenium ...``
+imports. In environments without selenium installed, the whole module
+failed to import, which cascaded through
+``unlimited_extractor_with_fallbacks`` → ``data_extractor``, making
+``from backend.etl.data_extractor import DataExtractor`` raise
+ModuleNotFoundError.
+"""
+
+from __future__ import annotations
+
+import builtins
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def test_module_imports_without_selenium(monkeypatch: pytest.MonkeyPatch) -> None:
+    """F-05-001: module must import even when selenium is missing.
+
+    Synthesises a ``loki_test_etl`` package, copies just the two files
+    we care about (``types.py`` and ``unlimited_data_extractor.py``)
+    into it, and imports under that name. This avoids both pulling in
+    the heavy real ``backend.etl`` package and dealing with relative
+    import edge cases under spec_from_file_location.
+    """
+
+    # Drop any cached selenium-touched modules.
+    for name in list(sys.modules):
+        if name.startswith("selenium") or "unlimited_data_extractor" in name:
+            del sys.modules[name]
+
+    real_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "selenium" or name.startswith("selenium."):
+            raise ImportError(f"simulated: {name} not installed")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    etl_dir = Path(__file__).resolve().parents[2] / "etl"
+    for heavy in ("aiohttp", "bs4", "pandas", "numpy", "yfinance", "requests"):
+        pytest.importorskip(heavy, reason=f"{heavy} not installed")
+
+    # Build a synthetic package on disk to host the two source files.
+    import tempfile
+    import shutil
+    import textwrap
+
+    with tempfile.TemporaryDirectory() as tmp:
+        pkg = Path(tmp) / "loki_test_etl"
+        pkg.mkdir()
+        (pkg / "__init__.py").write_text("")
+        shutil.copy(etl_dir / "types.py", pkg / "types.py")
+        shutil.copy(
+            etl_dir / "unlimited_data_extractor.py",
+            pkg / "unlimited_data_extractor.py",
+        )
+
+        monkeypatch.syspath_prepend(tmp)
+        module = importlib.import_module(
+            "loki_test_etl.unlimited_data_extractor"
+        )
+
+    assert hasattr(module, "SELENIUM_AVAILABLE")
+    assert module.SELENIUM_AVAILABLE is False
+
+
+def test_selenium_available_flag_exists_in_source() -> None:
+    """F-05-001: source-level guarantee of the SELENIUM_AVAILABLE flag."""
+
+    path = (
+        Path(__file__).resolve().parents[2]
+        / "etl"
+        / "unlimited_data_extractor.py"
+    )
+    text = path.read_text()
+    assert "SELENIUM_AVAILABLE" in text, (
+        "unlimited_data_extractor.py must export a SELENIUM_AVAILABLE flag"
+    )
+    assert "try:" in text and "from selenium import webdriver" in text, (
+        "selenium imports must live inside a try/except block"
+    )
+    assert "except ImportError" in text

--- a/backend/tests/unit/test_etl_sqlite_leak.py
+++ b/backend/tests/unit/test_etl_sqlite_leak.py
@@ -1,0 +1,73 @@
+"""
+Regression tests for sqlite FD leak.
+
+F-05-008 (audit 2026-04, G2a sub-theme C step 23):
+``backend/etl/distributed_batch_processor.py``, ``cache_storage.py``,
+and ``multi_source_extractor.py`` opened 18 raw ``sqlite3.connect(...)``
+handles. The happy paths called ``conn.close()`` but any exception
+between the connect and the close (e.g. SQL error mid-transaction)
+leaked the file descriptor — FD count grew unbounded under load.
+
+The fix wraps every connection in ``contextlib.closing`` so the
+descriptor is released on every code path, including exceptions.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+_TARGETS = [
+    Path(__file__).resolve().parents[2] / "etl" / "distributed_batch_processor.py",
+    Path(__file__).resolve().parents[2] / "etl" / "cache_storage.py",
+    Path(__file__).resolve().parents[2] / "etl" / "multi_source_extractor.py",
+]
+
+
+def test_no_unwrapped_sqlite_connect_assignment() -> None:
+    """F-05-008: ``conn = sqlite3.connect(...)`` (unwrapped) must be gone."""
+
+    offenders: list[str] = []
+    for p in _TARGETS:
+        text = p.read_text()
+        for m in re.finditer(r"^\s*conn\s*=\s*sqlite3\.connect\(", text, re.MULTILINE):
+            offenders.append(f"{p.name}:{text.count(chr(10), 0, m.start()) + 1}")
+    assert not offenders, (
+        f"unwrapped sqlite3.connect assignments remain — FD leak risk: {offenders}"
+    )
+
+
+def test_closing_helper_imported() -> None:
+    """F-05-008: each target module imports ``closing`` from contextlib."""
+
+    for p in _TARGETS:
+        text = p.read_text()
+        assert re.search(r"from contextlib import .*\bclosing\b", text), (
+            f"{p.name} must import ``closing`` from contextlib"
+        )
+
+
+def test_with_closing_sqlite3_pattern_present() -> None:
+    """F-05-008: each target uses ``with closing(sqlite3.connect(...))``."""
+
+    for p in _TARGETS:
+        text = p.read_text()
+        count = len(re.findall(r"with\s+closing\(\s*sqlite3\.connect\(", text))
+        assert count > 0, (
+            f"{p.name} must use ``with closing(sqlite3.connect(...))``"
+        )
+
+
+def test_total_sqlite_sites_match_expected() -> None:
+    """F-05-008: 18 total sqlite3.connect callsites all wrapped."""
+
+    total_wrapped = 0
+    total_calls = 0
+    for p in _TARGETS:
+        text = p.read_text()
+        total_wrapped += len(re.findall(r"with\s+closing\(\s*sqlite3\.connect\(", text))
+        total_calls += len(re.findall(r"sqlite3\.connect\(", text))
+    assert total_wrapped == total_calls == 18, (
+        f"expected 18/18 wrapped, got {total_wrapped}/{total_calls}"
+    )

--- a/backend/tests/unit/test_feature_store_macd_bollinger.py
+++ b/backend/tests/unit/test_feature_store_macd_bollinger.py
@@ -1,0 +1,157 @@
+"""
+Regression tests for MACD + Bollinger Bands builtin features.
+
+F-03-008 (audit 2026-04, G2a sub-theme A step 31):
+ML_PIPELINE_DOCUMENTATION.md advertised ``macd``, ``macd_signal``,
+``bollinger_upper_20d``, and ``bollinger_lower_20d`` as built-in
+features but the corresponding compute methods did not exist on
+``FeatureStore``. Calls to compute them silently returned ``None``
+(``builtin_features.get(...)``).
+
+This test verifies that the four feature names are now registered AND
+their compute methods produce sane numeric values on a synthetic price
+series.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import numpy as np
+import pandas as pd
+import pytest
+
+
+_FS_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "ml"
+    / "feature_store.py"
+)
+
+
+def _load_feature_store(monkeypatch: pytest.MonkeyPatch):
+    """Load feature_store with heavy deps stubbed where possible.
+
+    Earlier tests in the same session (notably
+    test_etl_extended_agent2.py) install MagicMocks at
+    ``sys.modules["backend.ml"]`` which break feature_store's
+    ``from backend.ml.feature_types import ...`` lookup. Drop those
+    polluted entries before loading so we get a clean import on the
+    real package path.
+    """
+
+    for name in list(sys.modules):
+        if name == "backend" or name.startswith("backend."):
+            monkeypatch.delitem(sys.modules, name, raising=False)
+
+    spec = importlib.util.spec_from_file_location(
+        "feature_store_under_test", _FS_PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _synth_close_series(start: float = 100.0, n: int = 60, drift: float = 0.5):
+    """A deterministic price series long enough for MACD+signal (>=35)."""
+    return [start + drift * i for i in range(n)]
+
+
+def _price_frame(ticker: str = "ACME"):
+    closes = _synth_close_series()
+    return pd.DataFrame({
+        "ticker": [ticker] * len(closes),
+        "date": pd.date_range("2024-01-01", periods=len(closes), freq="D"),
+        "close": closes,
+    })
+
+
+def test_macd_and_bollinger_registered(monkeypatch: pytest.MonkeyPatch) -> None:
+    """F-03-008: builtin_features dict must include the 4 documented names."""
+
+    text = _FS_PATH.read_text()
+    for name in ("macd", "macd_signal", "bollinger_upper_20d", "bollinger_lower_20d"):
+        assert f"'{name}'" in text, (
+            f"builtin_features must register {name!r}"
+        )
+        assert f"_compute_{name}" in text or f"_compute_bollinger_band" in text, (
+            f"compute method for {name!r} must exist"
+        )
+
+
+def test_macd_produces_finite_value(monkeypatch: pytest.MonkeyPatch) -> None:
+    """F-03-008: MACD = EMA(12)-EMA(26) over a 60-day series → finite float."""
+
+    mod = _load_feature_store(monkeypatch)
+    fs = mod.FeatureStore.__new__(mod.FeatureStore)
+    fs.computation_cache = {}
+
+    df = _price_frame("ACME")
+    result = fs._compute_macd(["ACME"], datetime.now(), {"price_data": df}, pd.DataFrame())
+    val = result.loc["ACME"]
+    assert np.isfinite(val), f"MACD must be finite for a healthy series, got {val!r}"
+
+
+def test_macd_signal_produces_finite_value(monkeypatch: pytest.MonkeyPatch) -> None:
+    """F-03-008: MACD signal = EMA(9) of MACD on a >=35-day series."""
+
+    mod = _load_feature_store(monkeypatch)
+    fs = mod.FeatureStore.__new__(mod.FeatureStore)
+    fs.computation_cache = {}
+
+    df = _price_frame("ACME")
+    result = fs._compute_macd_signal(["ACME"], datetime.now(), {"price_data": df}, pd.DataFrame())
+    val = result.loc["ACME"]
+    assert np.isfinite(val)
+
+
+def test_bollinger_bands_bracket_sma(monkeypatch: pytest.MonkeyPatch) -> None:
+    """F-03-008: upper > SMA(20) > lower for any positive-volatility window."""
+
+    mod = _load_feature_store(monkeypatch)
+    fs = mod.FeatureStore.__new__(mod.FeatureStore)
+    fs.computation_cache = {}
+
+    # Use a series with real volatility (drift + noise) so std > 0.
+    closes = [100.0 + 0.5 * i + (3.0 if i % 2 == 0 else -3.0) for i in range(60)]
+    df = pd.DataFrame({
+        "ticker": ["ACME"] * len(closes),
+        "date": pd.date_range("2024-01-01", periods=len(closes), freq="D"),
+        "close": closes,
+    })
+
+    sma = fs._compute_sma_20d(["ACME"], datetime.now(), {"price_data": df}, pd.DataFrame()).loc["ACME"]
+    upper = fs._compute_bollinger_upper_20d(["ACME"], datetime.now(), {"price_data": df}, pd.DataFrame()).loc["ACME"]
+    lower = fs._compute_bollinger_lower_20d(["ACME"], datetime.now(), {"price_data": df}, pd.DataFrame()).loc["ACME"]
+
+    assert lower < sma < upper, (
+        f"expected lower < sma < upper; got lower={lower}, sma={sma}, upper={upper}"
+    )
+
+
+def test_short_series_returns_nan(monkeypatch: pytest.MonkeyPatch) -> None:
+    """F-03-008: insufficient data → NaN, not crash."""
+
+    mod = _load_feature_store(monkeypatch)
+    fs = mod.FeatureStore.__new__(mod.FeatureStore)
+    fs.computation_cache = {}
+
+    # Only 10 days of data — too short for any of the 4 features.
+    df = pd.DataFrame({
+        "ticker": ["X"] * 10,
+        "date": pd.date_range("2024-01-01", periods=10, freq="D"),
+        "close": [100.0 + i for i in range(10)],
+    })
+    for method in (
+        fs._compute_macd,
+        fs._compute_macd_signal,
+        fs._compute_bollinger_upper_20d,
+        fs._compute_bollinger_lower_20d,
+    ):
+        out = method(["X"], datetime.now(), {"price_data": df}, pd.DataFrame())
+        assert np.isnan(out.loc["X"]), f"{method.__name__} on short series should be NaN"

--- a/backend/tests/unit/test_hybrid_engine_error_path.py
+++ b/backend/tests/unit/test_hybrid_engine_error_path.py
@@ -1,0 +1,105 @@
+"""
+Regression tests for hybrid_engine._create_error_recommendation.
+
+F-09-005 (audit 2026-04, G2a sub-theme E step 35):
+The error-fallback factory passed ``recommendation="HOLD"`` and
+``overall_score=0.5`` to ``EnhancedStockRecommendation(...)`` —
+neither is a declared field on the dataclass or its parent. Worse,
+many parent-required fields (priority, entry_price, time_horizon_days,
+etc.) were missing, so the constructor TypeError'd on every error
+path. The error fallback itself was broken.
+
+This test verifies source-level shape rather than instantiating the
+class, because EnhancedStockRecommendation pulls in
+``backend.analytics.recommendation_engine`` which transitively imports
+heavy ML deps.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+_HE = (
+    Path(__file__).resolve().parents[2]
+    / "analytics"
+    / "agents"
+    / "hybrid_engine.py"
+)
+
+
+def test_error_recommendation_does_not_pass_unknown_kwargs() -> None:
+    """F-09-005: ``recommendation=`` and ``overall_score=`` kwargs are gone."""
+
+    text = _HE.read_text()
+    # Locate the _create_error_recommendation block.
+    body = re.search(
+        r"def _create_error_recommendation\(.*?\n    [^ ]",
+        text,
+        re.DOTALL,
+    )
+    assert body is not None, "could not locate _create_error_recommendation"
+    block = body.group(0)
+    assert "recommendation=\"HOLD\"" not in block, (
+        "_create_error_recommendation must not pass ``recommendation=`` "
+        "(use ``action=RecommendationAction.HOLD`` instead)"
+    )
+    assert "overall_score=" not in block, (
+        "_create_error_recommendation must not pass ``overall_score=`` "
+        "(not a declared field on StockRecommendation)"
+    )
+
+
+def test_error_recommendation_uses_recommendation_action_enum() -> None:
+    """F-09-005: error path must use the real ``action`` field + enum."""
+
+    text = _HE.read_text()
+    assert "RecommendationAction.HOLD" in text, (
+        "error path must use RecommendationAction.HOLD on the action field"
+    )
+
+
+def test_error_recommendation_supplies_all_parent_required_fields() -> None:
+    """F-09-005: every required parent field must be passed."""
+
+    text = _HE.read_text()
+    block = re.search(
+        r"return EnhancedStockRecommendation\((.*?)\n        \)",
+        text,
+        re.DOTALL,
+    )
+    assert block is not None, "error path return block not found"
+    body = block.group(1)
+
+    required = [
+        "ticker", "action", "confidence", "priority",
+        "entry_price", "target_price", "stop_loss", "expected_return",
+        "time_horizon_days",
+        "risk_score", "volatility", "beta", "sharpe_ratio", "max_drawdown",
+        "technical_score", "fundamental_score", "sentiment_score",
+        "ml_prediction_score",
+        "technical_analysis", "fundamental_analysis", "sentiment_analysis",
+        "ml_predictions",
+        "key_factors", "risks", "opportunities", "catalysts",
+        "generated_at", "valid_until",
+        "recommended_allocation", "max_position_size",
+    ]
+    missing = [f for f in required if f"{f}=" not in body]
+    assert not missing, (
+        f"_create_error_recommendation missing parent-required kwargs: {missing}"
+    )
+
+
+def test_no_self_overall_score_access() -> None:
+    """F-09-005: hybrid score logic must not read self.overall_score."""
+
+    text = _HE.read_text()
+    # Allow it in comments / docstrings (rationale text), forbid in code.
+    code_lines = [
+        line for line in text.splitlines()
+        if "self.overall_score" in line and not line.lstrip().startswith("#")
+    ]
+    assert not code_lines, (
+        f"self.overall_score is accessed in non-comment code: {code_lines}"
+    )

--- a/backend/tests/unit/test_ml_api_server_e2e_path_traversal.py
+++ b/backend/tests/unit/test_ml_api_server_e2e_path_traversal.py
@@ -1,0 +1,178 @@
+"""
+HTTP-level end-to-end test for F-03-006 (model_name path traversal).
+
+The companion unit test ``test_ml_api_server_path_traversal.py`` covers the
+validator helpers (``_validate_model_name``, ``_safe_model_path``) directly
+with FastAPI stubbed out. This file complements it with a true E2E test
+that drives the real ``app`` via ``fastapi.testclient.TestClient``,
+exercising routing → validator → exception handler → status-code
+mapping end-to-end. The acceptance criterion from the workpaper is:
+
+    curl -X POST .../models/../../../etc/passwd/load → 400 (not 500)
+
+Source-level grep tests catch the validator's existence; this test
+proves the HTTP boundary actually returns 400 with a useful body
+instead of leaking a 500 stack trace.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Project root for backend.* package resolution under --noconftest.
+_PROJECT_ROOT = Path(__file__).resolve().parents[3]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+
+@pytest.fixture(scope="module")
+def client():
+    """A real TestClient over the production FastAPI app.
+
+    Defensively evicts ``sys.modules`` entries for fastapi /
+    pydantic / backend.* / joblib / uvicorn before importing, so a
+    sibling test that stubbed those (like
+    ``test_ml_api_server_path_traversal.py`` which inserts
+    ``MagicMock`` instances to test the validator helpers in
+    isolation) doesn't leak its stubs into our real-FastAPI import.
+    """
+    for prefix in (
+        "fastapi", "pydantic", "backend", "joblib", "uvicorn",
+        "ml_api_server_under_test",
+    ):
+        for name in list(sys.modules):
+            if name == prefix or name.startswith(prefix + "."):
+                del sys.modules[name]
+
+    from fastapi.testclient import TestClient
+    from backend.ml.ml_api_server import app
+
+    return TestClient(app)
+
+
+# Inputs WITHOUT path separators that DO route to the load endpoint —
+# these are rejected by the application-level validator with HTTP 400.
+# (The route pattern ``/models/{model_name}/load`` only matches a single
+# path segment, so slash-containing inputs never reach the handler;
+# those are tested separately below as routing-layer rejections.)
+VALIDATOR_REJECTED_INPUTS = [
+    "model;rmrf",          # shell semicolon
+    "model$(whoami)",      # command substitution
+    "model`id`",           # backtick command sub
+    "model with spaces",   # spaces
+    "model.pkl",           # dot (rule is [A-Za-z0-9_-]+)
+    "model@bad",           # @ symbol
+    "model#hash",          # hash
+]
+
+# Inputs WITH path separators (raw or URL-encoded). These never reach
+# the handler because Starlette path routing rejects them — the URL
+# doesn't match the single-segment ``{model_name}`` pattern. Either way
+# the security outcome is correct: no 500, no filesystem touch.
+ROUTING_REJECTED_INPUTS = [
+    "..",                           # bare dotdot — URL-normalized to /load (parent dir)
+    "../../../etc/passwd",          # raw traversal
+    "%2e%2e/%2e%2e/etc/passwd",     # URL-encoded traversal
+    "model/with/slashes",           # embedded slashes
+    "..%2F..%2Fetc%2Fpasswd",       # mixed encoding
+]
+
+
+@pytest.mark.parametrize("bad_name", VALIDATOR_REJECTED_INPUTS)
+def test_validator_rejects_single_segment_inputs_with_http_400(
+    client, bad_name: str
+) -> None:
+    """F-03-006: malformed single-segment ``model_name`` → HTTP 400 (not 500).
+
+    These inputs all reach ``load_model_endpoint`` because they don't
+    contain path separators. The application-level
+    ``_validate_model_name`` regex (``[A-Za-z0-9_-]+``) rejects each,
+    raising ValueError → mapped to HTTP 400 by the ``except ValueError``
+    arm.
+    """
+    from urllib.parse import quote
+
+    encoded = quote(bad_name, safe="")
+    resp = client.post(f"/models/{encoded}/load")
+
+    assert resp.status_code == 400, (
+        f"input {bad_name!r} → HTTP {resp.status_code} "
+        f"(body: {resp.text[:200]!r})"
+    )
+
+    body = resp.json()
+    assert "detail" in body
+    detail = body["detail"].lower()
+    assert "model_name" in detail or "invalid" in detail, (
+        f"response detail must mention the validation failure: {body!r}"
+    )
+
+
+@pytest.mark.parametrize("bad_name", ROUTING_REJECTED_INPUTS)
+def test_routing_rejects_path_traversal_at_starlette_layer(
+    client, bad_name: str
+) -> None:
+    """F-03-006: traversal inputs with separators never reach the handler.
+
+    Starlette's single-segment ``{model_name}`` route pattern can't
+    match a path with embedded slashes (raw or URL-encoded). The
+    request is rejected with HTTP 404 BEFORE any handler runs — which
+    is the strongest possible security outcome: no application code is
+    invoked, no filesystem touch happens, no stack trace leaks.
+
+    Critical assertion: response code is NOT 500 and the body does NOT
+    leak a stack trace.
+    """
+    from urllib.parse import quote
+
+    encoded = quote(bad_name, safe="")
+    resp = client.post(f"/models/{encoded}/load")
+
+    assert resp.status_code in (404, 400, 422), (
+        f"traversal input {bad_name!r} produced unexpected HTTP "
+        f"{resp.status_code} (body: {resp.text[:200]!r})"
+    )
+    assert resp.status_code != 500, (
+        f"server returned 500 on traversal input {bad_name!r} — "
+        f"FileNotFoundError or stack trace leaking?"
+    )
+    # Stack trace check: body should be plain JSON, not a traceback.
+    body_text = resp.text
+    for tb_marker in ("Traceback", "File \"", "line "):
+        assert tb_marker not in body_text, (
+            f"response body contains traceback marker {tb_marker!r}: "
+            f"{body_text[:300]!r}"
+        )
+
+
+def test_load_model_endpoint_500_not_leaked_on_traversal(client) -> None:
+    """F-03-006 anti-regression: traversal must NOT produce HTTP 500.
+
+    Critical security property: the previous version leaked
+    ``FileNotFoundError`` (HTTP 500) for any input, which both confirmed
+    the traversal attempt was attempted on the filesystem AND included
+    a stack trace in the response. Both signals are gone.
+    """
+    resp = client.post("/models/..%2F..%2F..%2Fetc%2Fpasswd/load")
+    assert resp.status_code != 500, (
+        f"traversal input produced HTTP 500 — server is still leaking "
+        f"stack traces for malformed model names (body: {resp.text[:300]!r})"
+    )
+
+
+def test_load_model_endpoint_accepts_well_formed_name(client) -> None:
+    """F-03-006 sanity: legitimate name passes validation, fails at filesystem.
+
+    A name like ``test_model`` should clear ``_validate_model_name`` +
+    ``_safe_model_path`` and reach ``FileNotFoundError`` → HTTP 404.
+    This distinguishes "bad input" (400) from "no such model" (404).
+    """
+    resp = client.post("/models/test_model_does_not_exist/load")
+    # Valid name → no traversal → FileNotFoundError → 404.
+    assert resp.status_code == 404, (
+        f"well-formed name should yield 404 (not found), got "
+        f"HTTP {resp.status_code}: {resp.text[:200]!r}"
+    )

--- a/backend/tests/unit/test_ml_api_server_path_traversal.py
+++ b/backend/tests/unit/test_ml_api_server_path_traversal.py
@@ -1,0 +1,128 @@
+"""
+Regression tests for the model path-traversal guard.
+
+F-03-006 (audit 2026-04, G2a sub-theme A step 28):
+``backend/ml/ml_api_server.py`` accepted an arbitrary ``model_name``
+from the ``POST /models/{model_name}/load`` route and concatenated it
+directly into a filesystem path. A caller could supply
+``../../../etc/passwd`` (or any other traversal) and read host files
+through the model-load surface. The fix enforces a strict character
+class AND verifies the resolved path stays under the models root.
+
+The module imports FastAPI / uvicorn which the audit env may not have.
+We exercise the validator helpers directly via ``importlib.util``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+
+_API_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "ml"
+    / "ml_api_server.py"
+)
+
+
+def _load_module(monkeypatch: pytest.MonkeyPatch):
+    """Load ml_api_server with FastAPI / uvicorn / joblib stubbed out."""
+
+    for name in (
+        "fastapi", "fastapi.middleware", "fastapi.middleware.cors",
+        "fastapi.responses", "uvicorn", "joblib", "pydantic",
+    ):
+        if name not in sys.modules:
+            stub = MagicMock()
+            stub.__path__ = []
+            sys.modules[name] = stub
+
+    # FastAPI() returns an app; patch its decorators to be no-ops.
+    fastapi_stub = sys.modules["fastapi"]
+    fake_app = MagicMock()
+    for method in ("get", "post", "put", "delete", "on_event"):
+        getattr(fake_app, method).return_value = lambda f: f
+    fastapi_stub.FastAPI = MagicMock(return_value=fake_app)
+    fastapi_stub.HTTPException = type("HTTPException", (Exception,), {
+        "__init__": lambda self, status_code, detail: setattr(self, "status_code", status_code) or setattr(self, "detail", detail)
+    })
+    fastapi_stub.BackgroundTasks = MagicMock()
+
+    pydantic_stub = sys.modules["pydantic"]
+    pydantic_stub.BaseModel = type("BaseModel", (), {})
+    pydantic_stub.Field = lambda *a, **kw: None
+
+    spec = importlib.util.spec_from_file_location(
+        "ml_api_server_under_test", _API_PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.parametrize(
+    "bad_name",
+    [
+        "../../../etc/passwd",
+        "model/../../../secret",
+        "..",
+        "/etc/passwd",
+        "model with spaces",
+        "model;rm -rf /",
+        "model$(whoami)",
+        "",
+        "model.pkl",  # would build path with .pkl.pkl, but the dot is also invalid
+    ],
+)
+def test_validate_rejects_path_traversal_attempts(
+    monkeypatch: pytest.MonkeyPatch, bad_name: str
+) -> None:
+    """F-03-006: any non-[A-Za-z0-9_-]+ name must raise ValueError."""
+
+    mod = _load_module(monkeypatch)
+    with pytest.raises(ValueError, match="invalid model_name"):
+        mod._validate_model_name(bad_name)
+
+
+def test_validate_accepts_well_formed_names(monkeypatch: pytest.MonkeyPatch) -> None:
+    """F-03-006: legitimate names pass through unchanged."""
+
+    mod = _load_module(monkeypatch)
+    for ok in ("xgboost_v1", "lstm-30d", "abc", "Model_42"):
+        assert mod._validate_model_name(ok) == ok
+
+
+def test_safe_model_path_returns_path_under_root(monkeypatch: pytest.MonkeyPatch) -> None:
+    """F-03-006: ``_safe_model_path`` resolves under the configured root."""
+
+    mod = _load_module(monkeypatch)
+    p = mod._safe_model_path(mod._MODELS_ROOT, "good_name", ".pkl")
+    # Must be relative to the configured root.
+    p.relative_to(mod._MODELS_ROOT)
+
+
+def test_load_model_rejects_traversal_before_filesystem_touch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """F-03-006: load_model() raises before any joblib.load() call."""
+
+    mod = _load_module(monkeypatch)
+    # Patch joblib.load to a sentinel that would mark the test as
+    # "validator did not run".
+    called = {"value": False}
+
+    def fail_joblib_load(_path):
+        called["value"] = True
+        raise AssertionError("joblib.load was reached on bad input")
+
+    monkeypatch.setattr(mod.joblib, "load", fail_joblib_load)
+
+    with pytest.raises(ValueError):
+        mod.load_model("../../../etc/passwd")
+    assert called["value"] is False

--- a/backend/tests/unit/test_ml_log_path_anchored.py
+++ b/backend/tests/unit/test_ml_log_path_anchored.py
@@ -1,0 +1,68 @@
+"""
+Regression tests for the __file__-anchored ML log path.
+
+F-03-007 (audit 2026-04, G2a sub-theme A step 29):
+``backend/ml/training_pipeline.py`` and ``simple_training_pipeline.py``
+configured logging.FileHandler with the relative path
+``'backend/ml_logs/...'``. Run from any cwd other than the repo root,
+this created a stray ``backend/ml_logs/`` directory next to the
+caller and orphaned the log files.
+
+The fix anchors the log directory to ``Path(__file__).parent.parent.parent /
+"backend" / "ml_logs"`` so the location is invariant under cwd.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+_TARGETS = [
+    Path(__file__).resolve().parents[2] / "ml" / "training_pipeline.py",
+    Path(__file__).resolve().parents[2] / "ml" / "simple_training_pipeline.py",
+    Path(__file__).resolve().parents[2] / "ml" / "minimal_training.py",
+]
+
+
+def test_no_unanchored_backend_ml_logs_string() -> None:
+    """F-03-007: bare ``'backend/ml_logs/...'`` literal must not appear in FileHandler."""
+
+    for p in _TARGETS:
+        text = p.read_text()
+        # The legacy form was
+        # ``logging.FileHandler('backend/ml_logs/training_...')``.
+        assert not re.search(
+            r"FileHandler\(\s*['\"]backend/ml_logs/", text
+        ), (
+            f"{p.name} still uses unanchored 'backend/ml_logs/' string in "
+            f"FileHandler — log path is cwd-dependent"
+        )
+
+
+def test_file_anchored_log_dir_present() -> None:
+    """F-03-007: each target derives the log dir from ``__file__``."""
+
+    for p in _TARGETS:
+        text = p.read_text()
+        assert re.search(
+            r"Path\(__file__\)\.resolve\(\)\.parent\.parent\.parent",
+            text,
+        ), (
+            f"{p.name} must derive the ml_logs directory from "
+            f"Path(__file__).resolve().parent.parent.parent"
+        )
+
+
+def test_log_dir_creation_is_idempotent() -> None:
+    """F-03-007: target must mkdir(parents=True, exist_ok=True)."""
+
+    for p in _TARGETS:
+        text = p.read_text()
+        # Either an explicit mkdir() on the derived path, or the target
+        # is the unit test stub which doesn't need it. Both training
+        # pipelines must explicitly create the directory.
+        if p.name in ("training_pipeline.py", "simple_training_pipeline.py", "minimal_training.py"):
+            assert "mkdir(parents=True, exist_ok=True)" in text, (
+                f"{p.name} must mkdir the log dir on import"
+            )

--- a/backend/tests/unit/test_mpt_optimizer_targets.py
+++ b/backend/tests/unit/test_mpt_optimizer_targets.py
@@ -1,0 +1,118 @@
+"""
+Regression tests for MPT optimizer target enforcement.
+
+F-09-010 (audit 2026-04, G2a sub-theme E step 40):
+``PortfolioOptimizer.optimize`` ignored ``target_return`` and
+``target_volatility`` parameters entirely — it always returned equal
+weights regardless of what the caller requested. The efficient frontier
+helper that walks ``target_return`` values produced 50 identical
+results.
+
+The fix uses ``scipy.optimize.minimize(method="SLSQP")`` to actually
+solve the mean-variance problem.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+
+_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "analytics"
+    / "portfolio"
+    / "modern_portfolio_theory.py"
+)
+
+
+def _load(monkeypatch: pytest.MonkeyPatch):
+    for name in list(sys.modules):
+        if name == "backend" or name.startswith("backend."):
+            monkeypatch.delitem(sys.modules, name, raising=False)
+    spec = importlib.util.spec_from_file_location("mpt_under_test", _PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules["mpt_under_test"] = module
+    monkeypatch.setitem(sys.modules, "mpt_under_test", module)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _three_asset_returns():
+    """Three assets with distinct mean returns so a real solver moves weights."""
+    rng = np.random.default_rng(42)
+    n = 252
+    # Asset A: high return, high vol.
+    a = rng.normal(0.0008, 0.02, n)
+    # Asset B: medium.
+    b = rng.normal(0.0004, 0.015, n)
+    # Asset C: low return, low vol.
+    c = rng.normal(0.0002, 0.008, n)
+    return pd.DataFrame({"A": a, "B": b, "C": c})
+
+
+def test_no_target_maximizes_sharpe(monkeypatch: pytest.MonkeyPatch) -> None:
+    """F-09-010: with no target, optimizer should not produce equal weights."""
+
+    mod = _load(monkeypatch)
+    opt = mod.PortfolioOptimizer()
+    result = opt.optimize(_three_asset_returns())
+    weights = np.array(list(result.weights.values()))
+    # Equal-weight signature would be [1/3, 1/3, 1/3] exactly.
+    assert not np.allclose(weights, 1.0 / 3, atol=1e-6), (
+        f"optimizer returned equal weights {weights} — the solver did not run"
+    )
+    assert abs(weights.sum() - 1.0) < 1e-6
+
+
+def test_target_return_constraint_is_enforced(monkeypatch: pytest.MonkeyPatch) -> None:
+    """F-09-010: portfolio return must meet or exceed the target."""
+
+    mod = _load(monkeypatch)
+    opt = mod.PortfolioOptimizer()
+    df = _three_asset_returns()
+    # Pick a target somewhere in the middle of the feasible range.
+    target = df.mean().mean() * 252  # average annualized return
+    result = opt.optimize(df, target_return=target)
+    assert result.expected_return >= target - 1e-3, (
+        f"target_return={target:.4f} not met (got {result.expected_return:.4f})"
+    )
+
+
+def test_target_volatility_constraint_is_enforced(monkeypatch: pytest.MonkeyPatch) -> None:
+    """F-09-010: portfolio volatility must not exceed the target."""
+
+    mod = _load(monkeypatch)
+    opt = mod.PortfolioOptimizer()
+    df = _three_asset_returns()
+    # Pick a relatively tight vol cap that should bind.
+    target_vol = 0.15
+    result = opt.optimize(df, target_volatility=target_vol)
+    assert result.volatility <= target_vol + 1e-3, (
+        f"target_volatility={target_vol} exceeded (got {result.volatility:.4f})"
+    )
+
+
+def test_efficient_frontier_walks_returns(monkeypatch: pytest.MonkeyPatch) -> None:
+    """F-09-010: efficient frontier must produce varying portfolios.
+
+    ``get_efficient_frontier`` yields a list of ``(volatility, return)``
+    tuples — we expect the return coordinate to vary across the 10
+    points (previously every point was identical because the underlying
+    optimizer ignored the target_return).
+    """
+
+    mod = _load(monkeypatch)
+    opt = mod.PortfolioOptimizer()
+    df = _three_asset_returns()
+    frontier = opt.get_efficient_frontier(df, n_points=10)
+    rets = [ret for (_vol, ret) in frontier]
+    assert len(set(round(r, 4) for r in rets)) > 1, (
+        f"efficient frontier collapsed to a single point: {rets}"
+    )

--- a/backend/tests/unit/test_recommendation_engine_sentiment.py
+++ b/backend/tests/unit/test_recommendation_engine_sentiment.py
@@ -1,0 +1,57 @@
+"""
+Regression tests for _run_sentiment_analysis.
+
+F-09-001 (audit 2026-04, G2a sub-theme E step 32):
+``recommendation_engine._run_sentiment_analysis`` called
+``self.sentiment_engine.analyze_sentiment(ticker, text_data)`` but
+``analyze_sentiment`` is the per-text entrypoint with signature
+``(text: str, source: str = "unknown")`` — it rejects the
+list-of-dicts shape this method assembles, raising AttributeError /
+TypeError on every call.
+
+The fix delegates to ``analyze_stock_sentiment(ticker, texts: List[str])``
+and adapts the returned ``SentimentResult`` back to the dict shape
+downstream consumers read via ``sentiment_analysis.get('overall_sentiment',
+...)``.
+
+Tests inspect source rather than instantiating the engine (which pulls
+in heavy ML deps).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+_ENGINE = (
+    Path(__file__).resolve().parents[2]
+    / "analytics"
+    / "recommendation_engine.py"
+)
+
+
+def test_uses_analyze_stock_sentiment_not_analyze_sentiment() -> None:
+    """F-09-001: must call analyze_stock_sentiment with extracted text list."""
+
+    text = _ENGINE.read_text()
+    # The legacy buggy call.
+    assert "self.sentiment_engine.analyze_sentiment(ticker, text_data)" not in text, (
+        "_run_sentiment_analysis still calls analyze_sentiment with "
+        "the list-of-dicts shape; that method takes (text: str, source: str)"
+    )
+    # The corrected call.
+    assert re.search(
+        r"analyze_stock_sentiment\(\s*ticker\s*,\s*\[",
+        text,
+    ), "_run_sentiment_analysis must call analyze_stock_sentiment(ticker, [...])"
+
+
+def test_returns_overall_sentiment_dict_shape() -> None:
+    """F-09-001: downstream consumers expect ``overall_sentiment`` key."""
+
+    text = _ENGINE.read_text()
+    # The dict-shape adapter must still emit 'overall_sentiment' so the
+    # downstream get('overall_sentiment', {}).get('score', 0) keeps
+    # working.
+    assert "'overall_sentiment'" in text and "'score'" in text

--- a/backend/tests/unit/test_recommendation_risk_free_and_portfolio_size.py
+++ b/backend/tests/unit/test_recommendation_risk_free_and_portfolio_size.py
@@ -1,0 +1,98 @@
+"""
+Regression tests for risk-free rate + portfolio size config plumbing.
+
+F-09-008 (audit 2026-04, G2a sub-theme E step 37):
+backend/analytics/recommendation_engine.py:429 hardcoded
+``risk_free_rate = 0.045`` inside the Sharpe-ratio calculation,
+silently drifting from FundamentalAnalysisEngine.risk_free_rate.
+
+F-09-009 (step 38):
+backend/analytics/recommendation_scoring.py:398 hardcoded
+``portfolio_size = 100_000`` inside ``calculate_position_sizing`` and
+recommendation_ranking.py:147 multiplied ``weight * 100_000`` —
+neither was configurable, so max-position-size dollars never tracked
+the actual portfolio.
+
+Source-level tests because the modules pull in a large transitive
+graph (technical/fundamental/sentiment engines).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+_ENGINE = (
+    Path(__file__).resolve().parents[2]
+    / "analytics"
+    / "recommendation_engine.py"
+)
+_RANKING = (
+    Path(__file__).resolve().parents[2]
+    / "analytics"
+    / "recommendation_ranking.py"
+)
+_SCORING = (
+    Path(__file__).resolve().parents[2]
+    / "analytics"
+    / "recommendation_scoring.py"
+)
+
+
+def test_no_hardcoded_risk_free_rate_in_engine() -> None:
+    """F-09-008: bare ``risk_free_rate = 0.045`` literal must be gone."""
+
+    text = _ENGINE.read_text()
+    assert not re.search(
+        r"^\s*risk_free_rate\s*=\s*0\.045\s*$", text, re.MULTILINE
+    ), "recommendation_engine.py still has a hardcoded risk_free_rate constant"
+
+
+def test_engine_syncs_risk_free_rate_with_fundamental_engine() -> None:
+    """F-09-008: engine must pull from FundamentalAnalysisEngine."""
+
+    text = _ENGINE.read_text()
+    assert "self.risk_free_rate = self.fundamental_engine.risk_free_rate" in text, (
+        "RecommendationEngine.__init__ must source risk_free_rate from "
+        "self.fundamental_engine.risk_free_rate so the two stay in sync"
+    )
+
+
+def test_no_hardcoded_portfolio_size_constant() -> None:
+    """F-09-009: bare ``portfolio_size = 100_000`` must be gone from scoring."""
+
+    text = _SCORING.read_text()
+    assert not re.search(
+        r"^\s*portfolio_size\s*=\s*100_000\s*$", text, re.MULTILINE
+    ), "recommendation_scoring.py still has a hardcoded portfolio_size constant"
+
+
+def test_scoring_accepts_portfolio_size_param() -> None:
+    """F-09-009: ``calculate_position_sizing`` must accept portfolio_size kwarg."""
+
+    text = _SCORING.read_text()
+    assert "portfolio_size: float = 100_000" in text, (
+        "calculate_position_sizing must accept portfolio_size as a parameter"
+    )
+
+
+def test_ranking_accepts_portfolio_size_param() -> None:
+    """F-09-009: ``optimize_recommendations`` must accept portfolio_size kwarg."""
+
+    text = _RANKING.read_text()
+    assert "portfolio_size: float = 100_000" in text, (
+        "optimize_recommendations must accept portfolio_size as a parameter"
+    )
+    assert "weight * portfolio_size" in text, (
+        "max_position_size assignment must use the portfolio_size parameter"
+    )
+
+
+def test_engine_reads_default_portfolio_size_from_env() -> None:
+    """F-09-009: engine sources portfolio size from DEFAULT_PORTFOLIO_SIZE env."""
+
+    text = _ENGINE.read_text()
+    assert "DEFAULT_PORTFOLIO_SIZE" in text, (
+        "engine must default portfolio_size from the DEFAULT_PORTFOLIO_SIZE env var"
+    )

--- a/backend/tests/unit/test_sec_edgar_contact_email.py
+++ b/backend/tests/unit/test_sec_edgar_contact_email.py
@@ -1,0 +1,57 @@
+"""
+Regression tests for SEC EDGAR contact email enforcement.
+
+F-05-006 (audit 2026-04, G2a sub-theme C step 21):
+``backend/data_ingestion/sec_edgar_client.py`` shipped a
+``contact@example.com`` placeholder in its User-Agent header. SEC
+throttles or bans clients that don't supply real contact info, so this
+silently degraded fundamentals fetching.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+_CLIENT = (
+    Path(__file__).resolve().parents[2]
+    / "data_ingestion"
+    / "sec_edgar_client.py"
+)
+
+
+def test_no_placeholder_email_in_user_agent() -> None:
+    """F-05-006: hardcoded ``contact@example.com`` must be gone."""
+
+    text = _CLIENT.read_text()
+    # The literal string survives in the validation message (used to
+    # reject the env value), but not as a User-Agent default. The
+    # disqualifying pattern is the User-Agent f-string with example.com.
+    assert "(contact@example.com)" not in text, (
+        "sec_edgar_client.py still embeds the placeholder contact email "
+        "directly in the User-Agent header"
+    )
+
+
+def test_reads_contact_email_from_env() -> None:
+    """F-05-006: must source contact email from ``SEC_EDGAR_CONTACT_EMAIL``."""
+
+    text = _CLIENT.read_text()
+    assert "SEC_EDGAR_CONTACT_EMAIL" in text, (
+        "sec_edgar_client.py must read SEC_EDGAR_CONTACT_EMAIL env var"
+    )
+    assert re.search(
+        r"os\.getenv\(\s*[\"']SEC_EDGAR_CONTACT_EMAIL", text
+    ), "must use os.getenv to read SEC_EDGAR_CONTACT_EMAIL"
+
+
+def test_fails_loudly_on_missing_email() -> None:
+    """F-05-006: missing/placeholder env var must raise at construction."""
+
+    text = _CLIENT.read_text()
+    assert "raise RuntimeError" in text or "raise ValueError" in text, (
+        "sec_edgar_client.py must raise when SEC_EDGAR_CONTACT_EMAIL is "
+        "missing or set to a placeholder — silent degradation would let "
+        "us run unidentified against sec.gov"
+    )

--- a/backend/tests/unit/test_sentiment_stubs_wired.py
+++ b/backend/tests/unit/test_sentiment_stubs_wired.py
@@ -1,0 +1,84 @@
+"""
+Regression tests for sentiment-stub wiring against SmartDataFetcher.
+
+F-09-006 (audit 2026-04, G2a sub-theme E step 41):
+``SentimentAnalysisEngine.get_news_sentiment`` returned hardcoded
+neutral with ``source: 'news_placeholder'`` regardless of input.
+``get_social_sentiment`` did the same with ``confidence=0.5`` — a
+lie that overstated availability.
+
+Now that F-05-004 has wired SmartDataFetcher to real clients,
+get_news_sentiment delegates to it. get_social_sentiment remains a
+sentinel (no ingestion source exists) but with ``confidence=0.0``
+and a loud warning so consumers can detect the no-data path.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "analytics"
+    / "sentiment_analysis.py"
+)
+
+
+def test_news_stub_calls_smart_fetcher() -> None:
+    """F-09-006: get_news_sentiment must delegate to SmartDataFetcher."""
+
+    text = _PATH.read_text()
+    assert "from backend.data_ingestion.smart_data_fetcher import get_smart_fetcher" in text
+    assert 'fetch_stock_data(ticker, "news")' in text, (
+        "get_news_sentiment must call the SmartDataFetcher news endpoint"
+    )
+
+
+def test_news_stub_runs_real_analysis_on_articles() -> None:
+    """F-09-006: news path must feed articles into analyze_stock_sentiment."""
+
+    text = _PATH.read_text()
+    assert "return await self.analyze_stock_sentiment(ticker, texts)" in text, (
+        "get_news_sentiment must run the real batch analyzer over fetched texts"
+    )
+
+
+def test_no_news_placeholder_source_label() -> None:
+    """F-09-006: legacy ``news_placeholder`` literal must be gone."""
+
+    text = _PATH.read_text()
+    assert "'news_placeholder'" not in text, (
+        "get_news_sentiment still emits the legacy news_placeholder source label"
+    )
+
+
+def test_social_stub_drops_confidence_to_zero() -> None:
+    """F-09-006: social stub must not lie about confidence."""
+
+    text = _PATH.read_text()
+    # The legacy stub returned confidence=0.5; check the new sentinel
+    # path explicitly notes confidence=0.0 and is unimplemented.
+    assert "'social_unimplemented'" in text or "social_unimplemented" in text, (
+        "social stub must label its source as social_unimplemented"
+    )
+    # Find the get_social_sentiment block and verify it doesn't ship
+    # confidence=0.5.
+    import re
+    block = re.search(
+        r"def get_social_sentiment.*?(?=\n    async def |\Z)",
+        text, re.DOTALL,
+    )
+    assert block is not None
+    assert "confidence=0.5" not in block.group(0), (
+        "get_social_sentiment must not return confidence=0.5 for a no-data path"
+    )
+
+
+def test_social_stub_logs_warning() -> None:
+    """F-09-006: social stub must log a loud warning per workpaper §9."""
+
+    text = _PATH.read_text()
+    assert "is not implemented (F-09-006)" in text, (
+        "social stub must log a warning naming the finding ID"
+    )

--- a/backend/tests/unit/test_smart_data_fetcher.py
+++ b/backend/tests/unit/test_smart_data_fetcher.py
@@ -1,0 +1,114 @@
+"""
+Regression tests for SmartDataFetcher real-source delegation.
+
+F-05-004 (audit 2026-04, G2a sub-theme C step 25): the previous
+implementation returned hardcoded zeros / empty lists from every
+``_fetch_*`` method with ``source: "mock"``. The new implementation
+delegates to the real clients and returns ``source: "unavailable"``
+only when every client failed or is not configured.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+
+_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "data_ingestion"
+    / "smart_data_fetcher.py"
+)
+
+
+def _load_module(monkeypatch: pytest.MonkeyPatch):
+    """Load smart_data_fetcher in isolation with logging stubbed."""
+
+    spec = importlib.util.spec_from_file_location(
+        "smart_data_fetcher_under_test", _PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_price_fetcher_delegates_to_finnhub(monkeypatch: pytest.MonkeyPatch) -> None:
+    """F-05-004: finnhub get_quote result must populate the price payload."""
+
+    mod = _load_module(monkeypatch)
+    fetcher = mod.SmartDataFetcher()
+
+    finnhub_stub = AsyncMock()
+    finnhub_stub.get_quote = AsyncMock(return_value={"c": 195.5, "d": 1.5, "dp": 0.77, "v": 12345})
+    monkeypatch.setattr(fetcher, "_get_client", lambda n: finnhub_stub if n == "finnhub" else None)
+
+    result = asyncio.run(fetcher._fetch_price_data("AAPL"))
+    assert result["ticker"] == "AAPL"
+    assert result["price"] == 195.5
+    assert result["source"] == "finnhub"
+
+
+def test_price_fetcher_falls_through_to_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
+    """F-05-004: no working client → source == 'unavailable' (not 'mock')."""
+
+    mod = _load_module(monkeypatch)
+    fetcher = mod.SmartDataFetcher()
+    monkeypatch.setattr(fetcher, "_get_client", lambda n: None)
+
+    result = asyncio.run(fetcher._fetch_price_data("AAPL"))
+    assert result["source"] == "unavailable"
+    assert result["price"] == 0.0  # sentinel value preserved
+
+
+def test_fundamentals_uses_finnhub_metric_dict(monkeypatch: pytest.MonkeyPatch) -> None:
+    """F-05-004: finnhub.get_basic_financials shape is consumed correctly."""
+
+    mod = _load_module(monkeypatch)
+    fetcher = mod.SmartDataFetcher()
+
+    finnhub_stub = AsyncMock()
+    finnhub_stub.get_basic_financials = AsyncMock(return_value={
+        "metric": {
+            "peNormalizedAnnual": 28.4,
+            "marketCapitalization": 3_000_000,
+            "epsAnnual": 6.84,
+            "dividendYieldIndicatedAnnual": 0.005,
+        }
+    })
+    monkeypatch.setattr(fetcher, "_get_client", lambda n: finnhub_stub if n == "finnhub" else None)
+
+    result = asyncio.run(fetcher._fetch_fundamentals("AAPL"))
+    assert result["source"] == "finnhub"
+    assert result["pe_ratio"] == 28.4
+    assert result["market_cap"] == 3_000_000
+    assert result["eps"] == 6.84
+
+
+def test_no_mock_source_label_in_implementation() -> None:
+    """F-05-004: ``"source": "mock"`` literal must be gone."""
+
+    text = _PATH.read_text()
+    assert '"source": "mock"' not in text, (
+        "smart_data_fetcher.py must no longer ship hardcoded mock source labels"
+    )
+
+
+def test_client_failure_falls_through(monkeypatch: pytest.MonkeyPatch) -> None:
+    """F-05-004: a raising client must not crash the fetcher."""
+
+    mod = _load_module(monkeypatch)
+    fetcher = mod.SmartDataFetcher()
+
+    failing = AsyncMock()
+    failing.get_quote = AsyncMock(side_effect=RuntimeError("api down"))
+    monkeypatch.setattr(fetcher, "_get_client", lambda n: failing if n == "finnhub" else None)
+
+    # Should fall through to unavailable, not raise.
+    result = asyncio.run(fetcher._fetch_price_data("AAPL"))
+    assert result["source"] == "unavailable"

--- a/backend/tests/unit/test_stock_recommendation_ranking_score.py
+++ b/backend/tests/unit/test_stock_recommendation_ranking_score.py
@@ -1,0 +1,109 @@
+"""
+Regression tests for StockRecommendation.ranking_score field.
+
+F-09-004 (audit 2026-04, G2a sub-theme E step 34):
+The ranking layer assigned ``rec.ranking_score = X`` on every
+recommendation, but ``StockRecommendation`` had no such field — the
+attribute survived as an ad-hoc instance attr that disappeared from
+``dataclasses.asdict(rec)`` and ``to_dict()`` output. Consumers reading
+the serialized form (storage, API responses) never saw the score.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import importlib.util
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+
+_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "analytics"
+    / "recommendation_types.py"
+)
+
+
+def _load_module(monkeypatch: pytest.MonkeyPatch):
+    # Drop polluted backend.* sys.modules entries first.
+    for name in list(sys.modules):
+        if name == "backend" or name.startswith("backend."):
+            monkeypatch.delitem(sys.modules, name, raising=False)
+
+    name = "recommendation_types_under_test"
+    spec = importlib.util.spec_from_file_location(name, _PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    # @dataclass resolves forward refs by looking up cls.__module__ in
+    # sys.modules; register before exec to avoid AttributeError.
+    sys.modules[name] = module
+    monkeypatch.setitem(sys.modules, name, module)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _build_rec(mod):
+    return mod.StockRecommendation(
+        ticker="ACME",
+        action=mod.RecommendationAction.BUY,
+        confidence=0.8,
+        priority=5,
+        entry_price=100.0,
+        target_price=120.0,
+        stop_loss=90.0,
+        expected_return=0.2,
+        time_horizon_days=30,
+        risk_score=0.3,
+        volatility=0.2,
+        beta=1.1,
+        sharpe_ratio=1.5,
+        max_drawdown=0.1,
+        technical_score=0.7,
+        fundamental_score=0.6,
+        sentiment_score=0.5,
+        ml_prediction_score=0.65,
+        technical_analysis={},
+        fundamental_analysis={},
+        sentiment_analysis={},
+        ml_predictions={},
+        key_factors=[],
+        risks=[],
+        opportunities=[],
+        catalysts=[],
+        generated_at=datetime.now(timezone.utc),
+        valid_until=datetime.now(timezone.utc),
+        recommended_allocation=0.05,
+        max_position_size=10_000.0,
+    )
+
+
+def test_dataclass_has_ranking_score_field(monkeypatch: pytest.MonkeyPatch) -> None:
+    """F-09-004: ``ranking_score`` must be a declared field on the dataclass."""
+
+    mod = _load_module(monkeypatch)
+    fields = {f.name for f in dataclasses.fields(mod.StockRecommendation)}
+    assert "ranking_score" in fields, (
+        "StockRecommendation must declare ranking_score as a dataclass field"
+    )
+
+
+def test_default_ranking_score_is_zero(monkeypatch: pytest.MonkeyPatch) -> None:
+    """F-09-004: ``ranking_score`` defaults to 0.0 when not supplied."""
+
+    mod = _load_module(monkeypatch)
+    rec = _build_rec(mod)
+    assert rec.ranking_score == 0.0
+
+
+def test_asdict_includes_ranking_score(monkeypatch: pytest.MonkeyPatch) -> None:
+    """F-09-004: serialization paths surface ranking_score."""
+
+    mod = _load_module(monkeypatch)
+    rec = _build_rec(mod)
+    rec.ranking_score = 0.87
+    assert dataclasses.asdict(rec)["ranking_score"] == 0.87
+    assert rec.to_dict()["ranking_score"] == 0.87

--- a/backend/tests/unit/test_torch_load_weights_only.py
+++ b/backend/tests/unit/test_torch_load_weights_only.py
@@ -1,0 +1,73 @@
+"""
+Regression tests for ``torch.load(weights_only=True)`` enforcement.
+
+F-03-002 (audit 2026-04, G2a sub-theme A step 27):
+Five ``torch.load(...)`` callsites in ``backend/ml/`` deserialized
+artifacts with the default ``weights_only=False``, which is
+pickle-based and equivalent to arbitrary code execution if an
+attacker can write to (or substitute) a model artifact path. CVE
+class: torch.load pickle RCE (cf. CVE-2025-32434).
+
+The workpaper acceptance gate is:
+
+    grep -rn "torch.load" backend/ml/ | grep -v weights_only
+
+returning empty. The literal pattern collides with the explanatory
+docstring/comments that document the fix, so the tighter form below
+matches only the function-call syntax (``torch.load(``) — preserving
+the audit intent without flagging the rationale comments. See
+[[feedback_test_anchor_logic]] in user memory.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+_ML_DIR = Path(__file__).resolve().parents[2] / "ml"
+
+
+def test_every_torch_load_call_passes_weights_only() -> None:
+    """F-03-002: every ``torch.load(...)`` invocation must include weights_only."""
+
+    offenders: list[str] = []
+    for py in _ML_DIR.rglob("*.py"):
+        text = py.read_text()
+        # Match the call form ``torch.load(`` and capture up to the
+        # matching close-paren on the same statement.
+        for m in re.finditer(r"torch\.load\(([^)]*)\)", text):
+            args = m.group(1)
+            if "weights_only" not in args:
+                line_no = text.count("\n", 0, m.start()) + 1
+                offenders.append(f"{py.relative_to(_ML_DIR.parent)}:{line_no}")
+    assert not offenders, (
+        f"torch.load call(s) without weights_only kwarg — RCE risk: {offenders}"
+    )
+
+
+def test_weights_only_value_is_true_not_false() -> None:
+    """F-03-002: ``weights_only=False`` is the unsafe default; ban it."""
+
+    offenders: list[str] = []
+    for py in _ML_DIR.rglob("*.py"):
+        text = py.read_text()
+        for m in re.finditer(
+            r"torch\.load\([^)]*weights_only\s*=\s*False[^)]*\)", text
+        ):
+            line_no = text.count("\n", 0, m.start()) + 1
+            offenders.append(f"{py.relative_to(_ML_DIR.parent)}:{line_no}")
+    assert not offenders, (
+        f"torch.load called with weights_only=False — unsafe: {offenders}"
+    )
+
+
+def test_expected_callsite_count_unchanged() -> None:
+    """F-03-002: still exactly 5 callsites after the patch."""
+
+    count = 0
+    for py in _ML_DIR.rglob("*.py"):
+        count += len(re.findall(r"torch\.load\(", py.read_text()))
+    assert count == 5, (
+        f"expected 5 torch.load callsites in backend/ml/, found {count}"
+    )

--- a/backend/tests/unit/test_torch_load_weights_only.py
+++ b/backend/tests/unit/test_torch_load_weights_only.py
@@ -63,11 +63,21 @@ def test_weights_only_value_is_true_not_false() -> None:
 
 
 def test_expected_callsite_count_unchanged() -> None:
-    """F-03-002: still exactly 5 callsites after the patch."""
+    """F-03-002: every torch.load callsite in backend/ml/ is guarded.
+
+    Originally 5 callsites at audit time. After commit f5dd8ac on main
+    (file-relocation refactor that introduced ``runtime_models.py``)
+    the count is 7 — this PR guards the 2 new state_dict loads too.
+    The meaningful contract is in
+    ``test_every_torch_load_call_passes_weights_only``; this test
+    just records the current expected count so unexpected new
+    callsites (e.g. a future refactor) get flagged for review.
+    """
 
     count = 0
     for py in _ML_DIR.rglob("*.py"):
         count += len(re.findall(r"torch\.load\(", py.read_text()))
-    assert count == 5, (
-        f"expected 5 torch.load callsites in backend/ml/, found {count}"
+    assert count == 7, (
+        f"expected 7 torch.load callsites in backend/ml/ post f5dd8ac, "
+        f"found {count}"
     )

--- a/data_pipelines/airflow/dags/daily_stock_pipeline.py
+++ b/data_pipelines/airflow/dags/daily_stock_pipeline.py
@@ -38,8 +38,6 @@ from airflow.providers.postgres.operators.postgres import PostgresOperator
 from airflow.providers.postgres.hooks.postgres import PostgresHook
 from airflow.sensors.base import BaseSensorOperator
 from airflow.utils.task_group import TaskGroup
-from airflow.models import Pool
-from airflow.utils.db import create_session
 from airflow.exceptions import AirflowException
 from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor, as_completed
 import yfinance as yf
@@ -119,7 +117,7 @@ dag = DAG(
     'daily_stock_pipeline',
     default_args=default_args,
     description='Optimized daily stock data ingestion with native parallel processing (6000+ stocks)',
-    schedule_interval='0 6 * * 1-5',  # 6 AM ET, weekdays only
+    schedule='0 6 * * 1-5',  # 6 AM ET, weekdays only
     catchup=False,
     max_active_runs=1,  # Prevent overlapping runs
     max_active_tasks=MAX_ACTIVE_TIS_PER_DAG,  # Limit concurrent tasks
@@ -163,17 +161,11 @@ class MarketHoursSensor(BaseSensorOperator):
         return is_after_close
 
 
-def ensure_pool_exists():
-    """Ensure the API rate limiting pool exists"""
-    with create_session() as session:
-        pool = session.query(Pool).filter(Pool.pool == POOL_NAME).first()
-        if not pool:
-            pool = Pool(pool=POOL_NAME, slots=POOL_SLOTS, description='Pool for stock API rate limiting')
-            session.add(pool)
-            session.commit()
-            logger.info(f"Created pool '{POOL_NAME}' with {POOL_SLOTS} slots")
-        else:
-            logger.info(f"Pool '{POOL_NAME}' already exists with {pool.slots} slots")
+# F-06-006: ``airflow.utils.db.create_session`` was removed from public
+# API; runtime pool creation from DAG code is also discouraged. Create
+# the pool at deployment time with:
+#     airflow pools set stock_api_pool 8 "Pool for stock API rate limiting"
+# The DAG references the pool by name via ``POOL_NAME``.
 
 
 def get_all_active_stocks(**context) -> List[str]:
@@ -775,13 +767,7 @@ def calculate_indicators_parallel(**context) -> Dict[str, Any]:
 
 
 def calculate_rsi(prices: List[float], period: int = 14) -> float:
-    """
-    Calculate RSI indicator.
-
-    DEPRECATED: This function is kept for backward compatibility.
-    The main indicator calculation now uses PostgreSQL window functions
-    in calculate_indicators_parallel() for better performance.
-    """
+    """Calculate RSI indicator (fallback path)."""
     if len(prices) < period:
         return 50.0
 
@@ -798,13 +784,7 @@ def calculate_rsi(prices: List[float], period: int = 14) -> float:
 
 
 def calculate_macd(prices: List[float]) -> Tuple[float, float]:
-    """
-    Calculate MACD indicator.
-
-    DEPRECATED: This function is kept for backward compatibility.
-    The main indicator calculation now uses PostgreSQL window functions
-    in calculate_indicators_parallel() for better performance.
-    """
+    """Calculate MACD indicator (fallback path)."""
     if len(prices) < 26:
         return 0.0, 0.0
 
@@ -1568,8 +1548,8 @@ Parallelism Configuration:
 # DAG TASK DEFINITIONS WITH NATIVE PARALLELISM
 # ============================================================================
 
-# Initialize pool on DAG load
-ensure_pool_exists()
+# F-06-006: pool now created at deployment time via ``airflow pools set``;
+# DAG load no longer mutates the metadata DB.
 
 with dag:
     # -------------------------------------------------------------------------
@@ -1676,19 +1656,3 @@ with dag:
     fetch_group >> indicator_group >> finalize_group >> summary_task >> end_task
 
 
-# ============================================================================
-# LEGACY FUNCTIONS (kept for backwards compatibility and fallback)
-# These use ThreadPoolExecutor approach - superseded by native Airflow parallelism
-# Can be used if Airflow version < 2.3 doesn't support dynamic task mapping
-# ============================================================================
-
-# NOTE: The following functions are DEPRECATED but kept for reference:
-# - parallel_fetch_stock_data(): Uses ThreadPoolExecutor in single task
-# - calculate_indicators_parallel(): Uses sequential batch processing
-# - process_stock_batch(): Original batch processor
-# - fetch_batch_data_worker(): Worker for ThreadPoolExecutor
-#
-# The new approach (above) uses:
-# - prepare_stock_batches() + fetch_stock_batch.expand() for true parallelism
-# - prepare_indicator_batches() + calculate_indicators_batch.expand()
-# - Each batch is a separate Airflow task with individual monitoring/retry

--- a/data_pipelines/airflow/dags/enhanced_stock_pipeline.py
+++ b/data_pipelines/airflow/dags/enhanced_stock_pipeline.py
@@ -37,7 +37,7 @@ dag = DAG(
     'enhanced_stock_pipeline',
     default_args=default_args,
     description='Enhanced daily stock data ETL pipeline',
-    schedule_interval='0 6 * * *',  # Run at 6 AM daily
+    schedule='0 6 * * *',  # Run at 6 AM daily
     catchup=False,
     tags=['stocks', 'etl', 'production'],
 )
@@ -248,33 +248,51 @@ def cleanup_and_optimize(**context):
     # Additional cleanup via SQL
     pg_hook = PostgresHook(postgres_conn_id='postgres_default')
     
-    cleanup_queries = [
+    transactional_queries = [
         # Archive old recommendations
         """
-        UPDATE recommendations 
-        SET is_active = false 
+        UPDATE recommendations
+        SET is_active = false
         WHERE created_at < CURRENT_DATE - INTERVAL '30 days'
         AND is_active = true
         """,
-        
         # Clean up old pipeline logs
         """
-        DELETE FROM pipeline_logs 
+        DELETE FROM pipeline_logs
         WHERE run_date < CURRENT_DATE - INTERVAL '90 days'
         """,
-        
-        # Vacuum and analyze for performance
+    ]
+
+    # F-06-004: VACUUM cannot run inside a transaction block. PostgresHook.run
+    # wraps statements in a transaction by default, which produces
+    # ``ERROR: VACUUM cannot run inside a transaction block``. Drop to a raw
+    # psycopg2 connection with isolation level AUTOCOMMIT (= 0) for the
+    # maintenance commands.
+    vacuum_queries = [
         "VACUUM ANALYZE price_history",
         "VACUUM ANALYZE technical_indicators",
-        "VACUUM ANALYZE recommendations"
+        "VACUUM ANALYZE recommendations",
     ]
-    
-    for query in cleanup_queries:
+
+    for query in transactional_queries:
         try:
             pg_hook.run(query)
             logging.info(f"Executed cleanup: {query[:50]}...")
         except Exception as e:
             logging.error(f"Cleanup query failed: {e}")
+
+    conn = pg_hook.get_conn()
+    try:
+        conn.set_isolation_level(0)  # ISOLATION_LEVEL_AUTOCOMMIT
+        with conn.cursor() as cur:
+            for query in vacuum_queries:
+                try:
+                    cur.execute(query)
+                    logging.info(f"Executed maintenance: {query}")
+                except Exception as e:
+                    logging.error(f"Maintenance query failed: {e}")
+    finally:
+        conn.close()
     
     logging.info("Cleanup and optimization completed")
 

--- a/data_pipelines/airflow/dags/ml_training_pipeline_dag.py
+++ b/data_pipelines/airflow/dags/ml_training_pipeline_dag.py
@@ -21,9 +21,9 @@ Expected speedup with GPU: 3-4x faster training per model
 
 from datetime import datetime, timedelta, timezone
 from airflow import DAG
-from airflow.operators.python_operator import PythonOperator
-from airflow.operators.bash_operator import BashOperator
-from airflow.sensors.external_task_sensor import ExternalTaskSensor
+from airflow.operators.python import PythonOperator
+from airflow.operators.bash import BashOperator
+from airflow.sensors.external_task import ExternalTaskSensor
 from airflow.utils.dates import days_ago
 from airflow.models import Variable
 import sys
@@ -31,6 +31,8 @@ import os
 import asyncio
 import json
 import logging
+
+import numpy as np
 
 # Add backend to path
 sys.path.append('/app')
@@ -110,7 +112,14 @@ default_args = {
     'owner': 'ml-team',
     'depends_on_past': False,
     'start_date': days_ago(1),
-    'email': ['ml-alerts@company.com'],
+    # F-06-009: alert recipients now come from the ``ml_alert_emails``
+    # Airflow Variable (comma-separated). Falls back to empty list when
+    # unset so DAG load does not fail in fresh environments.
+    'email': [
+        e.strip()
+        for e in Variable.get("ml_alert_emails", default_var="").split(",")
+        if e.strip()
+    ],
     'email_on_failure': True,
     'email_on_retry': False,
     'retries': 2,
@@ -122,7 +131,7 @@ dag = DAG(
     'ml_training_pipeline',
     default_args=default_args,
     description='Automated ML Model Training and Retraining Pipeline',
-    schedule_interval='0 2 * * *',  # Daily at 2 AM
+    schedule='0 2 * * *',  # Daily at 2 AM
     catchup=False,
     max_active_runs=1,
     tags=['ml', 'training', 'production'],
@@ -165,29 +174,76 @@ def initialize_orchestrator(**context):
 
 
 def check_data_quality(**context):
-    """Check data quality and determine if training should proceed"""
+    """Check data quality and determine if training should proceed.
+
+    F-06-003: ``DataQualityChecker.check_recent_data_quality`` does not
+    exist on the real class. Uses the real public surface:
+    ``validate_price_data`` per recent batch, aggregated through
+    ``generate_quality_report``. Derives the DAG-level thresholds
+    (``missing_data_rate``, ``anomaly_rate``) from the resulting issues.
+    """
+    import pandas as pd
+    from airflow.providers.postgres.hooks.postgres import PostgresHook
+
     from backend.utils.data_quality import DataQualityChecker
-    
+
     checker = DataQualityChecker()
-    
-    # Get recent data statistics
-    quality_report = checker.check_recent_data_quality(
-        table="price_history",
-        days_back=7
+    pg = PostgresHook(postgres_conn_id="postgres_default")
+
+    cutoff = (datetime.now(timezone.utc) - timedelta(days=7)).strftime("%Y-%m-%d")
+    df = pg.get_pandas_df(
+        f"""
+        SELECT date, symbol, open, high, low, close, volume
+        FROM price_history
+        WHERE date >= '{cutoff}'
+        """
     )
-    
-    # Check quality thresholds
-    if quality_report['missing_data_rate'] > 0.1:
-        logger.warning(f"High missing data rate: {quality_report['missing_data_rate']}")
+
+    if df is None or df.empty:
+        logger.warning("No price_history rows in last 7 days; skipping training")
         return "skip_training"
-    
-    if quality_report['anomaly_rate'] > 0.05:
-        logger.warning(f"High anomaly rate: {quality_report['anomaly_rate']}")
+
+    validation_results = [
+        checker.validate_price_data(group, symbol=str(symbol))
+        for symbol, group in df.groupby("symbol")
+    ]
+
+    quality_report = checker.generate_quality_report(validation_results)
+
+    # Map the aggregated report to the thresholds this DAG cares about.
+    total_issues = sum(
+        len(r.get("issues", [])) for r in validation_results
+    )
+    missing_issues = sum(
+        1
+        for r in validation_results
+        for issue in r.get("issues", [])
+        if issue.get("type") == "missing_values"
+    )
+    anomaly_issues = sum(
+        1
+        for r in validation_results
+        for issue in r.get("issues", [])
+        if issue.get("type") in {"price_outlier", "volume_anomaly"}
+    )
+    denom = max(len(validation_results), 1)
+    missing_data_rate = missing_issues / denom
+    anomaly_rate = anomaly_issues / denom
+    quality_report["missing_data_rate"] = missing_data_rate
+    quality_report["anomaly_rate"] = anomaly_rate
+    quality_report["total_issues"] = total_issues
+
+    if missing_data_rate > 0.1:
+        logger.warning(f"High missing data rate: {missing_data_rate}")
+        return "skip_training"
+
+    if anomaly_rate > 0.05:
+        logger.warning(f"High anomaly rate: {anomaly_rate}")
         return "needs_review"
-    
-    # Store quality report
-    context['task_instance'].xcom_push(key='data_quality_report', value=quality_report)
-    
+
+    context["task_instance"].xcom_push(
+        key="data_quality_report", value=quality_report
+    )
     return "proceed_training"
 
 


### PR DESCRIPTION
## Summary

**Split of PR #186** per option 1 of the conflict analysis (see #186 comment-4480051725).

Contains only the active-code-path findings from wave3-G2a — drops the 10 sub-theme B commits whose target (`backend/TradingAgents/`) was deleted on main in commit `2c2ac5d` (archived to `backend/_archive_TradingAgents_fork_pre_2026-05-12/`). Those 9 findings need a separate disposition decision (port to canonical `TRADINGAGENTS_PATH` workspace, relocate to archive, or formally drop).

**This PR is mergeable into main cleanly** — no modify-vs-delete conflicts.

## Findings closed (30)

| Sub-theme | Closed | Findings |
|-----------|--------|----------|
| **C** Ingestion | **7/8** | F-05-001/2/4/5/6/7/8 (F-05-009 Kafka deferred) |
| **D** Airflow | **8/9** | F-06-001/2/3/4/5/6/7/9 (F-06-008 in #187) |
| **A** ML engine | **4/5** | F-03-002/6/7/8 (F-03-004 in #187) |
| **E** Analytics | **9/10** | F-09-001/3/4/5/6/7/8/9/10 (F-09-002 Q3=C streaming deferred) |
| Tooling polish | — | `chore(python-pro)` minor type/scope tightening |

**Plus a scope expansion for F-03-002**: main's commit `f5dd8ac` introduced `backend/ml/runtime_models.py` with 2 new `torch.load` callsites (lines 311, 314) — both now guarded with `weights_only=True`. The acceptance test was updated to expect 7 callsites (was 5 at audit time).

## Test coverage

**532/532 tests pass** in the full session sweep, including:
- 18 new fail-first source-level regression tests
- The recovered Wave-1 ETL extended suites (`test_etl_extended_agent2`, `test_etl_extended_agent3`)

Every fix shipped with a fail-first `--noconftest` regression test anchored to the workpaper's grep gates.

## Operator-facing changes

| Knob | Default | Purpose |
|------|---------|---------|
| `SEC_EDGAR_CONTACT_EMAIL` | **required** (raises if unset or `example.com`) | F-05-006 |
| `DEFAULT_PORTFOLIO_SIZE` | `100000` | F-09-009 |
| `ETL_DISTRIBUTED_MAX_WAIT_SECONDS` | `7200` | F-05-002 |
| Airflow Variable `ml_alert_emails` | unset (empty alerts) | F-06-009 |
| Airflow pool `stock_api_pool` | required, `airflow pools set stock_api_pool 8 ...` at deploy | F-06-006 |

## Sub-theme B (F-04-001..009) — deliberately not in this PR

These 9 findings target `backend/TradingAgents/` which main has archived. They need their own path:

1. Port the fixes to the canonical external TradingAgents repo at `TRADINGAGENTS_PATH` (most rigorous; separate repo).
2. Relocate the fixes into `backend/_archive_TradingAgents_fork_pre_2026-05-12/` (historical record only).
3. Drop with a memo in the audit ledger if the same bugs are confirmed absent from the active code path.

See [#186 comment](https://github.com/JoeyJoziah/investment-analysis-platform/pull/186#issuecomment-4480051725) for the full disposition analysis.

## Status of related PRs

| PR | State | Notes |
|----|-------|-------|
| #186 | CONFLICTING | Superseded by this PR for active-code work; sub-theme B disposition pending |
| #187 | OPEN, depends on #186 base | Will be re-targeted to this branch (or main after this merges) |
| #189 | MERGED | stale-pr-check CI workflow fix — already in this branch's history via main |

## Test plan

- [x] Full session regression sweep: 532/532 passing
- [x] Workpaper §5 acceptance greps verified empty (torch.load w/o weights_only, ml-alerts@company.com, store=True, schedule_interval=, create_session(, check_recent_data_quality(, DEPRECATED in daily_stock_pipeline.py)
- [x] `py_compile` clean on all touched .py files
- [ ] CI green on the branch (PR Review Analysis workflow now resolves correctly because main has the fix)
- [ ] Reviewer assignment