### PR TITLE
chore: remove leftover console.warn from login thunk (post-#153 cleanup)

### DIFF
--- a/frontend/web/src/store/slices/appSlice.ts
+++ b/frontend/web/src/store/slices/appSlice.ts
@@ -70,7 +70,6 @@ export const login = createAsyncThunk(
     const payload = response.data?.data ?? response.data;
     const token = payload?.access_token;
     if (!token) {
-      console.warn('login response missing access_token', response.data);
       throw new Error('Login response did not include access_token');
     }
     localStorage.setItem('access_token', token);


### PR DESCRIPTION
## Summary
Removes the lone `console.warn` left in the `login` async thunk's missing-token error path in `frontend/web/src/store/slices/appSlice.ts`. It violates the repo no-console coding-style rule, and the adjacent `throw new Error(...)` already surfaces the failure to the rejected-thunk state — so the warn was redundant.

This is a follow-up cleanup after **Workstream F (#153)**, which introduced the envelope-aware token handling but left this line in place.

## Change
- 1 line removed; no behavior change. The thunk still rejects when the `ApiResponse` envelope lacks `access_token`.

## Verification
- `vitest run src/store/slices/slices.test.ts` → **75/75 pass** (incl. "login thunk rejects when access_token is missing")
- `tsc --noEmit` error count **unchanged** vs `main` (no new type errors)
- `console.*` occurrences in `src/` reduced 3 → 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)