### PR TITLE
Wave 3 / G2a follow-up: F-03-004 + F-06-008 ML training/eval bundle (replaces #187)

### DIFF
--- a/backend/ml/training/evaluate_models.py
+++ b/backend/ml/training/evaluate_models.py
@@ -147,11 +147,21 @@ class ModelEvaluator:
             model = joblib.load(model_path)
             scaler = joblib.load(scaler_path)
 
-            # Prepare test data
-            X_test = self.prepare_features(self.test_data, config['feature_columns'])
+            # F-03-004: drop NaN-target rows in eval too so metrics
+            # aren't computed on synthetic zero labels.
+            target_col = config['target_column']
+            mask = self.test_data[target_col].notna()
+            test_df = self.test_data.loc[mask]
+            if len(test_df) < len(self.test_data):
+                logger.info(
+                    f"XGBoost eval: dropped "
+                    f"{len(self.test_data) - len(test_df)} "
+                    f"rows with NaN {target_col}"
+                )
+
+            X_test = self.prepare_features(test_df, config['feature_columns'])
             X_test_scaled = scaler.transform(X_test)
-            y_test = self.test_data[config['target_column']].values
-            y_test = np.nan_to_num(y_test, nan=0.0)
+            y_test = test_df[target_col].values
 
             # Predict
             predictions = model.predict(X_test_scaled)

--- a/backend/ml/training/train_xgboost.py
+++ b/backend/ml/training/train_xgboost.py
@@ -172,7 +172,27 @@ class XGBoostTrainer:
         return train_df, val_df, test_df
 
     def prepare_features(self, df: pd.DataFrame) -> Tuple[np.ndarray, np.ndarray]:
-        """Prepare features and targets for training."""
+        """Prepare features and targets for training.
+
+        F-03-004: the previous implementation called
+        ``np.nan_to_num(y, nan=0.0)`` on the target, turning every
+        end-of-series look-ahead truncated row (where ``future_return_*``
+        is NaN by construction) into a zero label. The resulting label
+        distribution had a spike at exactly 0.0 that the model learned
+        to predict, collapsing R² ≤ 0 and producing all-zero feature
+        importances. The fix:
+
+        - Drop rows where the target is NaN (those rows have no usable
+          ground truth — synthesizing zero is worse than dropping).
+        - Drop feature columns that are all-NaN or zero-variance after
+          target-row drop; otherwise ``nan_to_num`` would convert them
+          to constant zeros that XGBoost can't split on and they'd
+          end up in ``feature_columns`` with zero importance, polluting
+          downstream feature-importance reports.
+        - Only then ``nan_to_num`` the remaining feature NaNs (early-
+          window indicators); these survive as real signal once the
+          column has variance.
+        """
         # Define feature columns (exclude non-numeric and target columns)
         exclude_cols = [
             'date', 'ticker', 'sector', 'industry',
@@ -181,8 +201,45 @@ class XGBoostTrainer:
             'risk_adj_return_1d', 'risk_adj_return_5d', 'risk_adj_return_10d', 'risk_adj_return_20d'
         ]
 
-        self.feature_columns = [c for c in df.columns if c not in exclude_cols
-                                and df[c].dtype in ['float64', 'float32', 'int64', 'int32']]
+        # F-03-004: drop rows where target is NaN BEFORE picking
+        # feature columns — otherwise an all-NaN-in-trimmed-rows column
+        # could falsely look populated when sized against the original
+        # frame.
+        target_col = self.target_column
+        valid = df[target_col].notna()
+        dropped = int((~valid).sum())
+        if dropped:
+            logger.info(
+                f"prepare_features: dropping {dropped} rows with NaN "
+                f"{target_col} (F-03-004)"
+            )
+        df = df.loc[valid].reset_index(drop=True)
+
+        # First-pass candidate features.
+        candidate_cols = [
+            c for c in df.columns
+            if c not in exclude_cols
+            and df[c].dtype in ['float64', 'float32', 'int64', 'int32']
+        ]
+
+        # F-03-004: drop dead (all-NaN) and constant columns. They would
+        # collapse to zero variance after nan_to_num, contribute no
+        # split information to XGBoost, and silently inflate
+        # ``feature_columns`` with zero-importance entries.
+        kept: List[str] = []
+        for c in candidate_cols:
+            col = df[c]
+            if col.isna().all():
+                logger.info(f"prepare_features: dropping all-NaN column {c!r}")
+                continue
+            # Use nunique on non-NaN values to detect constants.
+            if col.dropna().nunique() <= 1:
+                logger.info(
+                    f"prepare_features: dropping zero-variance column {c!r}"
+                )
+                continue
+            kept.append(c)
+        self.feature_columns = kept
 
         logger.info(f"Using {len(self.feature_columns)} features")
 
@@ -190,9 +247,10 @@ class XGBoostTrainer:
         X = df[self.feature_columns].values
         y = df[self.target_column].values
 
-        # Handle NaN values
+        # Remaining feature NaNs (early-window indicators etc.) get
+        # zero-filled — only AFTER we've already dropped target NaNs
+        # and zero-variance columns, so the fill is signal-preserving.
         X = np.nan_to_num(X, nan=0.0, posinf=0.0, neginf=0.0)
-        y = np.nan_to_num(y, nan=0.0, posinf=0.0, neginf=0.0)
 
         return X, y
 

--- a/backend/tests/unit/test_airflow_dag_real_eval.py
+++ b/backend/tests/unit/test_airflow_dag_real_eval.py
@@ -1,0 +1,90 @@
+"""
+Regression tests for F-06-008 (evaluate-on-random).
+
+The DAG ``evaluate_models`` task previously called
+``monitor.calculate_metrics(y_true=np.random.randn(100),
+y_pred=np.random.randn(100), ...)`` — every "evaluation" run was
+uncorrelated noise, and the resulting ``ranking_score`` was random
+white noise. This means the "best model" picked for deployment was
+literally random.
+
+The fix delegates to the real ``backend.ml.training.evaluate_models.
+ModelEvaluator`` which loads the persisted ``test_data.parquet``
+held-out split.
+
+Tests inspect the DAG source rather than executing the task (which
+needs Airflow + Postgres + all the ML deps).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+_DAG = (
+    Path(__file__).resolve().parents[3]
+    / "data_pipelines"
+    / "airflow"
+    / "dags"
+    / "ml_training_pipeline_dag.py"
+)
+
+
+def test_evaluate_models_does_not_use_random_placeholders() -> None:
+    """F-06-008: ``np.random.randn(100)`` placeholder CALLS must be gone.
+
+    The docstring on evaluate_models describes the legacy behavior and
+    legitimately mentions the old kwargs — anchor on the call-site form
+    to avoid flagging the rationale comment (per
+    ``feedback_test_anchor_logic`` memory note).
+    """
+
+    text = _DAG.read_text()
+    # Strip docstrings so we only inspect executable code.
+    code = re.sub(r'""".*?"""', '', text, flags=re.DOTALL)
+    assert "y_true=np.random.randn(100)" not in code, (
+        "DAG evaluate_models still passes y_true=np.random.randn(100) "
+        "in executable code"
+    )
+    assert "y_pred=np.random.randn(100)" not in code, (
+        "DAG evaluate_models still passes y_pred=np.random.randn(100) "
+        "in executable code"
+    )
+
+
+def test_evaluate_models_uses_real_model_evaluator() -> None:
+    """F-06-008: DAG must delegate to the real ModelEvaluator."""
+
+    text = _DAG.read_text()
+    assert "from backend.ml.training.evaluate_models import ModelEvaluator" in text, (
+        "DAG evaluate_models must import the real ModelEvaluator"
+    )
+    assert "evaluator.run_evaluation()" in text, (
+        "DAG must call evaluator.run_evaluation() to compute real metrics"
+    )
+
+
+def test_evaluate_models_asserts_test_parquet_exists() -> None:
+    """F-06-008: missing test_data.parquet must raise, not silently noop."""
+
+    text = _DAG.read_text()
+    assert re.search(
+        r'test_path\s*=\s*Path\([^)]*\)\s*/\s*["\']test_data\.parquet["\']',
+        text,
+    ), "DAG must derive the held-out test parquet path explicitly"
+    assert "raise AirflowException" in text, (
+        "DAG must raise AirflowException when test_data.parquet is missing "
+        "rather than fall back to random-data metrics"
+    )
+
+
+def test_ranking_score_uses_r2_not_random() -> None:
+    """F-06-008: ranking_score must come from the real test_metrics, not noise."""
+
+    text = _DAG.read_text()
+    # ``ranking_score`` should now be derived from the model's r2 on
+    # held-out data, not a randomly-generated MonitorMetrics.r2.
+    assert "float(model_result.get('r2', 0.0))" in text, (
+        "ranking_score must be derived from real test-set R²"
+    )

--- a/backend/tests/unit/test_train_xgboost_signal_recovery.py
+++ b/backend/tests/unit/test_train_xgboost_signal_recovery.py
@@ -1,0 +1,234 @@
+"""
+Regression tests for F-03-004 (XGBoost R²<0, all-zero feature importances).
+
+Per workpaper §3 step 30:
+- Add gate test asserting ``r2 > 0.0`` AND at least one non-zero feature
+  importance — currently fails on main.
+- Audit pipeline: target construction, train/test split look-ahead,
+  feature preprocessing. Likely cross-cuts F-05-004 (mock data) and
+  F-06-008.
+
+Root cause: ``XGBoostTrainer.prepare_features`` runs
+``np.nan_to_num(y, nan=0.0)`` on the future-return target. Future
+returns at the end of every time series are NaN (no look-ahead data).
+Filling them with 0 means the best constant predictor is ``predict=0``,
+the model collapses to that, R²→0 or negative, and gradient-based
+feature importances all sit at zero.
+
+This test exercises the real ``prepare_features`` and a minimal
+training step on synthetic data with KNOWN signal:
+``y = 0.7*X[:,0] + 0.3*X[:,1] + small noise``. After the fix:
+- prepare_features must drop NaN-target rows rather than fill them.
+- A short XGBoost fit on the cleaned data must produce r2 > 0 AND
+  at least one non-zero feature importance.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import numpy as np
+import pandas as pd
+import pytest
+
+
+_TRAIN_XGB = (
+    Path(__file__).resolve().parents[2]
+    / "ml"
+    / "training"
+    / "train_xgboost.py"
+)
+
+
+def _load_trainer_module(monkeypatch: pytest.MonkeyPatch):
+    """Load train_xgboost in isolation with logger configured.
+
+    We stub out backend.ml.gpu_utils so the module loads in environments
+    without the gpu_utils helpers; the trainer's fallback path handles
+    the rest.
+    """
+    for name in list(sys.modules):
+        if name == "backend" or name.startswith("backend."):
+            monkeypatch.delitem(sys.modules, name, raising=False)
+
+    # Stub the optional gpu_utils chain so the import doesn't fail.
+    backend_pkg = MagicMock(); backend_pkg.__path__ = []
+    ml_pkg = MagicMock(); ml_pkg.__path__ = []
+    monkeypatch.setitem(sys.modules, "backend", backend_pkg)
+    monkeypatch.setitem(sys.modules, "backend.ml", ml_pkg)
+
+    name = "train_xgboost_under_test"
+    spec = importlib.util.spec_from_file_location(name, _TRAIN_XGB)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[name] = module
+    monkeypatch.setitem(sys.modules, name, module)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _synth_frame_with_signal_and_nan_tail(
+    n_per_ticker: int = 100,
+    n_tickers: int = 8,
+    seed: int = 7,
+) -> pd.DataFrame:
+    """Frame mirroring real multi-ticker shape with realistic NaN tails.
+
+    Real training data has one row per (ticker, date) and each ticker
+    has its own 5-day NaN tail at ``future_return_5d`` (the last 5 days
+    of the series have no future data). With 8 tickers × 5 NaN tail
+    rows = 40 NaN targets out of 800 = 5%, the bug's signal corruption
+    is severe enough that XGBoost collapses to predict=0 (the dominant
+    bin after nan_to_num zero-fill) and importances all sit at zero.
+
+    Includes:
+    - 4 non-degenerate float features ``feat_a..d``.
+    - The canonical target ``future_return_5d`` with NaN tail per ticker.
+    - Non-numeric ``date``, ``ticker`` columns that must be excluded.
+    """
+    rng = np.random.default_rng(seed)
+    frames = []
+    for ti in range(n_tickers):
+        feat_a = rng.normal(0, 1, n_per_ticker)
+        feat_b = rng.normal(0, 1, n_per_ticker)
+        feat_c = rng.normal(0, 1, n_per_ticker)
+        feat_d = rng.normal(0, 1, n_per_ticker)
+        # KNOWN signal: y = 0.7*a + 0.3*b + noise.
+        y = 0.7 * feat_a + 0.3 * feat_b + rng.normal(0, 0.1, n_per_ticker)
+        # Per-ticker NaN tail mirrors the look-ahead truncation reality.
+        y[-5:] = np.nan
+        frames.append(pd.DataFrame({
+            "date": pd.date_range("2023-01-01", periods=n_per_ticker, freq="D"),
+            "ticker": [f"TKR{ti:02d}"] * n_per_ticker,
+            "feat_a": feat_a,
+            "feat_b": feat_b,
+            "feat_c": feat_c,
+            "feat_d": feat_d,
+            "future_return_5d": y,
+        }))
+    return pd.concat(frames, ignore_index=True)
+
+
+def test_prepare_features_drops_nan_target_rows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """F-03-004: prepare_features must drop rows with NaN target, not synthesize 0."""
+
+    mod = _load_trainer_module(monkeypatch)
+    trainer = mod.XGBoostTrainer.__new__(mod.XGBoostTrainer)
+    trainer.target_column = "future_return_5d"
+    trainer.feature_columns = None
+
+    df = _synth_frame_with_signal_and_nan_tail(n_per_ticker=100, n_tickers=8)
+    n_rows = len(df)
+    n_nan_tails = 8 * 5  # n_tickers * 5-day tail
+    X, y = trainer.prepare_features(df)
+
+    assert len(y) == n_rows - n_nan_tails, (
+        f"prepare_features must drop NaN-target rows; expected "
+        f"{n_rows - n_nan_tails}, got {len(y)}"
+    )
+    # No zero-target spike from nan_to_num filling.
+    assert np.sum(y == 0.0) < 3, (
+        f"prepare_features still synthesizes 0 for NaN targets; "
+        f"got {np.sum(y == 0.0)} zero targets"
+    )
+
+
+def test_xgboost_recovers_r2_and_nonzero_importance(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """F-03-004 ACCEPTANCE GATE: r2 > 0.0 AND ≥1 non-zero feature importance."""
+
+    mod = _load_trainer_module(monkeypatch)
+    trainer = mod.XGBoostTrainer.__new__(mod.XGBoostTrainer)
+    trainer.target_column = "future_return_5d"
+    trainer.feature_columns = None
+    # Standard preprocessing path used by the trainer.
+    from sklearn.preprocessing import StandardScaler
+    trainer.scaler = StandardScaler()
+
+    # Build a small, low-SNR multi-ticker frame where the NaN-zero-fill
+    # bug actually dominates: 12 tickers × 60 days with σ=0.4 noise →
+    # ~12% NaN-zero-filled targets and SNR low enough that the
+    # nan_to_num spike at 0 swamps the real signal.
+    rng = np.random.default_rng(11)
+    frames = []
+    for ti in range(12):
+        feat_a = rng.normal(0, 1, 60)
+        feat_b = rng.normal(0, 1, 60)
+        feat_c = rng.normal(0, 1, 60)
+        feat_d = rng.normal(0, 1, 60)
+        y = 0.5 * feat_a + 0.2 * feat_b + rng.normal(0, 0.4, 60)
+        y[-7:] = np.nan
+        frames.append(pd.DataFrame({
+            "date": pd.date_range("2023-01-01", periods=60, freq="D"),
+            "ticker": [f"T{ti:02d}"] * 60,
+            "feat_a": feat_a, "feat_b": feat_b,
+            "feat_c": feat_c, "feat_d": feat_d,
+            "future_return_5d": y,
+        }))
+    df = pd.concat(frames, ignore_index=True)
+    X, y = trainer.prepare_features(df)
+    X_scaled = trainer.scaler.fit_transform(X)
+
+    # Train/test split (chronological — last 20% is the held-out tail).
+    cut = int(0.8 * len(X_scaled))
+    X_tr, X_te = X_scaled[:cut], X_scaled[cut:]
+    y_tr, y_te = y[:cut], y[cut:]
+
+    import xgboost as xgb
+    from sklearn.metrics import r2_score
+
+    model = xgb.XGBRegressor(
+        n_estimators=200,
+        max_depth=4,
+        learning_rate=0.05,
+        random_state=42,
+        n_jobs=1,
+        tree_method="hist",
+    )
+    model.fit(X_tr, y_tr, verbose=False)
+    preds = model.predict(X_te)
+    r2 = r2_score(y_te, preds)
+    importances = model.feature_importances_
+
+    assert r2 > 0.0, (
+        f"XGBoost R² is non-positive ({r2:.4f}). Signal is recoverable on "
+        f"this synthetic data ONLY if prepare_features stops the nan_to_num "
+        f"target-fill."
+    )
+    assert np.any(importances > 0.0), (
+        f"All feature importances are zero ({importances!r}). XGBoost failed "
+        f"to find a split — consistent with constant labels (post-nan_to_num)."
+    )
+
+
+def test_prepare_features_drops_pure_nan_columns(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """F-03-004 supporting: all-NaN feature columns must be dropped, not zero-filled.
+
+    nan_to_num turns an all-NaN column into all zeros — a constant
+    feature — which gets zero importance and pollutes feature_columns.
+    """
+    mod = _load_trainer_module(monkeypatch)
+    trainer = mod.XGBoostTrainer.__new__(mod.XGBoostTrainer)
+    trainer.target_column = "future_return_5d"
+    trainer.feature_columns = None
+
+    df = _synth_frame_with_signal_and_nan_tail(n_per_ticker=100, n_tickers=2)
+    df["dead_col"] = np.nan  # entirely NaN
+    df["const_col"] = 1.0    # zero variance
+    X, y = trainer.prepare_features(df)
+
+    # ``feature_columns`` must not contain the dead or constant columns.
+    assert "dead_col" not in trainer.feature_columns, (
+        "prepare_features kept an all-NaN column — it'll become a zero-importance constant"
+    )
+    assert "const_col" not in trainer.feature_columns, (
+        "prepare_features kept a zero-variance column — useless for learning"
+    )

--- a/backend/tests/unit/test_xgboost_train_eval_pipeline.py
+++ b/backend/tests/unit/test_xgboost_train_eval_pipeline.py
@@ -1,0 +1,225 @@
+"""
+End-to-end pipeline integration for the F-03-004 + F-06-008 bundle.
+
+The closest analog to a browser E2E for this branch's work — there is
+no UI surface yet for the ML evaluation outputs, so this exercises the
+actual round-trip the Airflow DAG depends on:
+
+    synthetic parquet
+        → XGBoostTrainer.train (prepare → fit → _save_model)
+        → ModelEvaluator.evaluate_xgboost (load model+scaler+config,
+                                          predict on test parquet,
+                                          compute metrics)
+        → assert real metrics (r2 > 0, non-zero feature importance,
+                               non-trivial direction accuracy)
+
+This is the contract F-06-008 actually depends on: the DAG fails loud
+on missing ``test_data.parquet`` only because the round trip produces
+meaningful metrics when the parquet IS present.
+
+Runs in ≤30 seconds on CPU with n_trials=2.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import numpy as np
+import pandas as pd
+import pytest
+
+
+_TRAIN_XGB = (
+    Path(__file__).resolve().parents[2]
+    / "ml"
+    / "training"
+    / "train_xgboost.py"
+)
+_EVAL_MODELS = (
+    Path(__file__).resolve().parents[2]
+    / "ml"
+    / "training"
+    / "evaluate_models.py"
+)
+
+
+def _load_module_under_synthetic_pkg(
+    monkeypatch: pytest.MonkeyPatch,
+    pkg_name: str,
+    module_name: str,
+    path: Path,
+):
+    """Load a module under a synthetic package so internal imports of
+    ``backend.ml.*`` resolve to harmless stubs (the trainer's gpu_utils
+    import is optional; the evaluator does no ``backend.ml.*`` imports
+    in the codepath we exercise).
+    """
+    # Clear any prior backend.* pollution from earlier tests in the run.
+    for name in list(sys.modules):
+        if name == "backend" or name.startswith("backend."):
+            monkeypatch.delitem(sys.modules, name, raising=False)
+
+    # Stub backend / backend.ml so the trainer's "try: from backend.ml.gpu_utils..."
+    # gracefully takes the ImportError path.
+    backend_pkg = MagicMock(); backend_pkg.__path__ = []
+    ml_pkg = MagicMock(); ml_pkg.__path__ = []
+    monkeypatch.setitem(sys.modules, "backend", backend_pkg)
+    monkeypatch.setitem(sys.modules, "backend.ml", ml_pkg)
+
+    fqname = f"{pkg_name}.{module_name}"
+    spec = importlib.util.spec_from_file_location(fqname, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[fqname] = module
+    monkeypatch.setitem(sys.modules, fqname, module)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_synth_parquets(data_dir: Path, target_col: str = "future_return_5d") -> None:
+    """Create train/val/test parquets with known signal + realistic NaN tails."""
+    rng = np.random.default_rng(11)
+
+    def _make(n_tickers: int, n_days: int, seed_offset: int):
+        rng_local = np.random.default_rng(11 + seed_offset)
+        frames = []
+        for ti in range(n_tickers):
+            feat_a = rng_local.normal(0, 1, n_days)
+            feat_b = rng_local.normal(0, 1, n_days)
+            feat_c = rng_local.normal(0, 1, n_days)
+            feat_d = rng_local.normal(0, 1, n_days)
+            # Known recoverable signal.
+            y = 0.6 * feat_a + 0.3 * feat_b + rng_local.normal(0, 0.15, n_days)
+            y[-5:] = np.nan  # per-ticker NaN tail
+            frames.append(pd.DataFrame({
+                "date": pd.date_range("2023-01-01", periods=n_days, freq="D"),
+                "ticker": [f"T{seed_offset:02d}_{ti:02d}"] * n_days,
+                "feat_a": feat_a, "feat_b": feat_b,
+                "feat_c": feat_c, "feat_d": feat_d,
+                target_col: y,
+            }))
+        return pd.concat(frames, ignore_index=True)
+
+    data_dir.mkdir(parents=True, exist_ok=True)
+    _make(n_tickers=6, n_days=120, seed_offset=0).to_parquet(data_dir / "train_data.parquet")
+    _make(n_tickers=3, n_days=60, seed_offset=1).to_parquet(data_dir / "val_data.parquet")
+    _make(n_tickers=3, n_days=60, seed_offset=2).to_parquet(data_dir / "test_data.parquet")
+
+
+def test_train_xgboost_save_then_evaluate_round_trip(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """F-03-004 + F-06-008: train → save → load → evaluate produces real metrics.
+
+    Asserts the DAG-level contract: the held-out test set parquet is
+    consumed by a freshly-loaded model+scaler+config and produces
+    metrics with real signal (r2 > 0, direction_accuracy > 0.5,
+    non-zero feature importance).
+    """
+    data_dir = tmp_path / "data"
+    model_dir = tmp_path / "ml_models"
+
+    _write_synth_parquets(data_dir)
+
+    # --- Train ---------------------------------------------------------
+    trainer_mod = _load_module_under_synthetic_pkg(
+        monkeypatch, "ml_bundle_e2e", "train_xgboost", _TRAIN_XGB
+    )
+    trainer = trainer_mod.XGBoostTrainer(
+        data_dir=str(data_dir),
+        model_dir=str(model_dir),
+        n_trials=2,        # smoke; signal is strong enough to recover
+        cv_splits=2,       # minimum for TimeSeriesSplit
+        use_gpu=False,
+    )
+    results = trainer.train()
+
+    # Trainer must report at least one non-zero feature importance.
+    importances = results.get("feature_importance", {})
+    assert importances, "train() did not record feature_importance in results"
+    assert any(v > 0 for v in importances.values()), (
+        f"all feature importances zero — F-03-004 regression: {importances!r}"
+    )
+
+    # Artifacts persisted to model_dir (the contract evaluate_models depends on).
+    for art in ("xgboost_model.pkl", "xgboost_scaler.pkl", "xgboost_config.json"):
+        assert (model_dir / art).exists(), f"trainer did not persist {art}"
+
+    # --- Evaluate ------------------------------------------------------
+    # Reload modules fresh so the evaluator gets a clean import (avoid
+    # the trainer-side ``backend.ml`` MagicMock leaking into evaluate's
+    # ``from backend.ml.training.train_lstm import LSTMModel`` lookup —
+    # we don't exercise LSTM here so the stub is fine).
+    evaluator_mod = _load_module_under_synthetic_pkg(
+        monkeypatch, "ml_bundle_e2e", "evaluate_models", _EVAL_MODELS
+    )
+    evaluator = evaluator_mod.ModelEvaluator(
+        data_dir=str(data_dir), model_dir=str(model_dir),
+    )
+    evaluator.load_test_data()
+    metrics = evaluator.evaluate_xgboost()
+
+    # F-06-008 acceptance: evaluator returns real metrics from the
+    # persisted test parquet, not None and not random noise.
+    assert metrics is not None, "evaluate_xgboost returned None — load chain broken"
+    assert "r2" in metrics and "mse" in metrics and "direction_accuracy" in metrics
+
+    # F-03-004 acceptance on the eval side: r2 > 0 on a held-out set
+    # whose signal is recoverable from training.
+    assert metrics["r2"] > 0.0, (
+        f"eval R² non-positive ({metrics['r2']:.4f}) — either training "
+        f"signal collapsed (F-03-004) or train/test split lost the signal"
+    )
+
+    # Direction accuracy must beat the 0.5 coin-flip baseline by a
+    # margin — confirms the prediction is correlated with sign, not
+    # just centered noise.
+    assert metrics["direction_accuracy"] > 0.55, (
+        f"direction_accuracy ({metrics['direction_accuracy']:.3f}) is at "
+        f"or below coin-flip — predictions are uncorrelated with sign"
+    )
+
+    # MSE must be finite (sanity).
+    assert np.isfinite(metrics["mse"]), "MSE is non-finite — NaN poisoning?"
+
+
+def test_evaluator_loads_persisted_artifacts_exactly(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """F-06-008 supporting: evaluator reads the same config the trainer wrote.
+
+    Verifies the persistence contract: trainer.feature_columns saved to
+    xgboost_config.json is what evaluator reads back, and the scaler
+    persisted is the one that produces consistent X_test_scaled.
+    """
+    data_dir = tmp_path / "data"
+    model_dir = tmp_path / "ml_models"
+
+    _write_synth_parquets(data_dir)
+
+    trainer_mod = _load_module_under_synthetic_pkg(
+        monkeypatch, "ml_bundle_e2e_persist", "train_xgboost", _TRAIN_XGB
+    )
+    trainer = trainer_mod.XGBoostTrainer(
+        data_dir=str(data_dir),
+        model_dir=str(model_dir),
+        n_trials=2, cv_splits=2, use_gpu=False,
+    )
+    trainer.train()
+
+    # Config.json must contain the canonical feature list.
+    cfg = json.loads((model_dir / "xgboost_config.json").read_text())
+    assert "feature_columns" in cfg
+    assert "target_column" in cfg and cfg["target_column"] == "future_return_5d"
+    # F-03-004: dead/constant columns dropped — feature list non-empty
+    # and not full of obvious junk.
+    assert cfg["feature_columns"], "feature_columns list is empty"
+    assert all(col not in cfg["feature_columns"] for col in ("date", "ticker")), (
+        "non-numeric columns leaked into feature_columns"
+    )

--- a/data_pipelines/airflow/dags/ml_training_pipeline_dag.py
+++ b/data_pipelines/airflow/dags/ml_training_pipeline_dag.py
@@ -543,45 +543,60 @@ def train_models(**context):
 
 
 def evaluate_models(**context):
-    """Evaluate and compare trained models"""
-    
-    async def _evaluate_models():
-        registry = ModelRegistry()
-        monitor = ModelMonitor()
-        
-        training_results = context['task_instance'].xcom_pull(key='training_results')
-        
-        evaluation_results = []
-        
-        for result in training_results:
-            if result['status'] == 'completed':
-                model_name = result['model_name']
-                
-                # Get model from registry
-                model_version = await registry.get_model(model_name)
-                
-                if model_version:
-                    # Calculate additional metrics
-                    metrics = monitor.calculate_metrics(
-                        y_true=np.random.randn(100),  # Would use actual test data
-                        y_pred=np.random.randn(100),  # Would use actual predictions
-                        model_type='regression'
-                    )
-                    
-                    evaluation_results.append({
-                        'model_name': model_name,
-                        'version': model_version.version,
-                        'training_metrics': result['metrics'],
-                        'test_metrics': metrics.to_dict(),
-                        'ranking_score': metrics.r2  # Or custom ranking metric
-                    })
-        
-        # Rank models
-        evaluation_results.sort(key=lambda x: x.get('ranking_score', 0), reverse=True)
-        
-        return evaluation_results
-    
-    evaluation_results = asyncio.run(_evaluate_models())
+    """Evaluate and compare trained models on the persisted held-out test set.
+
+    F-06-008: previously called ``monitor.calculate_metrics`` with
+    ``y_true=np.random.randn(100)`` and ``y_pred=np.random.randn(100)``
+    — every "evaluation" report was uncorrelated noise. Now delegates
+    to ``backend.ml.training.evaluate_models.ModelEvaluator.run_evaluation``,
+    which loads the persisted ``test_data.parquet`` (the held-out test
+    set written by the upstream prepare-data step), loads each saved
+    model + scaler + config, and produces real MSE/MAE/R²/direction
+    metrics over the held-out data.
+
+    The DAG fails loud (AirflowException) if the held-out parquet is
+    missing — silent fallback to random noise (the previous behavior)
+    masked a broken upstream split-and-persist step for months.
+    """
+    from pathlib import Path
+    from airflow.exceptions import AirflowException
+
+    from backend.ml.training.evaluate_models import ModelEvaluator
+
+    data_dir = Variable.get("ml_data_dir", default_var="data/ml_training/processed")
+    model_dir = Variable.get("ml_model_dir", default_var="ml_models")
+
+    test_path = Path(data_dir) / "test_data.parquet"
+    if not test_path.exists():
+        raise AirflowException(
+            f"F-06-008: held-out test set not found at {test_path}. "
+            f"Upstream prepare-data step must persist ``test_data.parquet`` "
+            f"before evaluate_models can run. Refusing to fall back to "
+            f"random-data metrics (the legacy behavior)."
+        )
+
+    evaluator = ModelEvaluator(data_dir=str(data_dir), model_dir=str(model_dir))
+    report = evaluator.run_evaluation()
+
+    evaluation_results: List[Dict[str, Any]] = []
+    training_results = context['task_instance'].xcom_pull(key='training_results') or []
+    training_by_name = {
+        r['model_name']: r for r in training_results if r.get('status') == 'completed'
+    }
+
+    for model_result in report.get('model_results', []):
+        model_name = model_result['model']
+        training_entry = training_by_name.get(model_name, {})
+        evaluation_results.append({
+            'model_name': model_name,
+            'training_metrics': training_entry.get('metrics'),
+            'test_metrics': model_result,
+            # Use R² as the ranking score (higher = better fit).
+            'ranking_score': float(model_result.get('r2', 0.0)),
+        })
+
+    # Rank models
+    evaluation_results.sort(key=lambda x: x.get('ranking_score', 0.0), reverse=True)
     
     # Store results
     context['task_instance'].xcom_push(key='evaluation_results', value=evaluation_results)


### PR DESCRIPTION
## Summary

**Replaces #187** with a clean base on the split active-code branch (#190).

Identical commits to #187 — F-03-004 (XGBoost R²<0) + F-06-008 (DAG evaluate-on-random) + pipeline E2E — but rebased onto `remediation/audit-2026-04-wave3-G2a-active-code` so the diff is just the 3 ML-bundle commits and not the sub-theme B history that #187 carries from its original wave3-G2a base.

## Why a new PR

#187 was based on `wave3-G2a` which includes the 10 sub-theme B commits whose target (`backend/TradingAgents/`) is deleted on main. After #186 was split per option 1 → #190 (active-code), retargeting #187 directly would have made its diff show all the sub-theme B work too. Cherry-picking the 3 ML-bundle commits onto a fresh branch off #190 keeps the diff scope correct.

## Findings closed (2)

| ID | Fix |
|----|-----|
| **F-03-004** | XGBoost prepare_features drops NaN-target rows + zero-variance columns (don't synthesize zeros). r2 > 0 + ≥1 non-zero feature importance restored. |
| **F-06-008** | DAG `evaluate_models` delegates to real `ModelEvaluator.run_evaluation` on persisted `test_data.parquet`; AirflowException on missing parquet (no silent fallback to np.random.randn). |

Plus a **pipeline-level E2E** at `backend/tests/unit/test_xgboost_train_eval_pipeline.py` that exercises synthetic parquet → train → save → load → evaluate round-trip.

## Test plan

- [x] 9/9 ML-bundle tests pass (3 F-03-004 + 4 F-06-008 + 2 pipeline E2E)
- [x] py_compile clean on all 3 modified source files
- [x] Inherits #190's full 532-test sweep via the base branch
- [ ] CI green on the branch
- [ ] Reviewer assignment

## Dependency chain after this merges into main

- ✅ #189 merged (CI workflow fix on wave3-G2a)
- ⏳ #190 (active-code split) — depends on this merging in to be the base
- ⏳ This PR — depends on #190 merging first
- ⚠️ #186 (original) — superseded; close after #190 merges
- ⚠️ #187 (old ml-bundle) — superseded by this PR; close
- ❓ Sub-theme B (F-04-001..009) — disposition pending per #186 conflict comment