### PR TITLE
chore(test): drop dead elasticsearch sys.modules stub from monitoring test

### DIFF
--- a/backend/tests/unit/test_monitoring_extended_agent4.py
+++ b/backend/tests/unit/test_monitoring_extended_agent4.py
@@ -140,10 +140,6 @@ _orig_mime_text.MimeText = MagicMock  # Add the typo name
 import email.mime.multipart as _orig_mime_mp
 _orig_mime_mp.MimeMultipart = MagicMock  # Add the typo name
 
-# Stub elasticsearch (optional dep in log_analysis.py)
-sys.modules.setdefault("elasticsearch", MagicMock())
-sys.modules.setdefault("elasticsearch.helpers", MagicMock())
-
 # Stub backend.monitoring.alerting_system (used by log_analysis _create_alert_for_anomaly)
 _mock_alerting = MagicMock()
 _mock_alerting.alert_manager = MagicMock()


### PR DESCRIPTION
## TL;DR

Trivial follow-up to the ELK decommission (#210/#217). Removes a now-dead `sys.modules` stub for `elasticsearch` / `elasticsearch.helpers` in `backend/tests/unit/test_monitoring_extended_agent4.py`. **−4 lines, no behavior change.**

## Why it's safe

After #211/#217 removed all Elasticsearch imports from `backend/monitoring/`, none of the three modules this test loads via `spec_from_file_location` — `health_system.py`, `log_analysis.py`, `real_time_alerts.py` — import `elasticsearch` anymore (verified by grep). The `sys.modules.setdefault("elasticsearch", ...)` stub was only there to satisfy `log_analysis.py`'s old optional import, which is gone. The stub is referenced nowhere else in the test. Removing it can't cause an ImportError.

## Validation
- `py_compile` OK; 0 `elasticsearch` references remain in the file.
- Diff is exactly the 3 stub lines + their trailing blank.

## References
- Final tidy from the #210 ELK decommission. Builds on #211, #217.