### PR TITLE
fix(etl): prevent SQL injection in cleanup_old_data (#197)

### DIFF
--- a/backend/etl/data_loader.py
+++ b/backend/etl/data_loader.py
@@ -23,6 +23,18 @@ load_dotenv()
 
 logger = logging.getLogger(__name__)
 
+# Allowlist of tables eligible for retention cleanup. Table identifiers are NEVER
+# taken from caller-supplied input unchecked: cleanup_old_data() validates each
+# requested table against this set before any identifier is interpolated into SQL,
+# and binds the retention window as a query parameter. (Security: prevents SQLi.)
+_RETENTION_TABLES = frozenset({
+    'price_history',
+    'technical_indicators',
+    'news_sentiment',
+    'ml_predictions',
+    'recommendations',
+})
+
 
 class DataLoader:
     """Load transformed data into PostgreSQL/TimescaleDB"""
@@ -439,12 +451,20 @@ class DataLoader:
             
             with self.get_connection() as conn:
                 for table, days in retention_days.items():
+                    if table not in _RETENTION_TABLES:
+                        logger.warning("Skipping cleanup for unknown table: %r", table)
+                        continue
+                    try:
+                        days = int(days)
+                    except (TypeError, ValueError):
+                        logger.warning("Skipping %s: invalid retention days %r", table, days)
+                        continue
                     if table == 'recommendations':
                         # Archive old recommendations
                         query = text(f"""
                             UPDATE {table} 
                             SET is_active = false 
-                            WHERE created_at < CURRENT_TIMESTAMP - INTERVAL '{days} days'
+                            WHERE created_at < CURRENT_TIMESTAMP - (:days * INTERVAL '1 day')
                             AND is_active = true
                         """)
                     else:
@@ -452,10 +472,10 @@ class DataLoader:
                         date_column = 'date' if table != 'ml_predictions' else 'prediction_date'
                         query = text(f"""
                             DELETE FROM {table} 
-                            WHERE {date_column} < CURRENT_TIMESTAMP - INTERVAL '{days} days'
+                            WHERE {date_column} < CURRENT_TIMESTAMP - (:days * INTERVAL '1 day')
                         """)
                     
-                    result = conn.execute(query)
+                    result = conn.execute(query, {"days": days})
                     conn.commit()
                     
                     logger.info(f"Cleaned up {result.rowcount} rows from {table}")

--- a/backend/tests/unit/test_data_loader_cleanup_security.py
+++ b/backend/tests/unit/test_data_loader_cleanup_security.py
@@ -1,0 +1,95 @@
+"""Security regression tests for DataLoader.cleanup_old_data (SQL injection fix).
+
+Covers issue #197: table names were f-string-interpolated and the retention
+window was inlined, allowing SQL injection via caller-supplied retention_days.
+The fix validates tables against an allowlist and binds days as a parameter.
+"""
+import contextlib
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from backend.etl.data_loader import DataLoader, _RETENTION_TABLES
+
+
+@pytest.fixture
+def loader():
+    # Engine creation is irrelevant here; get_connection is mocked per test.
+    with patch.object(DataLoader, "_create_engine", return_value=MagicMock()):
+        return DataLoader()
+
+
+def _mock_connection(loader):
+    """Wire loader.get_connection() to yield a MagicMock and return it."""
+    conn = MagicMock()
+
+    @contextlib.contextmanager
+    def fake_get_connection():
+        yield conn
+
+    loader.get_connection = fake_get_connection
+    return conn
+
+
+def _executed_sql(conn):
+    return " ".join(str(call.args[0]) for call in conn.execute.call_args_list)
+
+
+def test_unknown_table_is_skipped_and_not_injected(loader):
+    conn = _mock_connection(loader)
+    malicious = "price_history; DROP TABLE users; --"
+
+    assert loader.cleanup_old_data({malicious: 30, "price_history": 30}) is True
+
+    sql = _executed_sql(conn)
+    assert "DROP TABLE users" not in sql          # injection payload never reaches SQL
+    assert malicious not in sql
+    assert "DELETE FROM price_history" in sql      # the allowlisted table still runs
+
+
+def test_days_is_bound_not_interpolated(loader):
+    conn = _mock_connection(loader)
+
+    loader.cleanup_old_data({"price_history": 30})
+
+    delete_calls = [
+        c for c in conn.execute.call_args_list
+        if "DELETE FROM price_history" in str(c.args[0])
+    ]
+    assert delete_calls, "expected a DELETE for price_history"
+    args = delete_calls[0].args
+    assert len(args) == 2, "query must be executed with a bound-parameter dict"
+    assert args[1] == {"days": 30}
+    assert "INTERVAL '30 days'" not in str(args[0])   # days not f-string-interpolated
+
+
+def test_non_integer_days_is_rejected(loader):
+    conn = _mock_connection(loader)
+
+    loader.cleanup_old_data({"price_history": "30 days'; DROP TABLE x; --"})
+
+    sql = _executed_sql(conn)
+    assert "DROP TABLE" not in sql
+    assert "DELETE FROM price_history" not in sql     # skipped due to invalid days
+
+
+def test_recommendations_archive_uses_bound_param(loader):
+    conn = _mock_connection(loader)
+
+    loader.cleanup_old_data({"recommendations": 30})
+
+    archive_calls = [
+        c for c in conn.execute.call_args_list
+        if "UPDATE recommendations" in str(c.args[0])
+    ]
+    assert archive_calls, "expected an UPDATE for recommendations"
+    assert archive_calls[0].args[1] == {"days": 30}
+    assert "INTERVAL '30 days'" not in str(archive_calls[0].args[0])
+
+
+def test_default_tables_are_all_allowlisted():
+    # Guards against drift: the documented default retention tables must remain
+    # members of the allowlist, or cleanup would silently skip them.
+    for table in ("price_history", "technical_indicators", "news_sentiment",
+                  "ml_predictions", "recommendations"):
+        assert table in _RETENTION_TABLES


### PR DESCRIPTION
## What

Fixes the SQL injection in `DataLoader.cleanup_old_data()` (`backend/etl/data_loader.py`).

Before, the table name, date column, and retention window were interpolated directly into a `text()` SQL string:

```python
query = text(f"DELETE FROM {table} WHERE {date_column} < CURRENT_TIMESTAMP - INTERVAL '{days} days'")
```

The public method signature accepts a caller-supplied `retention_days` dict, so a crafted key/value could inject arbitrary DDL/DML against the production database.

## Fix

- **Allowlist** (`_RETENTION_TABLES`): any table not in the hardcoded set is skipped with a warning, so only known-constant identifiers are ever interpolated.
- **Parameter binding**: the retention window is coerced to `int` and bound as a query parameter — `(:days * INTERVAL '1 day')` — instead of being inlined.

Default behavior is unchanged: all five default retention tables remain allowlisted, and a normal `cleanup_old_data()` call produces the same effective queries.

## Tests

New `backend/tests/unit/test_data_loader_cleanup_security.py` (5 tests, all passing locally):
- injection payload in a table name is skipped, never reaches SQL
- `days` is bound as a parameter, not f-string-interpolated
- non-integer `days` (injection attempt) is rejected
- `recommendations` archive path also uses a bound parameter
- all documented default tables remain allowlisted (drift guard)

```
5 passed in 0.84s
```

## Source

Identified in the 2026-05-20 codebase deep-dive audit (Data Layer segment); see `docs/audits/2026-05/CODEBASE_DEEP_DIVE_AUDIT.md`.

## Out of scope (follow-ups)

- `VACUUM ANALYZE` runs inside the transaction block (same function) — separate Data Layer finding, not addressed here to keep this PR atomic.
- Redis SCAN pattern injection in `cache_management.py` (also tracked in #197) — to be handled with the cache-auth fix (#199).

Closes #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)