### PR TITLE
Wave 3 G4 follow-up: drop orphaned log_aggregation_endpoint config (F-10-017)

### DIFF
--- a/backend/config/monitoring_config.py
+++ b/backend/config/monitoring_config.py
@@ -30,9 +30,11 @@ class LoggingConfig:
     include_performance_metrics: bool = True
     
     # Log aggregation
+    # NOTE: log_aggregation_endpoint was removed with F-10-017 (PRD audit
+    # 2026-04) when the Elasticsearch setup path in log_analysis.py was deleted;
+    # nothing else consumed it.
     enable_log_aggregation: bool = True
-    log_aggregation_endpoint: str = os.getenv("LOG_AGGREGATION_ENDPOINT", "")
-    
+
     # Sensitive data masking
     mask_sensitive_data: bool = True
     sensitive_fields: List[str] = field(default_factory=lambda: [


### PR DESCRIPTION
## TL;DR

F-10-017 (merged in #183) deleted `LogAggregator._setup_elasticsearch`, the **only** consumer of `LoggingConfig.log_aggregation_endpoint`. This one-line follow-up removes the now-dead config field (and the `LOG_AGGREGATION_ENDPOINT` env var it read), which is referenced nowhere else in the codebase. `enable_log_aggregation` is intentionally left in place.

## Why

This was flagged during post-merge verification of #183: the dead-code removal left dead *config* behind. Tying off the loose end so the F-10-017 cleanup is complete.

## Validation (throwaway venv, repo `.flake8` / `.mypy.ini` semantics)

- **flake8 / ruff / mypy**: zero new findings vs `main` (differential HEAD-vs-change). One stray whitespace-only blank line was also removed (W293 29→28). The 3 pre-existing F401s are untouched — `os` is still used by other `os.getenv(...)` defaults in the file.
- **Test-safe**: the field was only otherwise referenced in `backend/tests/unit/test_monitoring_extended_agent4.py:82`, where it is set on a `MagicMock` (not the real dataclass), so removal does not affect that test.
- A source-level loader confirms `LoggingConfig()` and the module-level `monitoring_config` singleton still build, and `enable_log_aggregation` remains `True`.

## Out of scope (noted, deliberately not changed)

- `enable_log_aggregation` is *also* unreferenced repo-wide, but that is a pre-existing condition unrelated to F-10-017 — left as-is.

## Acceptance

- [x] `monitoring_config.py` parses / compiles.
- [x] `grep -rn "log_aggregation_endpoint" backend/ scripts/` returns only the test MagicMock line.
- [x] flake8/ruff/mypy show no new findings vs `main`.
- [ ] CI green.

## References

- Follow-up to: PR #183 (F-10-017 + F-07-016)
- PRD: `docs/audits/2026-04/PRD-for-loki.md` §3 G4 Phase 3