### PR TITLE
feat(ml): wire PriceHistoryDataProvider as backtest data_provider (#208 item 1)

### DIFF
--- a/backend/ml/backtesting.py
+++ b/backend/ml/backtesting.py
@@ -494,9 +494,21 @@ class BacktestEngine:
         return comparison_results
     
     def _get_market_data(self, universe: List[str], start_date: datetime, end_date: datetime) -> Dict[str, pd.DataFrame]:
-        """Get market data for backtesting"""
-        # This would integrate with the actual data provider
-        # For now, return mock data structure
+        """Get market data for backtesting.
+
+        When a ``data_provider`` is wired (the default via
+        :func:`get_backtest_engine`), real OHLCV history is fetched from the
+        price repository. The provider is fail-loud: a missing symbol raises
+        rather than fabricating prices. Only when *no* provider is configured
+        do we fall back to the legacy synthetic data path (kept for backward
+        compatibility with ``BacktestEngine()`` constructed without a provider).
+        """
+        if self.data_provider is not None:
+            return self.data_provider.get_bulk_historical_prices(
+                universe, start_date, end_date
+            )
+
+        # Legacy synthetic fallback (no provider wired).
         market_data = {}
         
         for ticker in universe:
@@ -521,7 +533,18 @@ class BacktestEngine:
         return market_data
     
     def _get_benchmark_data(self, symbol: str, start_date: datetime, end_date: datetime) -> pd.DataFrame:
-        """Get benchmark data"""
+        """Get benchmark data.
+
+        Uses the wired ``data_provider`` (real repository-backed OHLCV) when
+        available, deriving a ``returns`` column from close prices. Falls back
+        to the legacy synthetic benchmark only when no provider is configured.
+        """
+        if self.data_provider is not None:
+            frame = self.data_provider.get_historical_prices(symbol, start_date, end_date)
+            benchmark = frame[['close']].copy()
+            benchmark['returns'] = benchmark['close'].pct_change().fillna(0)
+            return benchmark
+
         # Mock benchmark data
         dates = pd.date_range(start_date, end_date, freq='D')
         dates = dates[dates.weekday < 5]
@@ -946,8 +969,16 @@ class BacktestEngine:
 _backtest_engine: Optional[BacktestEngine] = None
 
 def get_backtest_engine() -> BacktestEngine:
-    """Get global backtest engine instance"""
+    """Get global backtest engine instance.
+
+    The default engine is wired with :class:`PriceHistoryDataProvider`, which
+    sources real OHLCV history from the price repository (fail-loud on missing
+    data). This replaces the previous synthetic-data behaviour for the
+    production backtest path (#208 item 1).
+    """
     global _backtest_engine
     if _backtest_engine is None:
-        _backtest_engine = BacktestEngine()
+        from backend.ml.data_providers import PriceHistoryDataProvider
+
+        _backtest_engine = BacktestEngine(data_provider=PriceHistoryDataProvider())
     return _backtest_engine

--- a/backend/ml/data_providers.py
+++ b/backend/ml/data_providers.py
@@ -1,0 +1,237 @@
+"""
+Backtest data providers.
+
+Adapts the existing :class:`PriceHistoryRepository` to the OHLCV pandas
+``DataFrame`` shape that :mod:`backend.ml.backtesting` consumes.  This is a
+thin adapter over the repository -- it deliberately does *not* introduce a new
+``MarketDataProvider`` abstraction.  The DDD seam already exists as
+``backend.domain.contracts.MarketDataContract``; this provider simply reuses
+the repository to keep the backtest path concrete and fail-loud.
+
+Design notes
+------------
+* The backtest engine consumes data synchronously (it iterates trading dates in
+  a plain ``for`` loop).  The repository is async, so this provider fetches all
+  required history up front via :meth:`PriceHistoryRepository.get_bulk_price_history`
+  and converts each symbol's ``List[PriceHistory]`` into an OHLCV ``DataFrame``
+  indexed by date with columns ``open/high/low/close/volume``.
+* Fail-loud: if the repository returns no rows for a requested symbol the
+  provider raises ``NoMarketDataError`` rather than synthesising prices.  No
+  random data is ever generated here.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import date, datetime
+from typing import Any, Dict, List, Optional, Sequence
+
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+# OHLCV columns the backtester expects on each per-symbol DataFrame.
+OHLCV_COLUMNS = ["open", "high", "low", "close", "volume"]
+
+
+class NoMarketDataError(RuntimeError):
+    """Raised when no price history exists for a requested symbol.
+
+    Fail-loud sentinel: the backtest data path must never fabricate prices, so
+    a missing symbol is surfaced as an error rather than silently filled.
+    """
+
+
+def _to_naive_timestamp(value: Any) -> pd.Timestamp:
+    """Coerce a date/datetime to a tz-naive pandas Timestamp for the index."""
+    ts = pd.Timestamp(value)
+    if ts.tzinfo is not None:
+        ts = ts.tz_localize(None)
+    return ts
+
+
+def price_history_to_dataframe(records: Sequence[Any]) -> pd.DataFrame:
+    """Convert a list of ``PriceHistory`` rows into an OHLCV ``DataFrame``.
+
+    Args:
+        records: Sequence of ``PriceHistory`` model instances (or any object
+            exposing ``date``, ``open``, ``high``, ``low``, ``close``,
+            ``volume``).  Decimal/None values are coerced to float.
+
+    Returns:
+        A ``DataFrame`` indexed by date (ascending) with columns
+        ``open/high/low/close/volume``.
+
+    Raises:
+        NoMarketDataError: If ``records`` is empty.  We never return a
+            fabricated or empty-but-valid frame for a missing symbol.
+    """
+    if not records:
+        raise NoMarketDataError(
+            "No price history records available to build an OHLCV DataFrame"
+        )
+
+    rows = []
+    index = []
+    for record in records:
+        index.append(_to_naive_timestamp(record.date))
+        rows.append(
+            {
+                "open": float(record.open),
+                "high": float(record.high),
+                "low": float(record.low),
+                "close": float(record.close),
+                "volume": float(record.volume),
+            }
+        )
+
+    frame = pd.DataFrame(rows, index=pd.DatetimeIndex(index), columns=OHLCV_COLUMNS)
+    # Repository returns chronological order, but sort defensively so the
+    # backtester's ``data[data.index <= date]`` slicing is always correct.
+    frame = frame.sort_index()
+    return frame
+
+
+class PriceHistoryDataProvider:
+    """Backtest data provider backed by :class:`PriceHistoryRepository`.
+
+    The backtest engine calls :meth:`get_historical_prices` for each symbol in
+    the universe and :meth:`get_historical_prices` again for the benchmark
+    symbol.  Both go through the repository; no abstraction layer is added.
+
+    Args:
+        repository: A ``PriceHistoryRepository`` (or compatible object exposing
+            ``get_bulk_price_history``).  If ``None``, the module-level
+            ``price_repository`` singleton is imported lazily so that importing
+            this module never pulls SQLAlchemy into light-weight test
+            processes.
+        limit_per_symbol: Max rows fetched per symbol (passed through to the
+            repository).  Large enough to cover typical backtest windows.
+    """
+
+    def __init__(
+        self,
+        repository: Optional[Any] = None,
+        *,
+        limit_per_symbol: int = 5000,
+    ) -> None:
+        self._repository = repository
+        self._limit_per_symbol = limit_per_symbol
+
+    @property
+    def repository(self) -> Any:
+        """Return the repository, importing the default singleton lazily."""
+        if self._repository is None:
+            # Lazy import keeps this module import-light for hermetic tests.
+            from backend.repositories.price_repository import price_repository
+
+            self._repository = price_repository
+        return self._repository
+
+    def _normalize_dates(
+        self,
+        start_date: Optional[Any],
+        end_date: Optional[Any],
+    ) -> tuple[Optional[date], Optional[date]]:
+        """Coerce datetime/Timestamp bounds to plain ``date`` for the repo."""
+        def _as_date(value: Optional[Any]) -> Optional[date]:
+            if value is None:
+                return None
+            if isinstance(value, datetime):
+                return value.date()
+            if isinstance(value, pd.Timestamp):
+                return value.to_pydatetime().date()
+            if isinstance(value, date):
+                return value
+            return pd.Timestamp(value).to_pydatetime().date()
+
+        return _as_date(start_date), _as_date(end_date)
+
+    async def _fetch_bulk(
+        self,
+        symbols: List[str],
+        start_date: Optional[date],
+        end_date: Optional[date],
+    ) -> Dict[str, List[Any]]:
+        return await self.repository.get_bulk_price_history(
+            symbols,
+            start_date=start_date,
+            end_date=end_date,
+            limit_per_symbol=self._limit_per_symbol,
+        )
+
+    def _run_bulk(
+        self,
+        symbols: List[str],
+        start_date: Optional[date],
+        end_date: Optional[date],
+    ) -> Dict[str, List[Any]]:
+        """Run the async bulk fetch from a synchronous context.
+
+        The backtest engine is synchronous; ``asyncio.run`` bridges to the
+        async repository.  If an event loop is already running (e.g. inside an
+        async API handler) the caller should pre-fetch instead -- we raise a
+        clear error rather than corrupting the loop.
+        """
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return asyncio.run(self._fetch_bulk(symbols, start_date, end_date))
+        raise RuntimeError(
+            "PriceHistoryDataProvider cannot fetch synchronously while an event "
+            "loop is running; fetch market data before invoking the backtest."
+        )
+
+    def get_bulk_historical_prices(
+        self,
+        symbols: List[str],
+        start_date: Optional[Any] = None,
+        end_date: Optional[Any] = None,
+    ) -> Dict[str, pd.DataFrame]:
+        """Fetch OHLCV DataFrames for several symbols in one repository call.
+
+        Raises:
+            NoMarketDataError: If any requested symbol has no price history.
+        """
+        if not symbols:
+            return {}
+
+        start, end = self._normalize_dates(start_date, end_date)
+        bulk = self._run_bulk([s.upper() for s in symbols], start, end)
+
+        frames: Dict[str, pd.DataFrame] = {}
+        missing: List[str] = []
+        for symbol in symbols:
+            records = bulk.get(symbol.upper()) or []
+            if not records:
+                missing.append(symbol)
+                continue
+            frames[symbol] = price_history_to_dataframe(records)
+
+        if missing:
+            raise NoMarketDataError(
+                f"No price history found for symbol(s): {', '.join(sorted(missing))}"
+            )
+        return frames
+
+    def get_historical_prices(
+        self,
+        symbol: str,
+        start_date: Optional[Any] = None,
+        end_date: Optional[Any] = None,
+    ) -> pd.DataFrame:
+        """Fetch an OHLCV DataFrame for a single symbol.
+
+        Args:
+            symbol: Stock ticker symbol.
+            start_date: Inclusive start bound (date/datetime/Timestamp).
+            end_date: Inclusive end bound.
+
+        Returns:
+            OHLCV ``DataFrame`` indexed by date.
+
+        Raises:
+            NoMarketDataError: If the symbol has no price history (fail-loud).
+        """
+        return self.get_bulk_historical_prices([symbol], start_date, end_date)[symbol]

--- a/backend/tests/unit/test_backtest_data_provider.py
+++ b/backend/tests/unit/test_backtest_data_provider.py
@@ -1,0 +1,147 @@
+"""
+Unit tests for backend/ml/data_providers.py (#208 item 1).
+
+Uses the importlib file-loading bypass (matching test_ml_extended_agent1.py)
+so the data provider can be exercised source-level without pulling SQLAlchemy
+or the rest of the backend package graph into the test process.
+
+Run (source-level, no conftest):
+    ENVIRONMENT=test ... python3 -m pytest \
+        backend/tests/unit/test_backtest_data_provider.py --noconftest -q
+"""
+
+import importlib.util
+import sys
+from datetime import date, datetime
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pandas as pd
+import pytest
+
+# ---------------------------------------------------------------------------
+# Load backend/ml/data_providers.py directly by file path. This avoids
+# importing backend.ml (and its SQLAlchemy-heavy siblings) as a package.
+# ---------------------------------------------------------------------------
+_ML_DIR = Path(__file__).resolve().parents[2] / "ml"
+
+
+def _load(mod_name: str, filename: str):
+    spec = importlib.util.spec_from_file_location(mod_name, _ML_DIR / filename)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[mod_name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_dp_mod = _load("data_providers_mod", "data_providers.py")
+
+PriceHistoryDataProvider = _dp_mod.PriceHistoryDataProvider
+NoMarketDataError = _dp_mod.NoMarketDataError
+price_history_to_dataframe = _dp_mod.price_history_to_dataframe
+OHLCV_COLUMNS = _dp_mod.OHLCV_COLUMNS
+
+
+def _fake_price_row(d: date, o, h, l, c, v):
+    """Mimic a PriceHistory ORM row (Decimal-ish values accepted as floats)."""
+    return SimpleNamespace(date=d, open=o, high=h, low=l, close=c, volume=v)
+
+
+class _FakeRepo:
+    """Stand-in for PriceHistoryRepository.get_bulk_price_history."""
+
+    def __init__(self, data):
+        # data: Dict[symbol_upper, List[row]]
+        self._data = data
+        self.get_bulk_price_history = AsyncMock(side_effect=self._bulk)
+
+    async def _bulk(self, symbols, start_date=None, end_date=None, limit_per_symbol=5000):
+        return {s.upper(): self._data.get(s.upper(), []) for s in symbols}
+
+
+# ---------------------------------------------------------------------------
+# DataFrame-shape test: correct columns/index from a fake List[PriceHistory].
+# ---------------------------------------------------------------------------
+def test_dataframe_shape_from_price_history():
+    rows = [
+        _fake_price_row(date(2024, 1, 3), 11, 13, 10, 12, 1000),
+        _fake_price_row(date(2024, 1, 2), 10, 12, 9, 11, 900),
+        _fake_price_row(date(2024, 1, 4), 12, 14, 11, 13, 1100),
+    ]
+    repo = _FakeRepo({"AAPL": rows})
+    provider = PriceHistoryDataProvider(repository=repo)
+
+    frame = provider.get_historical_prices("AAPL", date(2024, 1, 1), date(2024, 1, 31))
+
+    # Columns are exactly OHLCV, in order.
+    assert list(frame.columns) == OHLCV_COLUMNS == ["open", "high", "low", "close", "volume"]
+    # Index is a DatetimeIndex, sorted ascending regardless of input order.
+    assert isinstance(frame.index, pd.DatetimeIndex)
+    assert list(frame.index) == sorted(frame.index)
+    assert len(frame) == 3
+    # Values coerced to float and mapped correctly (chronological first row).
+    assert frame.iloc[0]["close"] == 11.0
+    assert frame.iloc[-1]["high"] == 14.0
+    assert frame["volume"].dtype == float
+
+    # repository was queried with date objects (datetime coerced to date).
+    _, kwargs = repo.get_bulk_price_history.call_args
+    assert kwargs["start_date"] == date(2024, 1, 1)
+    assert kwargs["end_date"] == date(2024, 1, 31)
+
+
+def test_datetime_bounds_are_coerced_to_date():
+    repo = _FakeRepo({"MSFT": [_fake_price_row(date(2024, 2, 1), 1, 2, 0.5, 1.5, 10)]})
+    provider = PriceHistoryDataProvider(repository=repo)
+
+    provider.get_historical_prices(
+        "MSFT", datetime(2024, 1, 1, 9, 30), datetime(2024, 3, 1, 16, 0)
+    )
+
+    _, kwargs = repo.get_bulk_price_history.call_args
+    assert kwargs["start_date"] == date(2024, 1, 1)
+    assert kwargs["end_date"] == date(2024, 3, 1)
+
+
+# ---------------------------------------------------------------------------
+# Empty-symbol test: no data -> fail-loud, no fabrication.
+# ---------------------------------------------------------------------------
+def test_empty_symbol_raises_no_market_data():
+    repo = _FakeRepo({})  # no symbols have data
+    provider = PriceHistoryDataProvider(repository=repo)
+
+    with pytest.raises(NoMarketDataError) as exc:
+        provider.get_historical_prices("NOPE", date(2024, 1, 1), date(2024, 1, 31))
+
+    assert "NOPE" in str(exc.value)
+
+
+def test_bulk_fails_loud_when_any_symbol_missing():
+    repo = _FakeRepo({"AAPL": [_fake_price_row(date(2024, 1, 2), 10, 12, 9, 11, 900)]})
+    provider = PriceHistoryDataProvider(repository=repo)
+
+    # AAPL has data but TSLA does not -> still fail loud, no partial fabrication.
+    with pytest.raises(NoMarketDataError) as exc:
+        provider.get_bulk_historical_prices(["AAPL", "TSLA"], date(2024, 1, 1), date(2024, 1, 31))
+
+    assert "TSLA" in str(exc.value)
+
+
+def test_price_history_to_dataframe_rejects_empty():
+    with pytest.raises(NoMarketDataError):
+        price_history_to_dataframe([])
+
+
+def test_no_fabrication_returns_only_real_rows():
+    rows = [
+        _fake_price_row(date(2024, 1, 2), 10, 12, 9, 11, 900),
+        _fake_price_row(date(2024, 1, 3), 11, 13, 10, 12, 1000),
+    ]
+    repo = _FakeRepo({"AAPL": rows})
+    provider = PriceHistoryDataProvider(repository=repo)
+
+    frame = provider.get_historical_prices("AAPL")
+
+    # Exactly the rows the repo returned -- nothing synthesised to fill gaps.
+    assert len(frame) == 2


### PR DESCRIPTION
## Summary

Implements plan item **B6**: a pandas adapter over the existing price-history repository, wired as the backtest `data_provider`. Resolves the **backtest half of #208 item 1**.

Previously `BacktestEngine._get_market_data` / `_get_benchmark_data` fabricated OHLCV data via `np.random.normal`. This PR replaces that for the production backtest path with real history sourced from `PriceHistoryRepository`.

## What changed

- **`backend/ml/data_providers.py`** (new): `PriceHistoryDataProvider` adapts `PriceHistoryRepository.get_bulk_price_history` into the OHLCV `DataFrame` shape the backtester consumes (indexed by date; columns `open/high/low/close/volume`). Exposes `get_historical_prices(symbol, start, end)` and a bulk variant. The async repo is bridged to the synchronous engine via `asyncio.run` (with a clear error if a loop is already running, so callers pre-fetch instead).
- **`backend/ml/backtesting.py`**: `get_backtest_engine()` now wires `PriceHistoryDataProvider` by default. `_get_market_data` / `_get_benchmark_data` use the provider when present and fall back to the legacy synthetic path **only** when no provider is configured.

## Reuse-the-repo decision (no new abstraction)

Per the plan, this **does not** introduce a new `MarketDataProvider` interface. It reuses the existing `PriceHistoryRepository` directly. The DDD seam already exists as `backend.domain.contracts.MarketDataContract`; a future refactor can route the provider through that contract, but B6 deliberately keeps the path concrete.

## Fail-loud preservation

The data path never synthesises prices. A missing symbol raises `NoMarketDataError` (at both `price_history_to_dataframe` and the engine `_get_market_data` boundary) rather than fabricating or returning an empty-but-valid frame. The legacy synthetic fallback is retained **only** for bare `BacktestEngine()` (no provider) to preserve backward compatibility with existing tests.

## Tests

`backend/tests/unit/test_backtest_data_provider.py` (source-level, importlib bypass, `--noconftest`):
- DataFrame-shape test: correct columns/index (sorted ascending) from a fake `List[PriceHistory]`, float coercion, date-bound coercion.
- Empty-symbol fail-loud test: no data raises `NoMarketDataError`, no fabrication; bulk fails loud if *any* symbol is missing.

All 6 new tests pass. The existing 34 backtest tests in `test_ml_extended_agent1.py` still pass (2 unrelated `TestFeatureStore` failures are pre-existing on `main`). Differential ruff: identical code profile vs `origin/main` for `backtesting.py`; new files are ruff-clean.

## Follow-ups (out of scope for B6)

- `feature_data` tensor wiring into the strategy/model call path.
- Per-fold model `.fit()` retraining for walk-forward — model classes still raise `NotImplementedError` to prevent data leakage; intentionally not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)