### PR TITLE
ci: fix frontend test runner to use Vitest flags (not Jest)

### DIFF
--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -227,12 +227,12 @@ jobs:
     - name: Run frontend tests
       working-directory: frontend/web
       run: |
-        TEST_ARGS="--coverage --ci --watchAll=false"
+        TEST_ARGS="--run --coverage --coverage.reporter=json-summary --coverage.reporter=lcov"
         if [[ "${{ inputs.skip-slow-tests }}" == "true" ]]; then
           TEST_ARGS="$TEST_ARGS --testNamePattern='^(?!.*slow).*$'"
         fi
         
-        npm test -- $TEST_ARGS --testResultsProcessor=jest-junit
+        npm test -- $TEST_ARGS --reporter=default --reporter=junit --outputFile=./test-results/results.xml
       env:
         CI: true
         JEST_JUNIT_OUTPUT_DIR: ./test-results


### PR DESCRIPTION
## What

Fixes the frontend test invocation in the reusable test workflow, which used **Jest-only flags against a Vitest project** (`package.json` `test` script is `vitest`).

| Before (Jest) | After (Vitest) |
|---|---|
| `--coverage --ci --watchAll=false` | `--run --coverage --coverage.reporter=json-summary --coverage.reporter=lcov` |
| `--testResultsProcessor=jest-junit` | `--reporter=default --reporter=junit --outputFile=./test-results/results.xml` |

## Why

Vitest does not recognise `--ci`, `--watchAll`, or `--testResultsProcessor`. The frontend test step could error on unknown options or silently fail to produce JUnit results and the `coverage-summary.json` that the coverage-extraction step reads — leaving the frontend **effectively ungated** in CI. Adding the `json-summary` coverage reporter makes the extraction step report real numbers.

## Source

Identified in the **2026-05-20 codebase deep-dive audit** (Tests & Validation segment). See `docs/QUEEN_AUDIT_MASTER_REPORT.md` (Addendum 2026-05-20) and audit issues #197-#202.

## Scope / deferred follow-ups (intentionally not in this PR)

- Ramp a **Vitest coverage threshold gate** — deferred because frontend coverage is currently ~5-8%; a hard 80% gate would block all PRs until coverage is raised.
- Reconcile the backend **`pyproject.toml --cov-fail-under=80` vs `pytest.ini`** coverage-gate contradiction.

## Test plan

- [ ] CI run on this PR shows the `frontend-tests` job invoking `vitest --run` and producing `test-results/results.xml` + `coverage/coverage-summary.json`.
- [ ] `frontend-coverage` output is a real percentage (not `0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)