### PR TITLE
fix(backend): resolve 11 F821 undefined-name latent NameErrors (B3)

### DIFF
--- a/backend/etl/concurrent_processor.py
+++ b/backend/etl/concurrent_processor.py
@@ -12,6 +12,7 @@ from typing import List, Dict, Any, Optional, Callable, Union, Tuple, Set
 import time
 import threading
 import queue
+import multiprocessing
 import multiprocessing as mp
 from dataclasses import dataclass, field
 import psutil

--- a/backend/ml/pipeline/implementations.py
+++ b/backend/ml/pipeline/implementations.py
@@ -30,7 +30,7 @@ import torch
 import torch.nn as nn
 from torch.utils.data import DataLoader, TensorDataset
 
-from .base import ModelPipeline, PipelineConfig, PipelineStep, ModelType, ModelArtifact
+from .base import ModelPipeline, PipelineConfig, PipelineStep, ModelType, ModelArtifact, PipelineStatus
 
 # GPU utilities for device detection
 try:

--- a/backend/monitoring/health_checks.py
+++ b/backend/monitoring/health_checks.py
@@ -167,7 +167,8 @@ class HealthChecker:
     async def execute(self) -> HealthCheckResult:
         """Execute health check with retries and timeout."""
         start_time = time.time()
-        
+        last_error: Optional[Exception] = None
+
         for attempt in range(self.retries + 1):
             try:
                 # Execute with timeout
@@ -237,6 +238,7 @@ class HealthChecker:
                 if attempt < self.retries:
                     continue
                 error_msg = f"Health check error: {str(e)}"
+                last_error = e
                 logger.error(f"Health check error: {self.service}.{self.name}: {e}")
         
         # All retries failed
@@ -248,7 +250,7 @@ class HealthChecker:
             message=error_msg,
             duration=duration,
             timestamp=datetime.now(),
-            error_details=str(e) if 'e' in locals() else None
+            error_details=str(last_error) if last_error else None
         )
         
         # Record failure metrics

--- a/backend/security/data_encryption.py
+++ b/backend/security/data_encryption.py
@@ -7,6 +7,7 @@ import os
 import json
 import base64
 import hashlib
+import ipaddress
 import secrets
 from typing import Any, Dict, List, Optional, Union, Tuple, BinaryIO
 from datetime import datetime, timedelta, timezone

--- a/backend/tests/fixtures/comprehensive_mock_fixtures.py
+++ b/backend/tests/fixtures/comprehensive_mock_fixtures.py
@@ -5,6 +5,7 @@ This module provides realistic mock data for all external services and
 financial scenarios, enabling complete offline testing.
 """
 
+import asyncio
 import pytest
 import numpy as np
 import pandas as pd

--- a/backend/tests/test_f821_import_smoke.py
+++ b/backend/tests/test_f821_import_smoke.py
@@ -1,0 +1,65 @@
+"""Import smoke tests guarding the B3 F821 missing-import fixes.
+
+Each of these modules previously referenced a name that was never imported
+(multiprocessing, PipelineStatus, ipaddress, asyncio, random, metrics, json,
+uuid), a latent ``NameError`` waiting at the referenced call site and flagged
+by ruff as F821.
+
+These tests import each module and assert the import succeeds. A missing
+*optional third-party* dependency (e.g. mlflow) or an upstream
+module-level ``pytest.skip`` is tolerated via ``importorskip``-style handling
+-- those are environment gaps, not the regression we guard. A ``NameError``
+(the actual bug class) is NOT tolerated and fails the test.
+"""
+
+import importlib
+
+import pytest
+
+# Modules that received a missing-import fix, paired with the name that was
+# previously undefined (documentation only).
+F821_FIXED_MODULES = [
+    ("backend.etl.concurrent_processor", "multiprocessing"),
+    ("backend.ml.pipeline.implementations", "PipelineStatus"),
+    ("backend.security.data_encryption", "ipaddress"),
+    ("backend.tests.fixtures.comprehensive_mock_fixtures", "asyncio"),
+    ("backend.tests.test_resilience_integration", "random"),
+    ("backend.utils.data_anonymization", "metrics"),
+    ("backend.utils.performance_tester", "json"),
+    ("backend.utils.resilient_pipeline", "uuid"),
+]
+
+
+@pytest.mark.parametrize(
+    "module_name,fixed_name",
+    F821_FIXED_MODULES,
+    ids=[m for m, _ in F821_FIXED_MODULES],
+)
+def test_module_imports_without_nameerror(module_name, fixed_name):
+    """Module imports cleanly; only environment gaps are skipped.
+
+    The regression we guard is a ``NameError`` (the undefined name the missing
+    import previously caused). Anything else raised at import time -- a missing
+    optional dependency (mlflow), a missing sibling module surfacing as an
+    upstream ``pytest.skip``, or a Python-3.9 ``asyncio.Event()``-at-import
+    event-loop ``RuntimeError`` -- is an environment artifact unrelated to the
+    fix and is reported as a skip.
+    """
+    try:
+        importlib.import_module(module_name)
+    except NameError:
+        # This is exactly the regression we are guarding against.
+        raise
+    except pytest.skip.Exception:
+        # An upstream module performed an allow_module_level skip
+        # (e.g. a missing sibling module). Propagate as a skip.
+        raise
+    except Exception as exc:  # noqa: BLE001 - environment gaps, not NameError
+        pytest.skip(
+            f"{module_name} could not be imported in this environment "
+            f"(not a NameError regression): {type(exc).__name__}: {exc}"
+        )
+
+
+if __name__ == "__main__":  # pragma: no cover - manual run convenience
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/backend/tests/test_health_check_error_details.py
+++ b/backend/tests/test_health_check_error_details.py
@@ -1,0 +1,74 @@
+"""Regression test for HealthChecker.error_details population (B3 / F821).
+
+HealthChecker.execute() previously computed ``error_details`` with
+``str(e) if 'e' in locals() else None``. In Python 3 the ``except Exception
+as e:`` target is deleted at the end of the except block, so after the retry
+loop ``'e' in locals()`` is always False and ``error_details`` was always
+None for failed checks (and ruff flagged the bare ``e`` as F821).
+
+This test drives the retry path to exhaustion with a raising check function
+and asserts the resulting HealthCheckResult carries the real exception text.
+"""
+
+import asyncio
+
+import pytest
+
+from backend.monitoring.health_checks import (
+    HealthChecker,
+    HealthStatus,
+    ServiceType,
+)
+
+
+def test_execute_populates_error_details_on_failure():
+    """A check that always raises must surface the exception text."""
+
+    async def always_failing_check():
+        raise RuntimeError("boom-db-down")
+
+    checker = HealthChecker(
+        name="db_ping",
+        service="database",
+        check_func=always_failing_check,
+        service_type=ServiceType.DATABASE,
+        timeout=1,
+        retries=2,
+        critical=True,
+    )
+
+    result = asyncio.run(checker.execute())
+
+    # The check exhausted all retries and failed.
+    assert result.status in (HealthStatus.CRITICAL, HealthStatus.UNHEALTHY)
+
+    # The real regression guard: error_details must be a non-None string
+    # containing the raised exception's message.
+    assert result.error_details is not None
+    assert isinstance(result.error_details, str)
+    assert "boom-db-down" in result.error_details
+
+
+def test_execute_error_details_none_on_success():
+    """A passing check leaves error_details unset (None)."""
+
+    async def healthy_check():
+        return True
+
+    checker = HealthChecker(
+        name="db_ping",
+        service="database",
+        check_func=healthy_check,
+        service_type=ServiceType.DATABASE,
+        timeout=1,
+        retries=0,
+    )
+
+    result = asyncio.run(checker.execute())
+
+    assert result.status == HealthStatus.HEALTHY
+    assert result.error_details is None
+
+
+if __name__ == "__main__":  # pragma: no cover - manual run convenience
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/backend/tests/test_resilience_integration.py
+++ b/backend/tests/test_resilience_integration.py
@@ -6,6 +6,7 @@ Tests circuit breakers, fallback mechanisms, retry logic, and system recovery.
 import pytest
 import asyncio
 import json
+import random
 from datetime import datetime, timedelta, timezone
 from typing import Dict, Any, List, Optional
 from unittest.mock import AsyncMock, patch, MagicMock

--- a/backend/utils/data_anonymization.py
+++ b/backend/utils/data_anonymization.py
@@ -10,6 +10,7 @@ from cryptography.fernet import Fernet
 from faker import Faker
 
 from backend.config import settings
+from backend.utils import monitoring as metrics
 from backend.utils.monitoring import data_anonymization_operations
 
 # Initialize Faker for generating fake data

--- a/backend/utils/performance_tester.py
+++ b/backend/utils/performance_tester.py
@@ -3,6 +3,7 @@ Database performance testing and validation utilities
 """
 
 import time
+import json
 import random
 import statistics
 from typing import List, Dict, Any, Callable, Optional

--- a/backend/utils/resilient_pipeline.py
+++ b/backend/utils/resilient_pipeline.py
@@ -7,6 +7,7 @@ import asyncio
 import time
 import json
 import hashlib
+import uuid
 # SECURITY: Removed pickle import - using JSON for state serialization
 from typing import Any, Dict, List, Optional, Callable, Union, TypeVar, Generic
 from dataclasses import dataclass, asdict


### PR DESCRIPTION
## Summary

Plan item **B3** — an independent change (not related to PR #207). Resolves all 11 ruff `F821` "undefined name" diagnostics in the backend. Each was a latent `NameError` waiting at its referenced call site.

`ruff check backend --select F821` went from **11 errors → 0**.

## Changes

### 8 missing-import fixes (commit `400e793`)
| File | Undefined name | Used at |
|------|---------------|---------|
| `backend/etl/concurrent_processor.py` | `multiprocessing` | `multiprocessing.cpu_count()` |
| `backend/ml/pipeline/implementations.py` | `PipelineStatus` | added to `from .base import ...` |
| `backend/security/data_encryption.py` | `ipaddress` | `x509.IPAddress(ipaddress.IPv4Address(...))` |
| `backend/tests/fixtures/comprehensive_mock_fixtures.py` | `asyncio` | `asyncio.TimeoutError(...)` |
| `backend/tests/test_resilience_integration.py` | `random` | `random.random()` |
| `backend/utils/data_anonymization.py` | `metrics` | `metrics.gdpr_requests` (3 sites) — `from backend.utils import monitoring as metrics` |
| `backend/utils/performance_tester.py` | `json` | `json.dumps(...)` |
| `backend/utils/resilient_pipeline.py` | `uuid` | `uuid.uuid4()` |

### 1 logic-bug fix (commit `6beafe4`)
`backend/monitoring/health_checks.py` — `HealthChecker.execute()` computed `error_details=str(e) if 'e' in locals() else None`. Python 3 deletes the `except Exception as e:` target at block exit, so after the retry loop `'e' in locals()` was always `False` and failed health checks always reported `error_details=None` (the bare `e` was the F821). Fix introduces a loop-scoped `last_error: Optional[Exception]`, assigns it inside the except block, and reads it after the loop so failed checks now carry the real exception text.

### Tests (commit `d34ded7`)
- `backend/tests/test_health_check_error_details.py` — fail-first regression guard for the `error_details` bug (verified RED against pre-fix code, GREEN after). Drives the retry path to exhaustion with a raising check fn and asserts `error_details` is a non-None string containing the exception text.
- `backend/tests/test_f821_import_smoke.py` — imports each of the 8 fixed modules; fails on `NameError` (the regression class), skips on unrelated environment gaps (missing optional deps like `mlflow`, py3.9 import-time event-loop).

## Verification
- `uvx ruff check backend --select F821` → **All checks passed!** (was 11 errors)
- Differential lint: every touched file has **equal-or-fewer** total ruff errors than `origin/main` and introduces **zero new error codes** (only `F821` removed).
- Tests (env stubs + `--noconftest`): **8 passed, 2 skipped, 0 failed**. The 2 skips are pre-existing optional-dependency/event-loop environment gaps, not regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)