### PR TITLE
chore(tooling): add [project] + [tool.ruff] alongside existing legacy tools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,18 @@
+# ============================================================================
+# Project metadata (PEP 621)
+# ============================================================================
+#
+# Added 2026-05-18 to declare the Python version the project supports.
+# The codebase has historically run on 3.9 (current dev env + Docker base)
+# while [tool.mypy] / [tool.black] declared 3.12 as target. This pin
+# resolves that ambiguity in favor of the actual runtime — bump to ">=3.12"
+# in a follow-up once the dev env and CI move to 3.12.
+[project]
+name = "investment-analysis-platform"
+version = "0.0.0"
+description = "Investment analysis platform — FastAPI backend, ML pipelines, Airflow DAGs"
+requires-python = ">=3.9"
+
 [tool.black]
 line-length = 88
 target-version = ['py312']
@@ -153,3 +168,63 @@ disable = [
 # B324 = use of weak hash function (md5, sha1) without usedforsecurity=False.
 skips = ["B303", "B324"]
 exclude_dirs = ["backend/tests", "backend/TradingAgents"]
+
+# ============================================================================
+# Ruff — modern Python linter + formatter (replaces black/isort/flake8/pylint).
+# ============================================================================
+#
+# Added 2026-05-18 alongside the existing legacy tooling so contributors can
+# adopt incrementally. Legacy configs (black/isort/flake8/pylint) are kept in
+# place; remove them in a follow-up once CI runs on ruff alone.
+#
+# Quick start (no install required):
+#   uv run --with ruff ruff check .
+#   uv run --with ruff ruff format .
+#
+# Or with a project venv: pip install ruff && ruff check .
+[tool.ruff]
+line-length = 88                  # matches existing black/pylint/isort
+target-version = "py39"           # matches actual runtime; tighten when env upgrades
+extend-exclude = [
+    ".venv",
+    "venv",
+    "build",
+    "dist",
+    "migrations",
+    "backend/_archive_TradingAgents_fork_pre_2026-05-12",
+]
+
+[tool.ruff.format]
+# Match black's existing posture.
+quote-style = "double"
+indent-style = "space"
+skip-magic-trailing-comma = false
+
+[tool.ruff.lint]
+# Conservative starting set focused on REAL BUGS, not style.
+# Style-only families (UP, I, C4, SIM) are deferred — running them on
+# this codebase surfaces ~21k findings (mostly UP006 ``List`` →
+# ``list``) which is migration work, not lint regression. Add them
+# back family-by-family with ``ruff check --select <X> --fix`` runs.
+select = [
+    "E",      # pycodestyle errors
+    "W",      # pycodestyle warnings
+    "F",      # pyflakes (undefined names, unused imports)
+    "B",      # flake8-bugbear (common bug patterns)
+]
+ignore = [
+    "E501",   # line-too-long — handled by formatter
+    "E402",   # module-level-import-not-at-top — pre-existing pattern
+    "E731",   # lambda-assignment — pre-existing pattern
+    "E741",   # ambiguous-variable-name — pre-existing
+    "B008",   # function-call-in-default-argument — FastAPI Depends() etc.
+    "B904",   # raise-without-from-inside-except — many pre-existing sites
+    "B027",   # empty-method-without-abstract-decorator
+    "B011",   # assert-false (defensive code)
+]
+
+[tool.ruff.lint.per-file-ignores]
+# Test files: relax pycodestyle + bugbear (fixtures often look weird).
+"backend/tests/**/*.py" = ["E", "B"]
+# Archived TradingAgents fork is intentionally read-only.
+"backend/_archive_TradingAgents_fork_pre_2026-05-12/**" = ["ALL"]


### PR DESCRIPTION
## Summary

Phase 1 of 2 tooling-modernization PRs. Both are **additive** — no existing tool config is removed or mutated. The goal is to start running ruff in parallel for new code while planning legacy-debt cleanup separately.

### What this PR does

**Adds `[project]` (PEP 621)**
- Minimal metadata: name, version, description.
- **Pins `requires-python = \">=3.9\"`** to match the actual runtime (Docker base + CI + current dev env Python 3.9.6).
- Resolves the long-standing ambiguity where `[tool.mypy]` + `[tool.black]` declared `3.12` as target but actual runtime is `3.9`. Bump to `>=3.12` in a follow-up when dev + CI move.

**Adds `[tool.ruff]`**
- `line-length=88` matches the existing black/pylint/isort posture.
- `target-version=\"py39\"` matches the runtime.
- **Conservative lint ruleset**: `E, W, F, B` (real-bug families). Style-only families (UP, I, C4, SIM) are intentionally deferred — running them on legacy code surfaces ~21k findings (mostly `UP006` `List` → `list`), which is migration work, not a lint regression. Add them back family-by-family later.
- Test files relax E + B (fixtures look weird; tolerance is fine).
- Archive path `backend/_archive_TradingAgents_fork_pre_2026-05-12` is explicitly excluded.
- `[tool.ruff.format]` mirrors black's double-quote / space-indent defaults so both formatters agree on output during the transition.

### Quick start (no install required)

```bash
uv run --with ruff ruff check .
uv run --with ruff ruff format .
```

Or via the existing pip-based workflow: `pip install ruff && ruff check .`

### Why additive instead of replacing black/flake8/etc

- **Active audit-remediation PRs** (#190, #191) need to remain merge-ready. Mixing tooling replacement into either would balloon them.
- **Existing CI/dev workflows** use black/flake8/mypy. Replacing them is a coordinated rollout, not a tiny PR.
- This PR lets you start adopting ruff today; the cleanup PR can come later.

### Verification

- [x] `pyproject.toml` parses (tomllib).
- [x] `ruff check` runs against `backend/` + `data_pipelines/` without crashing.
- [x] Current legacy debt: 15k findings (mostly pre-existing W291/W292 whitespace).
- [x] `ruff check` against the 31 source files touched by #190 + #191: **0 errors** (the new code is ruff-clean against the conservative ruleset).
- [ ] CI green on this branch.

### Phase 2 (separate PR)

Generate `uv.lock` from existing requirements.txt for reproducibility. Doesn't delete requirements files; downstream consumers unaffected.

### What this PR explicitly does NOT do

- Remove or modify black/isort/flake8/mypy/pylint/bandit configs.
- Delete any `requirements*.txt` files.
- Replace mypy with ty (would require Python 3.11+ in CI; separate decision).
- Touch any code in `backend/` or `data_pipelines/` (zero source-code changes).