### PR TITLE
fix(gdpr): require auth on deletion-process, audit & retention endpoints (#198)

### DIFF
--- a/backend/api/routers/gdpr.py
+++ b/backend/api/routers/gdpr.py
@@ -19,7 +19,7 @@ import logging
 
 from backend.config.database import get_async_db_session
 from backend.models.unified_models import User
-from backend.auth.oauth2 import get_current_user
+from backend.auth.oauth2 import get_current_user, get_current_admin_user
 from backend.compliance.gdpr import retention_manager
 from backend.models.api_response import ApiResponse, success_response
 from backend.security.rate_limiter import rate_limit, RateLimitCategory, RateLimitRule
@@ -229,6 +229,7 @@ async def request_deletion(
 async def process_deletion_request(
     request_id: str,
     request: Request,
+    current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_async_db_session)
 ) -> ApiResponse[DeleteRequestResponse]:
     """Process a pending deletion request."""
@@ -261,6 +262,7 @@ async def process_deletion_request(
 async def get_deletion_audit(
     request_id: str,
     request: Request,
+    current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_async_db_session)
 ) -> ApiResponse[DeletionAuditResponse]:
     """Get audit trail for a deletion request"""
@@ -514,6 +516,7 @@ async def get_retention_report(
 async def enforce_retention_policies(
     request: Request,
     background_tasks: BackgroundTasks,
+    current_user: User = Depends(get_current_admin_user),
     db: AsyncSession = Depends(get_async_db_session)
 ) -> ApiResponse[Dict[str, Any]]:
     """Enforce data retention policies (admin only)."""

--- a/backend/tests/test_gdpr_api.py
+++ b/backend/tests/test_gdpr_api.py
@@ -636,3 +636,28 @@ class TestGDPRErrorHandling:
                     )
 
         assert_api_error_response(response, 404, "not found")
+
+
+# ============================================================================
+# ENDPOINT AUTHORIZATION REGRESSION TESTS (#198)
+# Previously these three endpoints were reachable with no authentication.
+# ============================================================================
+
+class TestGDPREndpointAuthorization:
+    """Regression: process/audit require auth; retention requires admin (#198)."""
+
+    async def test_process_deletion_requires_auth(self, async_client: AsyncClient):
+        response = await async_client.post(
+            "/api/v1/gdpr/users/me/delete-request/some_request_id/process"
+        )
+        assert_api_error_response(response, 401)
+
+    async def test_deletion_audit_requires_auth(self, async_client: AsyncClient):
+        response = await async_client.get(
+            "/api/v1/gdpr/users/me/delete-request/some_request_id/audit"
+        )
+        assert_api_error_response(response, 401)
+
+    async def test_retention_enforce_requires_auth(self, async_client: AsyncClient):
+        response = await async_client.post("/api/v1/gdpr/admin/retention/enforce")
+        assert_api_error_response(response, 401)


### PR DESCRIPTION
## What

Adds authentication to three GDPR endpoints that were reachable with **no authentication** (the router is a bare `APIRouter()` and these handlers had no `current_user` dependency).

| Endpoint | Risk | Fix |
|---|---|---|
| `POST /users/me/delete-request/{id}/process` | Anonymous caller could trigger **irreversible** deletion/anonymization | `Depends(get_current_user)` |
| `GET /users/me/delete-request/{id}/audit` | Anonymous, enumerable **IDOR** exposing `anonymized_user_reference` + record counts | `Depends(get_current_user)` |
| `POST /admin/retention/enforce` | Anonymous could schedule platform-wide destructive retention jobs | `Depends(get_current_admin_user)` |

The `/users/me/...` endpoints take `get_current_user` (matching the self-service path semantics and the existing authenticated deletion flow); the `/admin/...` endpoint takes `get_current_admin_user`.

## Tests

- New `TestGDPREndpointAuthorization` — anonymous → 401 for all three.
- All 16 existing GDPR tests still pass (the authenticated `/process` flow is unaffected).

## Source

2026-05-20 deep-dive audit (Auth/Security/GDPR segment); `docs/audits/2026-05/CODEBASE_DEEP_DIVE_AUDIT.md`.

## Out of scope (follow-up)

Residual **IDOR**: an authenticated user could still pass another user's `request_id` to `/process` or `/audit`. Closing that needs ownership verification in `gdpr_service` (the request→owner link), tracked as a follow-up rather than bundled here.

Closes #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)