### PR TITLE
fix(analytics): add interim chunked scan_market_streaming wrapper (F-09-002)

### DIFF
--- a/backend/data_ingestion/market_scanner.py
+++ b/backend/data_ingestion/market_scanner.py
@@ -23,7 +23,7 @@ Fallback Chain Strategy:
 
 import asyncio
 import logging
-from typing import Dict, List, Optional, Tuple, Any, Callable
+from typing import AsyncIterator, Dict, List, Optional, Tuple, Any, Callable
 from datetime import datetime, timedelta, timezone
 from dataclasses import dataclass, field
 import pandas as pd
@@ -752,6 +752,53 @@ class MarketScanner:
 
         logger.info(f"Market scan returned {len(filtered_stocks)} stocks")
         return filtered_stocks
+
+    async def scan_market_streaming(
+        self,
+        sectors: Optional[List[str]] = None,
+        market_cap_range: Optional[Tuple[float, float]] = None,
+        chunk_size: int = 100,
+        max_stocks: int = 500,
+        min_volume: Optional[float] = None,
+        min_price: float = 5.0,
+        exchanges: Optional[List[str]] = None,
+    ) -> AsyncIterator[List[Dict[str, Any]]]:
+        """Stream market scan results as fixed-size chunks.
+
+        Interim wrapper around :meth:`scan_market` that yields the filtered
+        stock list in ``chunk_size`` batches so callers can consume it as an
+        async generator without buffering the entire result themselves. This
+        is intentionally minimal: it adds no backpressure or cancellation
+        logic (the full streaming engine remains a deferred feature) and
+        preserves the fail-loud behaviour of ``scan_market`` (errors raised by
+        the underlying scan propagate to the caller).
+
+        Args:
+            sectors: List of sectors to include.
+            market_cap_range: Tuple of (min_market_cap, max_market_cap).
+            chunk_size: Number of stocks to yield per chunk (must be > 0).
+            max_stocks: Maximum number of stocks to scan.
+            min_volume: Minimum average daily volume.
+            min_price: Minimum stock price.
+            exchanges: List of exchanges to include.
+
+        Yields:
+            Lists of stock dictionaries, each of length <= ``chunk_size``.
+        """
+        if chunk_size <= 0:
+            raise ValueError(f"chunk_size must be positive, got {chunk_size}")
+
+        stocks = await self.scan_market(
+            sectors=sectors,
+            market_cap_range=market_cap_range,
+            max_stocks=max_stocks,
+            min_volume=min_volume,
+            min_price=min_price,
+            exchanges=exchanges,
+        )
+
+        for start in range(0, len(stocks), chunk_size):
+            yield stocks[start:start + chunk_size]
 
     async def _build_stock_universe(self) -> List[Dict[str, Any]]:
         """Build comprehensive stock universe from available sources."""

--- a/backend/tests/test_market_scanner_streaming_guard.py
+++ b/backend/tests/test_market_scanner_streaming_guard.py
@@ -1,0 +1,127 @@
+"""Regression guard for F-09-002: scan_market_streaming must exist.
+
+``recommendation_optimized._scan_market_optimized`` consumes
+``scanner.scan_market_streaming(...)`` as an async generator. That method was
+never defined on :class:`MarketScanner`, which is a latent ``AttributeError``
+land-mine on the recommendation hot path. This test asserts the interim
+chunked wrapper exists, is an async generator, and yields fixed-size chunks.
+
+Run source-level (the repo conftest eagerly imports the full app)::
+
+    python3 -m pytest backend/tests/test_market_scanner_streaming_guard.py \
+        --noconftest -q
+
+The chunking behaviour is verified without live infra by extracting the
+``scan_market_streaming`` coroutine function from source and binding it to a
+fake ``self`` whose ``scan_market`` returns a small in-memory list. This keeps
+the test free of the heavy ``backend.*`` import tree.
+"""
+
+import ast
+import asyncio
+import types
+from pathlib import Path
+
+import pytest
+
+_SCANNER_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "data_ingestion"
+    / "market_scanner.py"
+)
+
+
+def _scanner_class_node() -> ast.ClassDef:
+    tree = ast.parse(_SCANNER_PATH.read_text())
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == "MarketScanner":
+            return node
+    raise AssertionError("MarketScanner class not found in market_scanner.py")
+
+
+def _streaming_method_node() -> ast.AsyncFunctionDef:
+    for item in _scanner_class_node().body:
+        if (
+            isinstance(item, ast.AsyncFunctionDef)
+            and item.name == "scan_market_streaming"
+        ):
+            return item
+    raise AssertionError(
+        "MarketScanner.scan_market_streaming is not defined "
+        "(F-09-002 AttributeError land-mine)"
+    )
+
+
+def test_scan_market_streaming_defined_as_async_generator():
+    """The wrapper must exist and be an async generator (has a yield)."""
+    node = _streaming_method_node()
+
+    has_yield = any(
+        isinstance(inner, (ast.Yield, ast.YieldFrom))
+        for inner in ast.walk(node)
+    )
+    assert has_yield, "scan_market_streaming must yield (be an async generator)"
+
+    arg_names = {a.arg for a in node.args.args}
+    # Must accept the call contract used at recommendation_optimized.py:295.
+    assert {"sectors", "market_cap_range", "chunk_size"} <= arg_names
+
+
+def _load_streaming_func():
+    """Compile only the wrapper function, isolated from heavy module imports."""
+    node = _streaming_method_node()
+    module = ast.Module(body=[node], type_ignores=[])
+    ast.fix_missing_locations(module)
+    namespace: dict = {
+        "AsyncIterator": __import__("typing").AsyncIterator,
+        "List": __import__("typing").List,
+        "Dict": __import__("typing").Dict,
+        "Any": __import__("typing").Any,
+        "Optional": __import__("typing").Optional,
+        "Tuple": __import__("typing").Tuple,
+    }
+    code = compile(module, str(_SCANNER_PATH), "exec")
+    exec(code, namespace)  # noqa: S102 - controlled, single-function source
+    return namespace["scan_market_streaming"]
+
+
+def test_scan_market_streaming_yields_fixed_size_chunks():
+    """Bound to a fake self, the wrapper chunks scan_market output."""
+    streaming_func = _load_streaming_func()
+
+    fake_stocks = [{"ticker": f"T{i}"} for i in range(25)]
+
+    class FakeScanner:
+        async def scan_market(self, **kwargs):
+            return list(fake_stocks)
+
+    fake = FakeScanner()
+    bound = types.MethodType(streaming_func, fake)
+
+    async def _collect():
+        chunks = []
+        async for chunk in bound(chunk_size=10):
+            chunks.append(chunk)
+        return chunks
+
+    chunks = asyncio.run(_collect())
+
+    assert [len(c) for c in chunks] == [10, 10, 5]
+    assert [s for c in chunks for s in c] == fake_stocks
+
+
+def test_scan_market_streaming_rejects_nonpositive_chunk_size():
+    streaming_func = _load_streaming_func()
+
+    class FakeScanner:
+        async def scan_market(self, **kwargs):
+            return []
+
+    bound = types.MethodType(streaming_func, FakeScanner())
+
+    async def _drain():
+        async for _ in bound(chunk_size=0):
+            pass
+
+    with pytest.raises(ValueError):
+        asyncio.run(_drain())


### PR DESCRIPTION
## Problem (F-09-002)

`backend/analytics/recommendation_optimized.py` (`_scan_market_optimized`, around line 295) consumes the market scanner as an async generator:

```python
async for stock_chunk in scanner.scan_market_streaming(
    sectors=sectors,
    market_cap_range=market_cap_range,
    chunk_size=chunk_size,
):
```

…but `scan_market_streaming` was **never defined** on `MarketScanner`. Only `scan_market` (a plain `async def` returning `List[Dict]`) exists. Any code path reaching `_scan_market_optimized` would raise `AttributeError: 'MarketScanner' object has no attribute 'scan_market_streaming'` — a latent land-mine on the recommendation hot path.

## Fix (interim)

Add a thin async-generator wrapper `MarketScanner.scan_market_streaming(...)` that:
- delegates to the existing `scan_market` (preserving its fail-loud behaviour — underlying errors propagate),
- accepts the call contract used at line 295 (`sectors`, `market_cap_range`, `chunk_size`),
- yields the filtered stock list in fixed-size chunks (`<= chunk_size`),
- validates `chunk_size > 0`.

This is intentionally minimal. It adds **no** backpressure or cancellation logic.

## Scope / deferral

The real backpressure + cancellation streaming engine remains a **deferred** product feature (estimated 24–40h). This PR only removes the `AttributeError` land-mine with a correct, drop-in chunked wrapper plus a guard test; it does not attempt to build the full engine.

## Test

`backend/tests/test_market_scanner_streaming_guard.py` (run source-level; repo conftest eagerly imports the full app):

```
ENVIRONMENT=test JWT_SECRET_KEY=x SECRET_KEY=y MASTER_SECRET_KEY=... \
  DATABASE_URL=... REDIS_URL=... POSTGRES_HOST=localhost POSTGRES_DB=test \
  python3 -m pytest backend/tests/test_market_scanner_streaming_guard.py --noconftest -q
# 3 passed
```

Asserts the method exists, is an async generator, accepts `{sectors, market_cap_range, chunk_size}`, and yields fixed-size chunks (`[10, 10, 5]` for 25 items / chunk_size 10) — verified without live infra by binding the extracted coroutine to a fake `self`.

## Verification
- New test: **3 passed**
- `uvx ruff check` on changed files: scanner has 9 pre-existing F401 errors on both this branch and `origin/main` (identical, zero new codes); new test file is clean.
- Both files `py_compile` cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)