### PR TITLE
fix(security): C2-prep — scanner truth (F8-08-003/004) + U2 rotation-window runbook

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -122,15 +122,21 @@ description = "Allowlisted files"
 # creds (scripts/testing/test_all_passwords.py, scope 17) and
 # credential-bearing docs (F-08-009) live. Genuine fixtures should use
 # narrow path-specific allowlist entries instead.
-files = [
+#
+# NOTE: gitleaks v8's path allowlist key is `paths` — the former separate
+# `files` list was a v7-ism that v8 silently ignored, so everything in it
+# was never actually allowlisted. All file patterns live in `paths` now.
+paths = [
     '''(.*?)(jpg|gif|doc|pdf|bin|svg|socket)$''',
-    '''^\.env\.example$''',
-    '''^\.env\.template$''',
+    '''(^|/)\.env\.example$''',
+    '''(^|/)\.env\.template$''',
     '''package-lock\.json$''',
     '''yarn\.lock$''',
-]
-
-paths = [
+    # detect-secrets ledger: stores SHA1 hashes of secrets, never plaintext —
+    # scanning it yields hundreds of generic-api-key false positives.
+    # (^|/) so the match survives both git mode (relative paths) and
+    # --no-git mode (absolute paths).
+    '''(^|/)\.secrets\.baseline$''',
     '''node_modules/''',
     '''\.git/''',
     '''htmlcov/''',

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -2,6 +2,14 @@
 
 title = "Investment Analysis App Secret Detection"
 
+# F8-08-003: extend the default ruleset instead of replacing it. Without
+# this block, gitleaks v8 runs ONLY the custom rules below — no
+# generic-api-key, high-entropy or private-key detection at all, which is
+# the mechanical reason the 2026-08 audit's hand-found credentials were
+# never flagged by CI.
+[extend]
+useDefault = true
+
 # Custom rules for financial data APIs and services
 [[rules]]
 id = "alpha-vantage-api-key"
@@ -25,6 +33,32 @@ secretGroup = 2
 id = "news-api-key"
 description = "NewsAPI Key"
 regex = '''(?i)(news[_-]?api[_-]?key|newsapi[_-]?key)['"\s]*[:=]\s*['"]?([a-f0-9]{32})['"]?'''
+secretGroup = 2
+
+# F8-08-003: the four leaked vendor keys (F8-16-001) that previously had
+# no matching rule.
+[[rules]]
+id = "fmp-api-key"
+description = "Financial Modeling Prep API Key"
+regex = '''(?i)(fmp[_-]?api[_-]?key)['"\s]*[:=]\s*['"]?([A-Za-z0-9]{20,64})['"]?'''
+secretGroup = 2
+
+[[rules]]
+id = "marketaux-api-key"
+description = "Marketaux API Key"
+regex = '''(?i)(marketaux[_-]?api[_-]?key)['"\s]*[:=]\s*['"]?([A-Za-z0-9]{16,64})['"]?'''
+secretGroup = 2
+
+[[rules]]
+id = "fred-api-key"
+description = "FRED API Key"
+regex = '''(?i)(fred[_-]?api[_-]?key)['"\s]*[:=]\s*['"]?([a-f0-9]{16,64})['"]?'''
+secretGroup = 2
+
+[[rules]]
+id = "openweather-api-key"
+description = "OpenWeather API Key"
+regex = '''(?i)(openweather[_-]?(?:map[_-]?)?api[_-]?key)['"\s]*[:=]\s*['"]?([a-f0-9]{16,64})['"]?'''
 secretGroup = 2
 
 [[rules]]
@@ -83,13 +117,15 @@ secretGroup = 2
 # File path allowlists (files to ignore)
 [allowlist]
 description = "Allowlisted files"
+# F8-08-003: the blanket test-file and markdown allowlist entries are
+# gone — they suppressed scanning of exactly the files where real service
+# creds (scripts/testing/test_all_passwords.py, scope 17) and
+# credential-bearing docs (F-08-009) live. Genuine fixtures should use
+# narrow path-specific allowlist entries instead.
 files = [
     '''(.*?)(jpg|gif|doc|pdf|bin|svg|socket)$''',
     '''^\.env\.example$''',
     '''^\.env\.template$''',
-    '''.*test.*\.py$''',
-    '''.*_test\.py$''',
-    '''.*\.md$''',
     '''package-lock\.json$''',
     '''yarn\.lock$''',
 ]

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,5 +1,5 @@
 {
-  "version": "1.5.0",
+  "version": "1.4.0",
   "plugins_used": [
     {
       "name": "ArtifactoryDetector"
@@ -27,9 +27,6 @@
       "name": "GitHubTokenDetector"
     },
     {
-      "name": "GitLabTokenDetector"
-    },
-    {
       "name": "HexHighEntropyString",
       "limit": 3.0
     },
@@ -38,9 +35,6 @@
     },
     {
       "name": "IbmCosHmacDetector"
-    },
-    {
-      "name": "IPPublicDetector"
     },
     {
       "name": "JwtTokenDetector"
@@ -56,13 +50,7 @@
       "name": "NpmDetector"
     },
     {
-      "name": "OpenAIDetector"
-    },
-    {
       "name": "PrivateKeyDetector"
-    },
-    {
-      "name": "PypiTokenDetector"
     },
     {
       "name": "SendGridDetector"
@@ -78,9 +66,6 @@
     },
     {
       "name": "StripeDetector"
-    },
-    {
-      "name": "TelegramBotTokenDetector"
     },
     {
       "name": "TwilioKeyDetector"
@@ -120,2654 +105,25 @@
     },
     {
       "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    },
+    {
+      "path": "detect_secrets.filters.regex.should_exclude_file",
+      "pattern": [
+        "^(datasets|\\.claude|\\.git)/",
+        "package-lock\\.json$",
+        "^\\.secrets\\.baseline$"
+      ]
     }
   ],
   "results": {
-    ".claude/agents/agentic-payments.md": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/agents/agentic-payments.md",
-        "hashed_secret": "cde9f5e8ae64a96edaed0e424d51babac3b1f7a3",
-        "is_verified": false,
-        "line_number": 35
-      }
-    ],
-    ".claude/agents/app-store.md": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/agents/app-store.md",
-        "hashed_secret": "a62f2225bf70bfaccbc7f1ef2a397836717377de",
-        "is_verified": false,
-        "line_number": 42
-      }
-    ],
-    ".claude/agents/authentication.md": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/agents/authentication.md",
-        "hashed_secret": "a616a64c0fbc30f12287d0f24f3b90dd2e6a206e",
-        "is_verified": false,
-        "line_number": 22
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/agents/authentication.md",
-        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
-        "is_verified": false,
-        "line_number": 29
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/agents/authentication.md",
-        "hashed_secret": "f054ffc85b4c1615a7190ea0b248564bb1e9f9ab",
-        "is_verified": false,
-        "line_number": 43
-      }
-    ],
-    ".claude/agents/code-reviewer.md": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/agents/code-reviewer.md",
-        "hashed_secret": "cba7d8d926ee837cf3f92636a6d1cd0eb397db64",
-        "is_verified": false,
-        "line_number": 84
-      }
-    ],
-    ".claude/agents/flow-nexus/app-store.md": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/agents/flow-nexus/app-store.md",
-        "hashed_secret": "a62f2225bf70bfaccbc7f1ef2a397836717377de",
-        "is_verified": false,
-        "line_number": 42
-      }
-    ],
-    ".claude/agents/flow-nexus/authentication.md": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/agents/flow-nexus/authentication.md",
-        "hashed_secret": "a616a64c0fbc30f12287d0f24f3b90dd2e6a206e",
-        "is_verified": false,
-        "line_number": 22
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/agents/flow-nexus/authentication.md",
-        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
-        "is_verified": false,
-        "line_number": 29
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/agents/flow-nexus/authentication.md",
-        "hashed_secret": "f054ffc85b4c1615a7190ea0b248564bb1e9f9ab",
-        "is_verified": false,
-        "line_number": 43
-      }
-    ],
-    ".claude/agents/flow-nexus/sandbox.md": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/agents/flow-nexus/sandbox.md",
-        "hashed_secret": "a62f2225bf70bfaccbc7f1ef2a397836717377de",
-        "is_verified": false,
-        "line_number": 24
-      }
-    ],
-    ".claude/agents/github-swarm/pr-reviewer.md": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/agents/github-swarm/pr-reviewer.md",
-        "hashed_secret": "a200967def1296094f1d05e89956b22e6542f561",
-        "is_verified": false,
-        "line_number": 227
-      }
-    ],
-    ".claude/agents/github-swarm/security-agent.md": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/agents/github-swarm/security-agent.md",
-        "hashed_secret": "e65787355492d27594a2b5cc6cf4d20d4d3b75d7",
-        "is_verified": false,
-        "line_number": 337
-      }
-    ],
-    ".claude/agents/payments/agentic-payments.md": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/agents/payments/agentic-payments.md",
-        "hashed_secret": "cde9f5e8ae64a96edaed0e424d51babac3b1f7a3",
-        "is_verified": false,
-        "line_number": 35
-      }
-    ],
-    ".claude/agents/production-validator.md": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/agents/production-validator.md",
-        "hashed_secret": "c5b62ea9ada21743c6f353e4a45bc8648b377006",
-        "is_verified": false,
-        "line_number": 144
-      }
-    ],
-    ".claude/agents/refinement.md": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/agents/refinement.md",
-        "hashed_secret": "72559b51f94a7a3ad058c5740cbe2f7cb0d4080b",
-        "is_verified": false,
-        "line_number": 62
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/agents/refinement.md",
-        "hashed_secret": "9da133c45f71d2bb9d5eb7cfa6fce7cdb6a215b5",
-        "is_verified": false,
-        "line_number": 90
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/agents/refinement.md",
-        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
-        "is_verified": false,
-        "line_number": 266
-      }
-    ],
-    ".claude/agents/sandbox.md": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/agents/sandbox.md",
-        "hashed_secret": "a62f2225bf70bfaccbc7f1ef2a397836717377de",
-        "is_verified": false,
-        "line_number": 24
-      }
-    ],
-    ".claude/agents/security-agent.md": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/agents/security-agent.md",
-        "hashed_secret": "e65787355492d27594a2b5cc6cf4d20d4d3b75d7",
-        "is_verified": false,
-        "line_number": 149
-      }
-    ],
-    ".claude/agents/security-reviewer.md": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/agents/security-reviewer.md",
-        "hashed_secret": "36cc070f10e2d5e10a30051412cbfca26665ca26",
-        "is_verified": false,
-        "line_number": 188
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/agents/security-reviewer.md",
-        "hashed_secret": "f865b53623b121fd34ee5426c792e5c33af8c227",
-        "is_verified": false,
-        "line_number": 189
-      }
-    ],
-    ".claude/agents/sparc/refinement.md": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/agents/sparc/refinement.md",
-        "hashed_secret": "72559b51f94a7a3ad058c5740cbe2f7cb0d4080b",
-        "is_verified": false,
-        "line_number": 62
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/agents/sparc/refinement.md",
-        "hashed_secret": "9da133c45f71d2bb9d5eb7cfa6fce7cdb6a215b5",
-        "is_verified": false,
-        "line_number": 90
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/agents/sparc/refinement.md",
-        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
-        "is_verified": false,
-        "line_number": 266
-      }
-    ],
-    ".claude/agents/tdd-london-swarm.md": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/agents/tdd-london-swarm.md",
-        "hashed_secret": "ecb252044b5ea0f679ee78ec1a12904739e2904d",
-        "is_verified": false,
-        "line_number": 115
-      }
-    ],
-    ".claude/agents/testing/production-validator.md": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/agents/testing/production-validator.md",
-        "hashed_secret": "c5b62ea9ada21743c6f353e4a45bc8648b377006",
-        "is_verified": false,
-        "line_number": 144
-      }
-    ],
-    ".claude/agents/testing/tdd-london-swarm.md": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/agents/testing/tdd-london-swarm.md",
-        "hashed_secret": "ecb252044b5ea0f679ee78ec1a12904739e2904d",
-        "is_verified": false,
-        "line_number": 115
-      }
-    ],
-    ".claude/agents/testing/unit/tdd-london-swarm.md": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/agents/testing/unit/tdd-london-swarm.md",
-        "hashed_secret": "ecb252044b5ea0f679ee78ec1a12904739e2904d",
-        "is_verified": false,
-        "line_number": 115
-      }
-    ],
-    ".claude/agents/testing/validation/production-validator.md": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/agents/testing/validation/production-validator.md",
-        "hashed_secret": "c5b62ea9ada21743c6f353e4a45bc8648b377006",
-        "is_verified": false,
-        "line_number": 144
-      }
-    ],
-    ".claude/agents/unit/tdd-london-swarm.md": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/agents/unit/tdd-london-swarm.md",
-        "hashed_secret": "ecb252044b5ea0f679ee78ec1a12904739e2904d",
-        "is_verified": false,
-        "line_number": 115
-      }
-    ],
-    ".claude/agents/validation/production-validator.md": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/agents/validation/production-validator.md",
-        "hashed_secret": "c5b62ea9ada21743c6f353e4a45bc8648b377006",
-        "is_verified": false,
-        "line_number": 144
-      }
-    ],
-    ".claude/commands/app-store.md": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/commands/app-store.md",
-        "hashed_secret": "9ad19750930e5cf133e024641c00daf5fc90c700",
-        "is_verified": false,
-        "line_number": 60
-      }
-    ],
-    ".claude/commands/login-registration.md": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/commands/login-registration.md",
-        "hashed_secret": "a616a64c0fbc30f12287d0f24f3b90dd2e6a206e",
-        "is_verified": false,
-        "line_number": 14
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/commands/login-registration.md",
-        "hashed_secret": "564e340cd48437d2dfe876ee154cc99dc4d0d137",
-        "is_verified": false,
-        "line_number": 23
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/commands/login-registration.md",
-        "hashed_secret": "52dcc83ec1e54426ad58a64854d1eb8d5f5d9685",
-        "is_verified": false,
-        "line_number": 45
-      }
-    ],
-    ".claude/commands/sandbox.md": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/commands/sandbox.md",
-        "hashed_secret": "89a6cfe2a229151e8055abee107d45ed087bbb4f",
-        "is_verified": false,
-        "line_number": 16
-      }
-    ],
-    ".claude/mcp-configs/mcp-servers.json": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/mcp-configs/mcp-servers.json",
-        "hashed_secret": "22b3ad9b3e99095e9b1d59cd65748c2941936aed",
-        "is_verified": false,
-        "line_number": 15
-      }
-    ],
-    ".claude/mcp/mcp-servers.json": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/mcp/mcp-servers.json",
-        "hashed_secret": "22b3ad9b3e99095e9b1d59cd65748c2941936aed",
-        "is_verified": false,
-        "line_number": 15
-      }
-    ],
-    ".claude/rules/security.md": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/rules/security.md",
-        "hashed_secret": "36cc070f10e2d5e10a30051412cbfca26665ca26",
-        "is_verified": false,
-        "line_number": 19
-      }
-    ],
-    ".claude/skills/1password/references/cli-examples.md": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/skills/1password/references/cli-examples.md",
-        "hashed_secret": "9dda0987cc3054773a2df97e352d4f64d233ef10",
-        "is_verified": false,
-        "line_number": 17
-      }
-    ],
-    ".claude/skills/local-places/SERVER_README.md": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/skills/local-places/SERVER_README.md",
-        "hashed_secret": "6d9c68c603e465077bdd49c62347fe54717f83a3",
-        "is_verified": false,
-        "line_number": 28
-      }
-    ],
-    ".claude/skills/openai-whisper-api/SKILL.md": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/skills/openai-whisper-api/SKILL.md",
-        "hashed_secret": "1077361f94d70e1ddcc7c6dc581a489532a81d03",
-        "is_verified": false,
-        "line_number": 39
-      }
-    ],
-    ".claude/skills/security-review/SKILL.md": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/skills/security-review/SKILL.md",
-        "hashed_secret": "36cc070f10e2d5e10a30051412cbfca26665ca26",
-        "is_verified": false,
-        "line_number": 26
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/skills/security-review/SKILL.md",
-        "hashed_secret": "cbfdac6008f9cab4083784cbd1874f76618d2a97",
-        "is_verified": false,
-        "line_number": 27
-      }
-    ],
-    ".claude/skills/trello/SKILL.md": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/skills/trello/SKILL.md",
-        "hashed_secret": "11fa7c37d697f30e6aee828b4426a10f83ab2380",
-        "is_verified": false,
-        "line_number": 18
-      }
-    ],
-    ".claude/v3/@claude-flow/aidefence/README.md": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/v3/@claude-flow/aidefence/README.md",
-        "hashed_secret": "f2b14f68eb995facb3a1c35287b778d5bd785511",
-        "is_verified": false,
-        "line_number": 337
-      }
-    ],
-    ".claude/v3/@claude-flow/browser/README.md": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/v3/@claude-flow/browser/README.md",
-        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
-        "is_verified": false,
-        "line_number": 279
-      }
-    ],
-    ".claude/v3/@claude-flow/browser/tests/workflow-templates.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/v3/@claude-flow/browser/tests/workflow-templates.test.ts",
-        "hashed_secret": "206c80413b9a96c1312cc346b7d2517b84463edd",
-        "is_verified": false,
-        "line_number": 100
-      }
-    ],
-    ".claude/v3/@claude-flow/cli/.claude/agents/flow-nexus/app-store.md": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/v3/@claude-flow/cli/.claude/agents/flow-nexus/app-store.md",
-        "hashed_secret": "a62f2225bf70bfaccbc7f1ef2a397836717377de",
-        "is_verified": false,
-        "line_number": 42
-      }
-    ],
-    ".claude/v3/@claude-flow/cli/.claude/agents/flow-nexus/authentication.md": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/v3/@claude-flow/cli/.claude/agents/flow-nexus/authentication.md",
-        "hashed_secret": "a616a64c0fbc30f12287d0f24f3b90dd2e6a206e",
-        "is_verified": false,
-        "line_number": 22
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/v3/@claude-flow/cli/.claude/agents/flow-nexus/authentication.md",
-        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
-        "is_verified": false,
-        "line_number": 29
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/v3/@claude-flow/cli/.claude/agents/flow-nexus/authentication.md",
-        "hashed_secret": "f054ffc85b4c1615a7190ea0b248564bb1e9f9ab",
-        "is_verified": false,
-        "line_number": 43
-      }
-    ],
-    ".claude/v3/@claude-flow/cli/.claude/agents/flow-nexus/sandbox.md": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/v3/@claude-flow/cli/.claude/agents/flow-nexus/sandbox.md",
-        "hashed_secret": "a62f2225bf70bfaccbc7f1ef2a397836717377de",
-        "is_verified": false,
-        "line_number": 24
-      }
-    ],
-    ".claude/v3/@claude-flow/cli/.claude/agents/payments/agentic-payments.md": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/v3/@claude-flow/cli/.claude/agents/payments/agentic-payments.md",
-        "hashed_secret": "cde9f5e8ae64a96edaed0e424d51babac3b1f7a3",
-        "is_verified": false,
-        "line_number": 35
-      }
-    ],
-    ".claude/v3/@claude-flow/cli/.claude/agents/sparc/refinement.md": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/v3/@claude-flow/cli/.claude/agents/sparc/refinement.md",
-        "hashed_secret": "72559b51f94a7a3ad058c5740cbe2f7cb0d4080b",
-        "is_verified": false,
-        "line_number": 339
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/v3/@claude-flow/cli/.claude/agents/sparc/refinement.md",
-        "hashed_secret": "9da133c45f71d2bb9d5eb7cfa6fce7cdb6a215b5",
-        "is_verified": false,
-        "line_number": 367
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/v3/@claude-flow/cli/.claude/agents/sparc/refinement.md",
-        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
-        "is_verified": false,
-        "line_number": 543
-      }
-    ],
-    ".claude/v3/@claude-flow/cli/.claude/agents/testing/production-validator.md": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/v3/@claude-flow/cli/.claude/agents/testing/production-validator.md",
-        "hashed_secret": "c5b62ea9ada21743c6f353e4a45bc8648b377006",
-        "is_verified": false,
-        "line_number": 144
-      }
-    ],
-    ".claude/v3/@claude-flow/cli/.claude/agents/testing/tdd-london-swarm.md": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/v3/@claude-flow/cli/.claude/agents/testing/tdd-london-swarm.md",
-        "hashed_secret": "ecb252044b5ea0f679ee78ec1a12904739e2904d",
-        "is_verified": false,
-        "line_number": 115
-      }
-    ],
-    ".claude/v3/@claude-flow/cli/.claude/agents/v3/security-auditor.md": [
-      {
-        "type": "Private Key",
-        "filename": ".claude/v3/@claude-flow/cli/.claude/agents/v3/security-auditor.md",
-        "hashed_secret": "4ada9713ec27066b2ffe0b7bd9c9c8d635dc4ab2",
-        "is_verified": false,
-        "line_number": 405
-      }
-    ],
-    ".claude/v3/@claude-flow/cli/.claude/commands/flow-nexus/app-store.md": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/v3/@claude-flow/cli/.claude/commands/flow-nexus/app-store.md",
-        "hashed_secret": "9ad19750930e5cf133e024641c00daf5fc90c700",
-        "is_verified": false,
-        "line_number": 60
-      }
-    ],
-    ".claude/v3/@claude-flow/cli/.claude/commands/flow-nexus/login-registration.md": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/v3/@claude-flow/cli/.claude/commands/flow-nexus/login-registration.md",
-        "hashed_secret": "a616a64c0fbc30f12287d0f24f3b90dd2e6a206e",
-        "is_verified": false,
-        "line_number": 14
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/v3/@claude-flow/cli/.claude/commands/flow-nexus/login-registration.md",
-        "hashed_secret": "564e340cd48437d2dfe876ee154cc99dc4d0d137",
-        "is_verified": false,
-        "line_number": 23
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/v3/@claude-flow/cli/.claude/commands/flow-nexus/login-registration.md",
-        "hashed_secret": "52dcc83ec1e54426ad58a64854d1eb8d5f5d9685",
-        "is_verified": false,
-        "line_number": 45
-      }
-    ],
-    ".claude/v3/@claude-flow/cli/.claude/commands/flow-nexus/sandbox.md": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/v3/@claude-flow/cli/.claude/commands/flow-nexus/sandbox.md",
-        "hashed_secret": "89a6cfe2a229151e8055abee107d45ed087bbb4f",
-        "is_verified": false,
-        "line_number": 16
-      }
-    ],
-    ".claude/v3/@claude-flow/cli/.claude/skills/flow-nexus-platform/SKILL.md": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/v3/@claude-flow/cli/.claude/skills/flow-nexus-platform/SKILL.md",
-        "hashed_secret": "a616a64c0fbc30f12287d0f24f3b90dd2e6a206e",
-        "is_verified": false,
-        "line_number": 33
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/v3/@claude-flow/cli/.claude/skills/flow-nexus-platform/SKILL.md",
-        "hashed_secret": "564e340cd48437d2dfe876ee154cc99dc4d0d137",
-        "is_verified": false,
-        "line_number": 43
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/v3/@claude-flow/cli/.claude/skills/flow-nexus-platform/SKILL.md",
-        "hashed_secret": "52dcc83ec1e54426ad58a64854d1eb8d5f5d9685",
-        "is_verified": false,
-        "line_number": 70
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/v3/@claude-flow/cli/.claude/skills/flow-nexus-platform/SKILL.md",
-        "hashed_secret": "89a6cfe2a229151e8055abee107d45ed087bbb4f",
-        "is_verified": false,
-        "line_number": 130
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/v3/@claude-flow/cli/.claude/skills/flow-nexus-platform/SKILL.md",
-        "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
-        "is_verified": false,
-        "line_number": 290
-      },
-      {
-        "type": "Basic Auth Credentials",
-        "filename": ".claude/v3/@claude-flow/cli/.claude/skills/flow-nexus-platform/SKILL.md",
-        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
-        "is_verified": false,
-        "line_number": 388
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/v3/@claude-flow/cli/.claude/skills/flow-nexus-platform/SKILL.md",
-        "hashed_secret": "72559b51f94a7a3ad058c5740cbe2f7cb0d4080b",
-        "is_verified": false,
-        "line_number": 875
-      }
-    ],
-    ".claude/v3/@claude-flow/cli/README.md": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/v3/@claude-flow/cli/README.md",
-        "hashed_secret": "c7a8c334eef5d1749fface7d42c66f9ae5e8cf36",
-        "is_verified": false,
-        "line_number": 859
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/v3/@claude-flow/cli/README.md",
-        "hashed_secret": "1e3667aaaaa887721550cf5cc8a0c5c5760810ed",
-        "is_verified": false,
-        "line_number": 1020
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/v3/@claude-flow/cli/README.md",
-        "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
-        "is_verified": false,
-        "line_number": 1428
-      }
-    ],
-    ".claude/v3/@claude-flow/cli/src/commands/neural.ts": [
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/cli/src/commands/neural.ts",
-        "hashed_secret": "47a3d60039bfc6448c154ad1bb5675608aabdbec",
-        "is_verified": false,
-        "line_number": 1173
-      }
-    ],
-    ".claude/v3/@claude-flow/cli/src/plugins/store/discovery.ts": [
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/cli/src/plugins/store/discovery.ts",
-        "hashed_secret": "76e88ee55010f71eca8262bff0d272fe5e25835a",
-        "is_verified": false,
-        "line_number": 57
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/cli/src/plugins/store/discovery.ts",
-        "hashed_secret": "47a3d60039bfc6448c154ad1bb5675608aabdbec",
-        "is_verified": false,
-        "line_number": 64
-      }
-    ],
-    ".claude/v3/@claude-flow/cli/src/transfer/exports/seraphine-genesis.cfp.json": [
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".claude/v3/@claude-flow/cli/src/transfer/exports/seraphine-genesis.cfp.json",
-        "hashed_secret": "0c8f792aa90ad05e8ac58fdb15bc49de36635c3f",
-        "is_verified": false,
-        "line_number": 39
-      }
-    ],
-    ".claude/v3/@claude-flow/cli/src/transfer/ipfs/upload.ts": [
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/cli/src/transfer/ipfs/upload.ts",
-        "hashed_secret": "5831a784a378504a94e06181f1a00c656b39701c",
-        "is_verified": false,
-        "line_number": 64
-      }
-    ],
-    ".claude/v3/@claude-flow/cli/src/transfer/store/discovery.ts": [
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/cli/src/transfer/store/discovery.ts",
-        "hashed_secret": "5831a784a378504a94e06181f1a00c656b39701c",
-        "is_verified": false,
-        "line_number": 231
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/cli/src/transfer/store/discovery.ts",
-        "hashed_secret": "650f08405a979892f2fcd7e7378fa8fd00b60ef7",
-        "is_verified": false,
-        "line_number": 322
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".claude/v3/@claude-flow/cli/src/transfer/store/discovery.ts",
-        "hashed_secret": "0c8f792aa90ad05e8ac58fdb15bc49de36635c3f",
-        "is_verified": false,
-        "line_number": 334
-      }
-    ],
-    ".claude/v3/@claude-flow/cli/src/transfer/store/registry.ts": [
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/cli/src/transfer/store/registry.ts",
-        "hashed_secret": "650f08405a979892f2fcd7e7378fa8fd00b60ef7",
-        "is_verified": false,
-        "line_number": 28
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/cli/src/transfer/store/registry.ts",
-        "hashed_secret": "bf423b68899b8a427faf48c7a377f11dcd3ffca7",
-        "is_verified": false,
-        "line_number": 36
-      }
-    ],
-    ".claude/v3/@claude-flow/embeddings/README.md": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/v3/@claude-flow/embeddings/README.md",
-        "hashed_secret": "11fa7c37d697f30e6aee828b4426a10f83ab2380",
-        "is_verified": false,
-        "line_number": 100
-      }
-    ],
-    ".claude/v3/@claude-flow/hooks/src/__tests__/guidance-provider.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/v3/@claude-flow/hooks/src/__tests__/guidance-provider.test.ts",
-        "hashed_secret": "59db85718c97565baccfdc97399b359640ad2eff",
-        "is_verified": false,
-        "line_number": 258
-      }
-    ],
-    ".claude/v3/@claude-flow/mcp/.claude/agents/flow-nexus/app-store.md": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/v3/@claude-flow/mcp/.claude/agents/flow-nexus/app-store.md",
-        "hashed_secret": "a62f2225bf70bfaccbc7f1ef2a397836717377de",
-        "is_verified": false,
-        "line_number": 42
-      }
-    ],
-    ".claude/v3/@claude-flow/mcp/.claude/agents/flow-nexus/authentication.md": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/v3/@claude-flow/mcp/.claude/agents/flow-nexus/authentication.md",
-        "hashed_secret": "a616a64c0fbc30f12287d0f24f3b90dd2e6a206e",
-        "is_verified": false,
-        "line_number": 22
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/v3/@claude-flow/mcp/.claude/agents/flow-nexus/authentication.md",
-        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
-        "is_verified": false,
-        "line_number": 29
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/v3/@claude-flow/mcp/.claude/agents/flow-nexus/authentication.md",
-        "hashed_secret": "f054ffc85b4c1615a7190ea0b248564bb1e9f9ab",
-        "is_verified": false,
-        "line_number": 43
-      }
-    ],
-    ".claude/v3/@claude-flow/mcp/.claude/agents/flow-nexus/sandbox.md": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/v3/@claude-flow/mcp/.claude/agents/flow-nexus/sandbox.md",
-        "hashed_secret": "a62f2225bf70bfaccbc7f1ef2a397836717377de",
-        "is_verified": false,
-        "line_number": 24
-      }
-    ],
-    ".claude/v3/@claude-flow/mcp/.claude/agents/payments/agentic-payments.md": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/v3/@claude-flow/mcp/.claude/agents/payments/agentic-payments.md",
-        "hashed_secret": "cde9f5e8ae64a96edaed0e424d51babac3b1f7a3",
-        "is_verified": false,
-        "line_number": 35
-      }
-    ],
-    ".claude/v3/@claude-flow/mcp/.claude/agents/sparc/refinement.md": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/v3/@claude-flow/mcp/.claude/agents/sparc/refinement.md",
-        "hashed_secret": "72559b51f94a7a3ad058c5740cbe2f7cb0d4080b",
-        "is_verified": false,
-        "line_number": 339
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/v3/@claude-flow/mcp/.claude/agents/sparc/refinement.md",
-        "hashed_secret": "9da133c45f71d2bb9d5eb7cfa6fce7cdb6a215b5",
-        "is_verified": false,
-        "line_number": 367
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/v3/@claude-flow/mcp/.claude/agents/sparc/refinement.md",
-        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
-        "is_verified": false,
-        "line_number": 543
-      }
-    ],
-    ".claude/v3/@claude-flow/mcp/.claude/agents/testing/production-validator.md": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/v3/@claude-flow/mcp/.claude/agents/testing/production-validator.md",
-        "hashed_secret": "c5b62ea9ada21743c6f353e4a45bc8648b377006",
-        "is_verified": false,
-        "line_number": 144
-      }
-    ],
-    ".claude/v3/@claude-flow/mcp/.claude/agents/testing/tdd-london-swarm.md": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/v3/@claude-flow/mcp/.claude/agents/testing/tdd-london-swarm.md",
-        "hashed_secret": "ecb252044b5ea0f679ee78ec1a12904739e2904d",
-        "is_verified": false,
-        "line_number": 115
-      }
-    ],
-    ".claude/v3/@claude-flow/mcp/.claude/agents/v3/security-auditor.md": [
-      {
-        "type": "Private Key",
-        "filename": ".claude/v3/@claude-flow/mcp/.claude/agents/v3/security-auditor.md",
-        "hashed_secret": "4ada9713ec27066b2ffe0b7bd9c9c8d635dc4ab2",
-        "is_verified": false,
-        "line_number": 405
-      }
-    ],
-    ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml": [
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "ba92041b8b57e5f3f7cfda01eca4eb5f863d8230",
-        "is_verified": false,
-        "line_number": 38
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "7543ee65aa0a02783414e8a1dbd3d18c0c3123cc",
-        "is_verified": false,
-        "line_number": 47
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "5cab2cbf14962ddc1d6ed2bfe25898fe4c36dec1",
-        "is_verified": false,
-        "line_number": 56
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "b3ffc344491402f73ea16b1b8718e18833050114",
-        "is_verified": false,
-        "line_number": 65
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "06c952d11f13461da10c7bba057d78cc5fa5e6fb",
-        "is_verified": false,
-        "line_number": 74
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "c2ea7b0b8f40b08e1b89209f677ff5d6a719b60a",
-        "is_verified": false,
-        "line_number": 83
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "8816a15bd9ad8879b3f1823b94fb7c46dd643f17",
-        "is_verified": false,
-        "line_number": 92
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "9836b23edc498bf0925d3e560f0684f6ec75bb9a",
-        "is_verified": false,
-        "line_number": 101
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "f42b2f70ce99e343a262e45315a2c4d27daba270",
-        "is_verified": false,
-        "line_number": 110
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "3e9fc60c601cab29ea7878a0c9688fb6ee925cf9",
-        "is_verified": false,
-        "line_number": 119
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "6b1f54e31a53e3667a97cf3af18a66d1cedec7b8",
-        "is_verified": false,
-        "line_number": 128
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "efbe56870cd191d53ef1e6ac6d40ed5eb4cd01c0",
-        "is_verified": false,
-        "line_number": 137
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "fefbbc2958b5d0546d6507d1aad9bead9ef7e9eb",
-        "is_verified": false,
-        "line_number": 146
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "489f7d6ea770d41978c763f306e573aa9c086e3b",
-        "is_verified": false,
-        "line_number": 155
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "84e33cad738a516642e9e4e00c9910ada2755eb8",
-        "is_verified": false,
-        "line_number": 164
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "0329358e1442ae9c1dd0cfa7884c4cc51c123c7d",
-        "is_verified": false,
-        "line_number": 173
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "5520077e071061b96b1bd30a351f2bb3a52cac50",
-        "is_verified": false,
-        "line_number": 182
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "5fd94d7bc55b700838f7232aa04cd14ce8883702",
-        "is_verified": false,
-        "line_number": 191
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "8c94dfd0dbadd0e968f0e9e175bf5bb4fd2594c0",
-        "is_verified": false,
-        "line_number": 200
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "38e7a2d417fe20d4760873aa7ad041fa74821645",
-        "is_verified": false,
-        "line_number": 209
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "2a46cf814514d8cf3a189ce88b22d30c24baf70a",
-        "is_verified": false,
-        "line_number": 218
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "f13e357a26f9e2972019db90dd8ceb867b494f9c",
-        "is_verified": false,
-        "line_number": 227
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "35ecb49473bd3c2a84f86fcae2c69e255bdcd843",
-        "is_verified": false,
-        "line_number": 236
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "fcf9843ee5d7fd1e0381fe3a4bc404adce5086a0",
-        "is_verified": false,
-        "line_number": 245
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "f60c00cacddf514ad090fbde7005d8721adc0b89",
-        "is_verified": false,
-        "line_number": 252
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "aaca8bdb9f898dd7d598ec3b6369e082c34a9981",
-        "is_verified": false,
-        "line_number": 256
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "b15134489f1e9387a47a670768d7da256d1559a4",
-        "is_verified": false,
-        "line_number": 264
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "8d9393dd067a32653cc8047d799f9b0f477ce0d6",
-        "is_verified": false,
-        "line_number": 272
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "4a02c218ca4e1bb772d1975306ecb5f35c86f663",
-        "is_verified": false,
-        "line_number": 280
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "d9789f6b02d3ffac8727cc07f8e44aa83b7a2fd3",
-        "is_verified": false,
-        "line_number": 288
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "30af86c8d7f9ad8fc102ddbd90c515ae9fbf529e",
-        "is_verified": false,
-        "line_number": 296
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "7b56796fc13ec9034a418c49cb590d4ff0e7d0a3",
-        "is_verified": false,
-        "line_number": 304
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "61c870a19442a21a97c28fcb7aa2365f3ce03dd4",
-        "is_verified": false,
-        "line_number": 312
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "1cc5df5dd1f8f8383ab5334c8dc856116294b6d7",
-        "is_verified": false,
-        "line_number": 320
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "33a986a3ac3fa790c6246f834418235142dfb699",
-        "is_verified": false,
-        "line_number": 328
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "56e58f6e42b1569c7b10ea67025c4f01745a5cc4",
-        "is_verified": false,
-        "line_number": 336
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "73137651df7f57f54d5727fdb6bcec93efb2431c",
-        "is_verified": false,
-        "line_number": 344
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "749ff194c11f71fdacdda86e917f5b73173a8404",
-        "is_verified": false,
-        "line_number": 352
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "a1d71ce3d245989418d589d840f94ef94f677ddd",
-        "is_verified": false,
-        "line_number": 360
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "8f92473b65aae0fee5e214e2ae2dc323329bf2d3",
-        "is_verified": false,
-        "line_number": 368
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "5d89564c48a0e7a9e571d15a149909039a2cf135",
-        "is_verified": false,
-        "line_number": 376
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "268246cffc520befb22d26412e6ee97ee1cf5d03",
-        "is_verified": false,
-        "line_number": 384
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "9ba03c5df2d00fdc27033b689d7f00727270f879",
-        "is_verified": false,
-        "line_number": 392
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "ac86f760b4136bd641c43e65749d9504281850da",
-        "is_verified": false,
-        "line_number": 400
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "d79b3be255c1a0905ed8c3887c30f7512986be7d",
-        "is_verified": false,
-        "line_number": 408
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "86c3473a3d32c3fb886a49da84ffaa3d76199c83",
-        "is_verified": false,
-        "line_number": 416
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "dba17cb05f94bc40087ab142b6c2a7734622d430",
-        "is_verified": false,
-        "line_number": 424
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "ec8c23ef33556f3ae1df5761420b48f3d1e97d7d",
-        "is_verified": false,
-        "line_number": 432
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "996931a82048bf3feb29e4797d432b7454e9b60d",
-        "is_verified": false,
-        "line_number": 440
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "b8ccfbbfda5efc8ac92fff40643114f1c5ff296c",
-        "is_verified": false,
-        "line_number": 448
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "bc486c7ee8c6e705c40702113d890eb90f3495b6",
-        "is_verified": false,
-        "line_number": 456
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "f0223109c42a9c75ee9a859c7897c6ab5c6eec49",
-        "is_verified": false,
-        "line_number": 460
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "7fa226273d5a0d1b9abf45e18909943d7007d1b2",
-        "is_verified": false,
-        "line_number": 467
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "41117aa4a8359e48df1c1e69dfb0642434df72be",
-        "is_verified": false,
-        "line_number": 473
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "904dae7e3147870781ad476afdbc281061d76e62",
-        "is_verified": false,
-        "line_number": 479
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "9054286a1dd83cc15f156d6f0fef50c76d72ea30",
-        "is_verified": false,
-        "line_number": 483
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "4dc32a98a7f7c93efa2563c7bbb81e7a80df0a96",
-        "is_verified": false,
-        "line_number": 492
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "7820059c8d2e0898ad244e8da132f1db709cf138",
-        "is_verified": false,
-        "line_number": 501
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "63b336193044808bbd0e235fac5f6aeadb612a52",
-        "is_verified": false,
-        "line_number": 505
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "651889592381f662a4e57b67e2e2f7d99678f325",
-        "is_verified": false,
-        "line_number": 509
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "6fe0c1d94e5bf7af28db976667694b068fbbcfa9",
-        "is_verified": false,
-        "line_number": 515
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "edad7a64109ca056f9c0c36e70e45ff24f5942b9",
-        "is_verified": false,
-        "line_number": 519
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "c8f95ac0a9d418a4b1c63432b5e6eb616005fb66",
-        "is_verified": false,
-        "line_number": 523
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "c713a0abb1cb447922b526b9e5de5d7d614f4792",
-        "is_verified": false,
-        "line_number": 530
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "f568f50d1e6ef9e6cc46beeb0c2a04e907062336",
-        "is_verified": false,
-        "line_number": 536
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "618a8148c9899b3b6bd69562f235038dc7953718",
-        "is_verified": false,
-        "line_number": 544
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "30bb0cc43631518c3933d148af810b71526dae8f",
-        "is_verified": false,
-        "line_number": 550
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "fc49daa773675bc7f0ac5eec81abcc57974b141d",
-        "is_verified": false,
-        "line_number": 558
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "f5eeeaf1d56064347ceb8df61f272de1061ad8b3",
-        "is_verified": false,
-        "line_number": 566
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "48de6d92948329ecff789271d7cb1529c4ce6881",
-        "is_verified": false,
-        "line_number": 574
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "ad1da120fedd362cdd5b46edd0fde09db94be318",
-        "is_verified": false,
-        "line_number": 580
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "89c31fa0d6838019bc29341b448d189aa712045b",
-        "is_verified": false,
-        "line_number": 589
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "370829deda225e5ee4d20ceb29b18c020c457932",
-        "is_verified": false,
-        "line_number": 597
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "30dff6e111c0a18b53cc71da853bac87f73a816c",
-        "is_verified": false,
-        "line_number": 604
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "371ce323d657e273939fdad274085642a4da69de",
-        "is_verified": false,
-        "line_number": 610
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "93aa782c4df17b6541e0e372240cf197066bab69",
-        "is_verified": false,
-        "line_number": 615
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "74106597d0b482d1234b7c43497027a1296250af",
-        "is_verified": false,
-        "line_number": 619
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "f2e6aadfcc320880c2d0ac82410e7608beec6a3c",
-        "is_verified": false,
-        "line_number": 623
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "c61921cb03b0d17c9d180fa6d2d765269458f5e9",
-        "is_verified": false,
-        "line_number": 643
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "c56c76bc828483f5553df346fb2eaa6e3e6c4bba",
-        "is_verified": false,
-        "line_number": 648
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "09ce1f68022d542bd4b111b2e648b4261e7ea537",
-        "is_verified": false,
-        "line_number": 653
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "f4713ff6d6ebe4c91eabb4abaa4fff79252287e2",
-        "is_verified": false,
-        "line_number": 661
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "7c36c3ff949a4f38922701a0fe3eb03c92eeb7ba",
-        "is_verified": false,
-        "line_number": 669
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "28072ac1f85a394efbe923fb172dfc8ff4d38556",
-        "is_verified": false,
-        "line_number": 682
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "f4c8d4909804be929ee867133fe4b0810002c8a4",
-        "is_verified": false,
-        "line_number": 688
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "f52956fa7c317746fde250d0f4e54d6115252cd4",
-        "is_verified": false,
-        "line_number": 692
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "7f104c1c37e525afe159a7b26fe2782992e9c896",
-        "is_verified": false,
-        "line_number": 699
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "1785152c56d58dd31a86fa5467b97bc8e5eff2a6",
-        "is_verified": false,
-        "line_number": 704
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "42cd07a10482e3b99b503ffc28f3e76e8dd1649c",
-        "is_verified": false,
-        "line_number": 708
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "dac0640634507d1e51d1abb71fad3023e8efe72c",
-        "is_verified": false,
-        "line_number": 713
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "862951cd71d0412b5e52bae3e952725486a655b0",
-        "is_verified": false,
-        "line_number": 721
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "8e948a3b773d1a2e4b6f4220216efa734315246d",
-        "is_verified": false,
-        "line_number": 730
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "d45062677e99f28b9a98f4b53e9af8f56b01bb10",
-        "is_verified": false,
-        "line_number": 741
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "2663e1112f14c846980b4a5ec9f6cd37552529a8",
-        "is_verified": false,
-        "line_number": 753
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "c5deff9c59d0e0419952da44431546620804d70e",
-        "is_verified": false,
-        "line_number": 760
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "572b5e5253ab86ef535e76d891766cc1a17ee6a5",
-        "is_verified": false,
-        "line_number": 765
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "4ee1accca30cee41b325697775406c5e5544600f",
-        "is_verified": false,
-        "line_number": 770
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "79119667cecad09809c34832b1f2b650b5ccded7",
-        "is_verified": false,
-        "line_number": 775
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "4d50b55900617c8d08097c03af9667c135c1fc24",
-        "is_verified": false,
-        "line_number": 784
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "2a0c5c01be780688ae4faf4a3e1cb6e48c50dc23",
-        "is_verified": false,
-        "line_number": 788
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "6d1db030d72c8b03fd95eaeb0266255402f70df5",
-        "is_verified": false,
-        "line_number": 793
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "cf75ddffbc923b32123e91e069fbcb97ac39c4d9",
-        "is_verified": false,
-        "line_number": 798
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "417a00b911e0b72a50a597cb7c4c70885c55516e",
-        "is_verified": false,
-        "line_number": 803
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "508e13818451655db815826a00fe15a68b7481b7",
-        "is_verified": false,
-        "line_number": 810
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "cc0394ae9ff7278ac1f8ba8305e06627798ae34b",
-        "is_verified": false,
-        "line_number": 841
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "763f4272f5426f2cb52dd90f1f6a490a4ce61418",
-        "is_verified": false,
-        "line_number": 845
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "3b9b4f0e0dc452a1ab51ff9a7e649171b0b54a70",
-        "is_verified": false,
-        "line_number": 851
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "8397cfed01049b1d4f005a8f06d81081e32e7bf0",
-        "is_verified": false,
-        "line_number": 856
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "d476b16e70f7a0ef92746a925be357e4bcbd2e4b",
-        "is_verified": false,
-        "line_number": 871
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "c7c109b373706b47cf9df00a37248b747d150701",
-        "is_verified": false,
-        "line_number": 910
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "dc9a2ba629796d6ef3323496eb952461f964e115",
-        "is_verified": false,
-        "line_number": 925
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "67e1630eef767c17f165bed8793abff78d5d53ac",
-        "is_verified": false,
-        "line_number": 930
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "d950cd8ef510429f57fb282e4a437321ca86158c",
-        "is_verified": false,
-        "line_number": 935
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "e7f54899a1654525fbfb1d8c3ac44d632f655af1",
-        "is_verified": false,
-        "line_number": 943
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "6a0b1415802be4d185b26687c46427264b5a82bf",
-        "is_verified": false,
-        "line_number": 947
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "4cd3a1b109eb67acf1557141e83880899d18eaea",
-        "is_verified": false,
-        "line_number": 951
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "5a4d96497ba98531c9c36ced1d043fbd8c535eff",
-        "is_verified": false,
-        "line_number": 967
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "8445443550ca4414f6d5ed6b062706991b53db72",
-        "is_verified": false,
-        "line_number": 975
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "979e2a14e4576c62a9748d7466bfa7f4f3a0620d",
-        "is_verified": false,
-        "line_number": 980
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "0d97c7fe1c124e07eb8bba42a86419c083ba0591",
-        "is_verified": false,
-        "line_number": 985
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "f52c08f63289414b8da2ea1271f68c9e1d6338ea",
-        "is_verified": false,
-        "line_number": 990
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "0fbd7edef887ee12aa44ddf7a04d0f8ebd192a79",
-        "is_verified": false,
-        "line_number": 997
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "9bad76463ceffd240ee9bd95c3faa98c0a4b94d0",
-        "is_verified": false,
-        "line_number": 1002
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "399a10e578724c52b45e79ab437f1ac7d890b205",
-        "is_verified": false,
-        "line_number": 1013
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "3e6c18abd5b90c63da0bd8b4c0d3a142e3d5a83d",
-        "is_verified": false,
-        "line_number": 1018
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "cf09cb791688fe019284bfdc362abc41918645a5",
-        "is_verified": false,
-        "line_number": 1025
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "89b283ab50bf537dfbd64a59830fb7dda89eb546",
-        "is_verified": false,
-        "line_number": 1029
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "22f3d72e7eefc7b3d1473692831de36cd4f9b451",
-        "is_verified": false,
-        "line_number": 1034
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "4e5e279b264f80f6302507f3bc02028118a5381f",
-        "is_verified": false,
-        "line_number": 1039
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "1a9c505c27a3d51d07d5cd60f1cd51dccb1ce4e6",
-        "is_verified": false,
-        "line_number": 1043
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "01242870f75bf9e4a05f9d14ee9482ebd3302804",
-        "is_verified": false,
-        "line_number": 1047
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "53aafd416c38a5d98f490f3f1b169550c6c49c41",
-        "is_verified": false,
-        "line_number": 1055
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "1e2228f0d8e0fc2bc3b8740a8ff3d287006b9a38",
-        "is_verified": false,
-        "line_number": 1061
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "87ae5db459dbd9fe4157473b016ae5ff5ef0f4ed",
-        "is_verified": false,
-        "line_number": 1067
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "d7c39664c403d1fecb3d1e330ad65a00bab67629",
-        "is_verified": false,
-        "line_number": 1072
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "33424d6062b147852810a1b4e7d5cd675caa3231",
-        "is_verified": false,
-        "line_number": 1077
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "2cf8bb850e018731465613b416d9603758dce6bb",
-        "is_verified": false,
-        "line_number": 1081
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "22f475d09df2c53aa6332a6d7aa6ac7e2cc09481",
-        "is_verified": false,
-        "line_number": 1085
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "838abb1331a160bdd441c25a2a2d44332ee8694b",
-        "is_verified": false,
-        "line_number": 1090
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "e6525dbd438fc8858b0d56c59d164f403792ba1e",
-        "is_verified": false,
-        "line_number": 1095
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "5c270f653b2fcd5b7c700b53f8543df4147a4aba",
-        "is_verified": false,
-        "line_number": 1102
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "825c3847dea034a478a75191a2b14d59fa5afa61",
-        "is_verified": false,
-        "line_number": 1108
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "90de41bb645eb912a3dcfbf357a4d329707ba620",
-        "is_verified": false,
-        "line_number": 1113
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "612b70ad4343adbb09a9cacc2fd28d7a2eae9313",
-        "is_verified": false,
-        "line_number": 1122
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "805d9656080308c11cde7cb7f0310e12c7e60c48",
-        "is_verified": false,
-        "line_number": 1126
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "ca13874532c9df50a570a36576667e2bbd4383bc",
-        "is_verified": false,
-        "line_number": 1129
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "4882a3f560bc1bf6d57e2e0d1bf68d2568e76dae",
-        "is_verified": false,
-        "line_number": 1135
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "65bf9ce9cce2677ae8a5ea43d01e18108ca6bca8",
-        "is_verified": false,
-        "line_number": 1140
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "bfa89e1607d2248db3523f241a0e9eb543cd0061",
-        "is_verified": false,
-        "line_number": 1147
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "0817713c3585298fbb156482ffc6787018397167",
-        "is_verified": false,
-        "line_number": 1152
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "1fd960f79ff7ccd39310bfdf81fba2b2663b71d0",
-        "is_verified": false,
-        "line_number": 1157
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "22ccb58cfd9117c60ea32a1d098a851f3c2efc0e",
-        "is_verified": false,
-        "line_number": 1164
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "5944d96f0a42954c63f1eba6c888565dc525f0cc",
-        "is_verified": false,
-        "line_number": 1171
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "ae745d719f97b3ddb9791348b1f29ff8208c0c5c",
-        "is_verified": false,
-        "line_number": 1178
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "61ff5c8a702d8ffe28063c06487a3a5a0db2ed70",
-        "is_verified": false,
-        "line_number": 1183
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "57c8d8926e4ba512c9b734875e9fb9ac68c06f8f",
-        "is_verified": false,
-        "line_number": 1188
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "78cac34debb068504165d4e64975947b641f5da8",
-        "is_verified": false,
-        "line_number": 1193
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "976e08d754318ea78969397d0d99157a6e8813a3",
-        "is_verified": false,
-        "line_number": 1197
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "9235bcf425e49c5749d9f52ed67b13717efda795",
-        "is_verified": false,
-        "line_number": 1201
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "541394d9706b7aa3694e656452be70a861e98358",
-        "is_verified": false,
-        "line_number": 1205
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "4439cc784aca22e5cdf33ed6656f5b8b99eaa44d",
-        "is_verified": false,
-        "line_number": 1209
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "18320432c7c3515f682ce9a5def8785bf11de5fd",
-        "is_verified": false,
-        "line_number": 1213
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "e4d0457c3771bd19a2db30ce4295cc025189392e",
-        "is_verified": false,
-        "line_number": 1221
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "1369198bf5cee9fcda4755ed3e7c041a4b9b04a5",
-        "is_verified": false,
-        "line_number": 1230
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "2a416cdbfc3b4651a6d04d447938ace3ff9c7b6a",
-        "is_verified": false,
-        "line_number": 1239
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "9366bc8779ea1bd895e15b0f9f3257a488db6397",
-        "is_verified": false,
-        "line_number": 1247
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "8287678ab8009ae16b02930c9e260d1f28578fbe",
-        "is_verified": false,
-        "line_number": 1254
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "52c607705ede5b492455a2cf8c60ed94b0fe9ad3",
-        "is_verified": false,
-        "line_number": 1259
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "5a233e343e439f5c0b7dad5b0bb3aac587600408",
-        "is_verified": false,
-        "line_number": 1269
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "3dae5288d620e04a965c1f200dd5d04ffabcbf81",
-        "is_verified": false,
-        "line_number": 1273
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "dab00d860d09dd9092b16718edd82bb24a6a21e9",
-        "is_verified": false,
-        "line_number": 1308
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "1508bbaf29927b5348d4df62823dab122a0d3b48",
-        "is_verified": false,
-        "line_number": 1312
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "3a84cb0624b6c580c119e861f942cae35cecacdb",
-        "is_verified": false,
-        "line_number": 1316
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "cfae64ecb55f017efd4c8c55aaa29db0bd61769b",
-        "is_verified": false,
-        "line_number": 1337
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "bae67d3ce231086fba18abc7365c94878f900c14",
-        "is_verified": false,
-        "line_number": 1349
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "3b7990b0f82bc9bc6c4ec02744f9c02e76aac827",
-        "is_verified": false,
-        "line_number": 1353
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "9072ebcbad57a1ae4256c5ae37c1e7c7ae5325de",
-        "is_verified": false,
-        "line_number": 1360
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "a1785e76071823a09f23d2c2b64db80b223c5411",
-        "is_verified": false,
-        "line_number": 1365
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "7cdaa4e52326d9a81d36d211cd26c2d7a9fc69e1",
-        "is_verified": false,
-        "line_number": 1373
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "6a66a6ffc1f1c2f31ec1c5c694938bedbae39c02",
-        "is_verified": false,
-        "line_number": 1383
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "05b9deaec8f504ac476e1af49d6dd6c7c79f6b36",
-        "is_verified": false,
-        "line_number": 1394
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "33e224ae0061fa6dc855702e88cad5e948136009",
-        "is_verified": false,
-        "line_number": 1405
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "e0c6ae09dd70fa25056d591ada0ad32df0dfe873",
-        "is_verified": false,
-        "line_number": 1409
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "336d02c1e7195c5237197b5884304099ab15c6ba",
-        "is_verified": false,
-        "line_number": 1414
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "b015b77432bd6d255596af7b2f552d8e8c91a7f7",
-        "is_verified": false,
-        "line_number": 1419
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "4dcc5c09923b9c0c9014f1f416f58aed8360e584",
-        "is_verified": false,
-        "line_number": 1423
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "32026694f097ae0956b46d081f53c72d129a0e9d",
-        "is_verified": false,
-        "line_number": 1428
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "34f5cd0383bf8e440ddb6c8bf2abadf4fad5b230",
-        "is_verified": false,
-        "line_number": 1432
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "d9566366e18e35f6f08d7086ab032c1d5e2322d4",
-        "is_verified": false,
-        "line_number": 1437
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "2fbe8ab30e5355ea9d7538aec4d6c869562a0ed8",
-        "is_verified": false,
-        "line_number": 1443
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "b0a1aa84d8bc7d20003fcac2a3a41e8a1169ec5c",
-        "is_verified": false,
-        "line_number": 1447
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "a02888a82a575f758f8f7a27049634d38ba6bae3",
-        "is_verified": false,
-        "line_number": 1452
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "a6d813aa7164341218d80a2b625ff1b254fa10c3",
-        "is_verified": false,
-        "line_number": 1457
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "0a2bf81ec8947036768ec8d26bc123da94537e6b",
-        "is_verified": false,
-        "line_number": 1462
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "955d2d24c472b4eb0b4488f935a0f65e38001df8",
-        "is_verified": false,
-        "line_number": 1467
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "b0cc5db4f99fc0fb773b7006064bd925ae04e9b5",
-        "is_verified": false,
-        "line_number": 1475
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "2cf79101947343f62524a7ab71f313b66d694198",
-        "is_verified": false,
-        "line_number": 1479
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "292b56ccb1313ea50f4d1bf0efc7f2b04670fe73",
-        "is_verified": false,
-        "line_number": 1483
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "4885a73ae27294938a483e855613b49825a795e8",
-        "is_verified": false,
-        "line_number": 1488
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "f436e5e80e3407aed61c6a5d0463a46e0da536d8",
-        "is_verified": false,
-        "line_number": 1493
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "23f815f2b868e17d37d451a92c0f0b8aca6182be",
-        "is_verified": false,
-        "line_number": 1498
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "2f73770c4b2c405b9f25e2bc5b5e42d82aa859dd",
-        "is_verified": false,
-        "line_number": 1520
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "f8038564553de251e0bbc18a236b4f4189d609c8",
-        "is_verified": false,
-        "line_number": 1558
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "f0257d02d23f53e799476af74cf0386375d4b6c2",
-        "is_verified": false,
-        "line_number": 1614
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "95b02c02e7cb902e9603042bf77d2ce3b47d7dd1",
-        "is_verified": false,
-        "line_number": 1622
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "687e3303e4e4d4159d08eb9eaea6acaedd0cbb30",
-        "is_verified": false,
-        "line_number": 1631
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/mcp/pnpm-lock.yaml",
-        "hashed_secret": "40cef9bc69de80307d1ed242394904663222fef2",
-        "is_verified": false,
-        "line_number": 1644
-      }
-    ],
-    ".claude/v3/@claude-flow/plugins/__tests__/ruvector-bridge.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/v3/@claude-flow/plugins/__tests__/ruvector-bridge.test.ts",
-        "hashed_secret": "9fb7fe1217aed442b04c0f5e43b5d5a7d3287097",
-        "is_verified": false,
-        "line_number": 129
-      }
-    ],
-    ".claude/v3/@claude-flow/plugins/__tests__/security.test.ts": [
-      {
-        "type": "Basic Auth Credentials",
-        "filename": ".claude/v3/@claude-flow/plugins/__tests__/security.test.ts",
-        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
-        "is_verified": false,
-        "line_number": 233
-      }
-    ],
-    ".claude/v3/@claude-flow/plugins/__tests__/utils/ruvector-test-utils.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/v3/@claude-flow/plugins/__tests__/utils/ruvector-test-utils.ts",
-        "hashed_secret": "9fb7fe1217aed442b04c0f5e43b5d5a7d3287097",
-        "is_verified": false,
-        "line_number": 188
-      }
-    ],
-    ".claude/v3/@claude-flow/plugins/examples/ruvector/docker-compose.yml": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/v3/@claude-flow/plugins/examples/ruvector/docker-compose.yml",
-        "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
-        "is_verified": false,
-        "line_number": 28
-      }
-    ],
-    ".claude/v3/@claude-flow/plugins/src/integrations/ruvector/ruvector-bridge.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/v3/@claude-flow/plugins/src/integrations/ruvector/ruvector-bridge.ts",
-        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
-        "is_verified": false,
-        "line_number": 1075
-      }
-    ],
-    ".claude/v3/@claude-flow/security/README.md": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/v3/@claude-flow/security/README.md",
-        "hashed_secret": "a0f4ea7d91495df92bbac2e2149dfb850fe81396",
-        "is_verified": false,
-        "line_number": 197
-      }
-    ],
-    ".claude/v3/@claude-flow/security/__tests__/acceptance/security-compliance.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/v3/@claude-flow/security/__tests__/acceptance/security-compliance.test.ts",
-        "hashed_secret": "a6f9656f4481dd8999a7da13ef1ace9d3ecce7cd",
-        "is_verified": false,
-        "line_number": 539
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/v3/@claude-flow/security/__tests__/acceptance/security-compliance.test.ts",
-        "hashed_secret": "5a5519487eea3bde8956b94e7469ba160c1d33a2",
-        "is_verified": false,
-        "line_number": 584
-      }
-    ],
-    ".claude/v3/@claude-flow/security/__tests__/fixtures/configurations.ts": [
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".claude/v3/@claude-flow/security/__tests__/fixtures/configurations.ts",
-        "hashed_secret": "c377074d6473f35a91001981355da793dc808ffd",
-        "is_verified": false,
-        "line_number": 359
-      }
-    ],
-    ".claude/v3/@claude-flow/security/__tests__/helpers/create-mock.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/v3/@claude-flow/security/__tests__/helpers/create-mock.ts",
-        "hashed_secret": "9b706eb37ccde8e5b7346f7520edbb71d5049f04",
-        "is_verified": false,
-        "line_number": 174
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/v3/@claude-flow/security/__tests__/helpers/create-mock.ts",
-        "hashed_secret": "297f79fe6314ed887f0d415d464337212a387e2d",
-        "is_verified": false,
-        "line_number": 175
-      }
-    ],
-    ".claude/v3/@claude-flow/security/__tests__/input-validator.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/v3/@claude-flow/security/__tests__/input-validator.test.ts",
-        "hashed_secret": "cbfdac6008f9cab4083784cbd1874f76618d2a97",
-        "is_verified": false,
-        "line_number": 193
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/v3/@claude-flow/security/__tests__/input-validator.test.ts",
-        "hashed_secret": "20b05c695ef1f14caa80ab1ce617d503ba9de093",
-        "is_verified": false,
-        "line_number": 218
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/v3/@claude-flow/security/__tests__/input-validator.test.ts",
-        "hashed_secret": "1ded3053d0363079a4e681a3b700435d6d880290",
-        "is_verified": false,
-        "line_number": 226
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/v3/@claude-flow/security/__tests__/input-validator.test.ts",
-        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
-        "is_verified": false,
-        "line_number": 354
-      }
-    ],
-    ".claude/v3/@claude-flow/security/__tests__/integration/security-flow.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/v3/@claude-flow/security/__tests__/integration/security-flow.test.ts",
-        "hashed_secret": "72559b51f94a7a3ad058c5740cbe2f7cb0d4080b",
-        "is_verified": false,
-        "line_number": 325
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/v3/@claude-flow/security/__tests__/integration/security-flow.test.ts",
-        "hashed_secret": "1ded3053d0363079a4e681a3b700435d6d880290",
-        "is_verified": false,
-        "line_number": 339
-      }
-    ],
-    ".claude/v3/@claude-flow/security/__tests__/password-hasher.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/v3/@claude-flow/security/__tests__/password-hasher.test.ts",
-        "hashed_secret": "20b05c695ef1f14caa80ab1ce617d503ba9de093",
-        "is_verified": false,
-        "line_number": 128
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": ".claude/v3/@claude-flow/security/__tests__/password-hasher.test.ts",
-        "hashed_secret": "005353fed1f2f620fb3ee70d858eafb013650632",
-        "is_verified": false,
-        "line_number": 161
-      }
-    ],
-    ".claude/v3/@claude-flow/security/__tests__/token-generator.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/v3/@claude-flow/security/__tests__/token-generator.test.ts",
-        "hashed_secret": "6f997accf7e030e24866cfd24b6d982034edb4e2",
-        "is_verified": false,
-        "line_number": 25
-      }
-    ],
-    ".claude/v3/@claude-flow/security/__tests__/unit/password-hasher.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/v3/@claude-flow/security/__tests__/unit/password-hasher.test.ts",
-        "hashed_secret": "89d0dfc4e4c8abcf1575e92fb8dff791a83f3240",
-        "is_verified": false,
-        "line_number": 96
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/v3/@claude-flow/security/__tests__/unit/password-hasher.test.ts",
-        "hashed_secret": "a0f4ea7d91495df92bbac2e2149dfb850fe81396",
-        "is_verified": false,
-        "line_number": 141
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/v3/@claude-flow/security/__tests__/unit/password-hasher.test.ts",
-        "hashed_secret": "71a35d8df92df793a7f186c5dde36aa2da4fa5da",
-        "is_verified": false,
-        "line_number": 210
-      }
-    ],
-    ".claude/v3/@claude-flow/security/__tests__/unit/token-generator.test.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/v3/@claude-flow/security/__tests__/unit/token-generator.test.ts",
-        "hashed_secret": "65882b5e8dbab0e649474b2a626c1d24e1b317f5",
-        "is_verified": false,
-        "line_number": 120
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/v3/@claude-flow/security/__tests__/unit/token-generator.test.ts",
-        "hashed_secret": "83a5b8a7b2e181736b4cad2391e48691b4434fdb",
-        "is_verified": false,
-        "line_number": 150
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/v3/@claude-flow/security/__tests__/unit/token-generator.test.ts",
-        "hashed_secret": "97a4ac7aa1a93b87cfec99597119d1be9dfa9072",
-        "is_verified": false,
-        "line_number": 151
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/v3/@claude-flow/security/__tests__/unit/token-generator.test.ts",
-        "hashed_secret": "fe1bae27cb7c1fb823f496f286e78f1d2ae87734",
-        "is_verified": false,
-        "line_number": 158
-      }
-    ],
-    ".claude/v3/@claude-flow/security/src/credential-generator.ts": [
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/@claude-flow/security/src/credential-generator.ts",
-        "hashed_secret": "e582429052cdb908833560f6f7582d232de37c4d",
-        "is_verified": false,
-        "line_number": 86
-      }
-    ],
-    ".claude/v3/@claude-flow/security/src/token-generator.ts": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/v3/@claude-flow/security/src/token-generator.ts",
-        "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
-        "is_verified": false,
-        "line_number": 85
-      }
-    ],
-    ".claude/v3/@claude-flow/shared/__tests__/hooks/bash-safety.test.ts": [
-      {
-        "type": "GitHub Token",
-        "filename": ".claude/v3/@claude-flow/shared/__tests__/hooks/bash-safety.test.ts",
-        "hashed_secret": "e175c6f5f2a92e8623bd9a4820edb4e8c1b0fd10",
-        "is_verified": false,
-        "line_number": 178
-      },
-      {
-        "type": "AWS Access Key",
-        "filename": ".claude/v3/@claude-flow/shared/__tests__/hooks/bash-safety.test.ts",
-        "hashed_secret": "25910f981e85ca04baf359199dd0bd4a3ae738b6",
-        "is_verified": false,
-        "line_number": 184
-      }
-    ],
-    ".claude/v3/implementation/adrs/ADR-021-transfer-hook-ipfs-pattern-sharing.md": [
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/implementation/adrs/ADR-021-transfer-hook-ipfs-pattern-sharing.md",
-        "hashed_secret": "650f08405a979892f2fcd7e7378fa8fd00b60ef7",
-        "is_verified": false,
-        "line_number": 1838
-      },
-      {
-        "type": "Base64 High Entropy String",
-        "filename": ".claude/v3/implementation/adrs/ADR-021-transfer-hook-ipfs-pattern-sharing.md",
-        "hashed_secret": "bf423b68899b8a427faf48c7a377f11dcd3ffca7",
-        "is_verified": false,
-        "line_number": 1846
-      }
-    ],
-    ".claude/v3/implementation/adrs/ADR-027-ruvector-postgresql-integration.md": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/v3/implementation/adrs/ADR-027-ruvector-postgresql-integration.md",
-        "hashed_secret": "21672328ab5c939c8a4324d118b264d9f34b0439",
-        "is_verified": false,
-        "line_number": 1295
-      }
-    ],
-    ".claude/v3/implementation/planning/CLAUDE-FLOW-V3-MASTER-PLAN.md": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/v3/implementation/planning/CLAUDE-FLOW-V3-MASTER-PLAN.md",
-        "hashed_secret": "f865b53623b121fd34ee5426c792e5c33af8c227",
-        "is_verified": false,
-        "line_number": 131
-      }
-    ],
-    ".claude/v3/implementation/security/SECURITY_AUDIT_REPORT.md": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/v3/implementation/security/SECURITY_AUDIT_REPORT.md",
-        "hashed_secret": "035bf17d591b5967aafe1700f7e7d0bf0f7d6bf3",
-        "is_verified": false,
-        "line_number": 292
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/v3/implementation/security/SECURITY_AUDIT_REPORT.md",
-        "hashed_secret": "6af3c121ed4a752936c297cddfb7b00394eabf10",
-        "is_verified": false,
-        "line_number": 293
-      }
-    ],
-    ".claude/v3/implementation/security/SECURITY_SUMMARY.md": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/v3/implementation/security/SECURITY_SUMMARY.md",
-        "hashed_secret": "f865b53623b121fd34ee5426c792e5c33af8c227",
-        "is_verified": false,
-        "line_number": 35
-      }
-    ],
-    ".claude/v3/implementation/swarm-plans/TDD-LONDON-SCHOOL-PLAN.md": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".claude/v3/implementation/swarm-plans/TDD-LONDON-SCHOOL-PLAN.md",
-        "hashed_secret": "72559b51f94a7a3ad058c5740cbe2f7cb0d4080b",
-        "is_verified": false,
-        "line_number": 481
-      }
-    ],
     ".context/context-manager.json": [
       {
         "type": "Secret Keyword",
         "filename": ".context/context-manager.json",
         "hashed_secret": "ebe8872498bd7a369441cf75f56db2bf3701eef9",
         "is_verified": false,
-        "line_number": 281
-      }
-    ],
-    ".context/deployment_readiness.md": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".context/deployment_readiness.md",
-        "hashed_secret": "632d8eb9ee5be70b5448c03a10544b62f577ad60",
-        "is_verified": false,
-        "line_number": 159
-      }
-    ],
-    ".context/identified_issues.md": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".context/identified_issues.md",
-        "hashed_secret": "564e340cd48437d2dfe876ee154cc99dc4d0d137",
-        "is_verified": false,
-        "line_number": 97
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".context/identified_issues.md",
-        "hashed_secret": "632d8eb9ee5be70b5448c03a10544b62f577ad60",
-        "is_verified": false,
-        "line_number": 239
-      }
-    ],
-    ".context/recommendations.md": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".context/recommendations.md",
-        "hashed_secret": "632d8eb9ee5be70b5448c03a10544b62f577ad60",
-        "is_verified": false,
-        "line_number": 51
+        "line_number": 281,
+        "is_secret": false
       }
     ],
     ".context/refresh_analysis.sh": [
@@ -2776,7 +132,8 @@
         "filename": ".context/refresh_analysis.sh",
         "hashed_secret": "1727362a714475223abe7282c85576599adc7ff9",
         "is_verified": false,
-        "line_number": 99
+        "line_number": 99,
+        "is_secret": true
       }
     ],
     ".devcontainer/devcontainer.json": [
@@ -2785,7 +142,8 @@
         "filename": ".devcontainer/devcontainer.json",
         "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
         "is_verified": false,
-        "line_number": 66
+        "line_number": 66,
+        "is_secret": false
       }
     ],
     ".env.airflow": [
@@ -2794,42 +152,48 @@
         "filename": ".env.airflow",
         "hashed_secret": "8892a35e0f616d532ad1f2ac5be1eb0d4a9675cb",
         "is_verified": false,
-        "line_number": 12
+        "line_number": 12,
+        "is_secret": true
       },
       {
         "type": "Hex High Entropy String",
         "filename": ".env.airflow",
         "hashed_secret": "d93e626bddcd4c28a22b24198b6a0734d6398e9d",
         "is_verified": false,
-        "line_number": 15
+        "line_number": 15,
+        "is_secret": true
       },
       {
         "type": "Secret Keyword",
         "filename": ".env.airflow",
         "hashed_secret": "d93e626bddcd4c28a22b24198b6a0734d6398e9d",
         "is_verified": false,
-        "line_number": 15
+        "line_number": 15,
+        "is_secret": true
       },
       {
         "type": "Secret Keyword",
         "filename": ".env.airflow",
         "hashed_secret": "3541adbf1f8d13d9f40614f0e2e41633a0d01ea6",
         "is_verified": false,
-        "line_number": 29
+        "line_number": 29,
+        "is_secret": true
       },
       {
         "type": "Secret Keyword",
         "filename": ".env.airflow",
         "hashed_secret": "191a7370b2a34f1faf71dd33efcbc6de689c5b5c",
         "is_verified": false,
-        "line_number": 39
+        "line_number": 39,
+        "is_secret": true
       },
       {
         "type": "Secret Keyword",
         "filename": ".env.airflow",
         "hashed_secret": "6cef6e6277ce256b0dae33d885e6e7b885e66c6d",
         "is_verified": false,
-        "line_number": 46
+        "line_number": 46,
+        "is_secret": true
       }
     ],
     ".env.airflow.template": [
@@ -2838,35 +202,40 @@
         "filename": ".env.airflow.template",
         "hashed_secret": "cf29a3a50a48c94bf5dbb19c87172c331eb8612f",
         "is_verified": false,
-        "line_number": 7
+        "line_number": 7,
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
         "filename": ".env.airflow.template",
         "hashed_secret": "b94921e4c3ee713a1925dfc91e7c8ac97f879c4a",
         "is_verified": false,
-        "line_number": 8
+        "line_number": 8,
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
         "filename": ".env.airflow.template",
         "hashed_secret": "6d1cac55f6f6e39755b4e8da2148244c5861dab8",
         "is_verified": false,
-        "line_number": 12
+        "line_number": 12,
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
         "filename": ".env.airflow.template",
         "hashed_secret": "056ce9478fb0052f3d40daf94d01f13a50058ef5",
         "is_verified": false,
-        "line_number": 16
+        "line_number": 16,
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
         "filename": ".env.airflow.template",
         "hashed_secret": "1687d274b732e2c80bfb50fac3ca642ac3c0bfcf",
         "is_verified": false,
-        "line_number": 20
+        "line_number": 20,
+        "is_secret": false
       }
     ],
     ".env.example": [
@@ -2875,7 +244,8 @@
         "filename": ".env.example",
         "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
         "is_verified": false,
-        "line_number": 312
+        "line_number": 358,
+        "is_secret": false
       }
     ],
     ".env.secure": [
@@ -2884,7 +254,8 @@
         "filename": ".env.secure",
         "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
         "is_verified": false,
-        "line_number": 294
+        "line_number": 294,
+        "is_secret": true
       }
     ],
     ".env.secure.template": [
@@ -2893,70 +264,80 @@
         "filename": ".env.secure.template",
         "hashed_secret": "c7a283c4c2b5cb31b92ebc7c695155197e9c38a4",
         "is_verified": false,
-        "line_number": 24
+        "line_number": 24,
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
         "filename": ".env.secure.template",
         "hashed_secret": "288f271ef54c0b0a1ff11319a660b300936948fc",
         "is_verified": false,
-        "line_number": 27
+        "line_number": 27,
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
         "filename": ".env.secure.template",
         "hashed_secret": "f265bbd42a2e573bf848045708c28cc887c45797",
         "is_verified": false,
-        "line_number": 38
+        "line_number": 38,
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
         "filename": ".env.secure.template",
         "hashed_secret": "13f8da5cf00f34a250e01a7647aff967c5aba8c7",
         "is_verified": false,
-        "line_number": 49
+        "line_number": 49,
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
         "filename": ".env.secure.template",
         "hashed_secret": "4f169d8590c987e7c7e9091161f358bc1d3e5572",
         "is_verified": false,
-        "line_number": 84
+        "line_number": 84,
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
         "filename": ".env.secure.template",
         "hashed_secret": "a4b571af307c612572294b9be601877ff5e1a726",
         "is_verified": false,
-        "line_number": 88
+        "line_number": 88,
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
         "filename": ".env.secure.template",
         "hashed_secret": "53c6bca90b83c26a98298482575ee1489ae847a4",
         "is_verified": false,
-        "line_number": 92
+        "line_number": 92,
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
         "filename": ".env.secure.template",
         "hashed_secret": "a28b1e43d0de8c6d65b58abea0bfcb00d2bae914",
         "is_verified": false,
-        "line_number": 97
+        "line_number": 97,
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
         "filename": ".env.secure.template",
         "hashed_secret": "99a8c6988f514314ac82f887378c5352bce2148c",
         "is_verified": false,
-        "line_number": 141
+        "line_number": 141,
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
         "filename": ".env.secure.template",
         "hashed_secret": "3ce1f24aad3e4e88dea0cf7f26ca56396182c64c",
         "is_verified": false,
-        "line_number": 148
+        "line_number": 148,
+        "is_secret": false
       }
     ],
     ".env.template": [
@@ -2965,77 +346,88 @@
         "filename": ".env.template",
         "hashed_secret": "89e789a7fcb5bcb20303a0e736089963ba27e120",
         "is_verified": false,
-        "line_number": 7
+        "line_number": 7,
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
         "filename": ".env.template",
         "hashed_secret": "b8eab03ad5f0b50c47e915eb4c706e593b9fd462",
         "is_verified": false,
-        "line_number": 8
+        "line_number": 8,
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
         "filename": ".env.template",
         "hashed_secret": "b2372c09b45b96961f41a196180c8f53518ea56e",
         "is_verified": false,
-        "line_number": 9
+        "line_number": 9,
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
         "filename": ".env.template",
         "hashed_secret": "bc97c8b157fd6ad9c5d8a51af62b6cb6c7360003",
         "is_verified": false,
-        "line_number": 10
+        "line_number": 10,
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
         "filename": ".env.template",
         "hashed_secret": "501dc5047dee08296e5ee5203e01d1e03a32d73a",
         "is_verified": false,
-        "line_number": 15
+        "line_number": 15,
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
         "filename": ".env.template",
         "hashed_secret": "753678aa70672b4cb0e544522f27de09433fa211",
         "is_verified": false,
-        "line_number": 16
+        "line_number": 16,
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
         "filename": ".env.template",
         "hashed_secret": "49959826c4ca3c9c5ddbd9997f628403cb76977a",
         "is_verified": false,
-        "line_number": 22
+        "line_number": 25,
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
         "filename": ".env.template",
         "hashed_secret": "2b35dcf1bbf206d2c94d087c4c72de3cc332a5d1",
         "is_verified": false,
-        "line_number": 31
+        "line_number": 34,
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
         "filename": ".env.template",
         "hashed_secret": "6cd8351191215ebd1dfdca4da58da2daad9e8c7d",
         "is_verified": false,
-        "line_number": 37
+        "line_number": 40,
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
         "filename": ".env.template",
         "hashed_secret": "5ce6258b2ca298fa6baedc331a78962a6b05b961",
         "is_verified": false,
-        "line_number": 42
+        "line_number": 45,
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
         "filename": ".env.template",
         "hashed_secret": "61ccaf8f4d56cb684246b40b375d408cf23f4d3c",
         "is_verified": false,
-        "line_number": 50
+        "line_number": 53,
+        "is_secret": false
       }
     ],
     ".env_backup_DONOTUSE/.env.airflow.template": [
@@ -3044,35 +436,40 @@
         "filename": ".env_backup_DONOTUSE/.env.airflow.template",
         "hashed_secret": "cf29a3a50a48c94bf5dbb19c87172c331eb8612f",
         "is_verified": false,
-        "line_number": 7
+        "line_number": 7,
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
         "filename": ".env_backup_DONOTUSE/.env.airflow.template",
         "hashed_secret": "b94921e4c3ee713a1925dfc91e7c8ac97f879c4a",
         "is_verified": false,
-        "line_number": 8
+        "line_number": 8,
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
         "filename": ".env_backup_DONOTUSE/.env.airflow.template",
         "hashed_secret": "6d1cac55f6f6e39755b4e8da2148244c5861dab8",
         "is_verified": false,
-        "line_number": 12
+        "line_number": 12,
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
         "filename": ".env_backup_DONOTUSE/.env.airflow.template",
         "hashed_secret": "056ce9478fb0052f3d40daf94d01f13a50058ef5",
         "is_verified": false,
-        "line_number": 16
+        "line_number": 16,
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
         "filename": ".env_backup_DONOTUSE/.env.airflow.template",
         "hashed_secret": "1687d274b732e2c80bfb50fac3ca642ac3c0bfcf",
         "is_verified": false,
-        "line_number": 20
+        "line_number": 20,
+        "is_secret": false
       }
     ],
     ".env_backup_DONOTUSE/.env.example": [
@@ -3081,7 +478,8 @@
         "filename": ".env_backup_DONOTUSE/.env.example",
         "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
         "is_verified": false,
-        "line_number": 298
+        "line_number": 298,
+        "is_secret": false
       }
     ],
     ".env_backup_DONOTUSE/.env.production.backup": [
@@ -3090,7 +488,8 @@
         "filename": ".env_backup_DONOTUSE/.env.production.backup",
         "hashed_secret": "1727362a714475223abe7282c85576599adc7ff9",
         "is_verified": false,
-        "line_number": 17
+        "line_number": 17,
+        "is_secret": true
       }
     ],
     ".env_backup_DONOTUSE/.env.secure": [
@@ -3099,7 +498,8 @@
         "filename": ".env_backup_DONOTUSE/.env.secure",
         "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
         "is_verified": false,
-        "line_number": 293
+        "line_number": 293,
+        "is_secret": true
       }
     ],
     ".github/README.md": [
@@ -3108,7 +508,8 @@
         "filename": ".github/README.md",
         "hashed_secret": "206c80413b9a96c1312cc346b7d2517b84463edd",
         "is_verified": false,
-        "line_number": 226
+        "line_number": 377,
+        "is_secret": false
       }
     ],
     ".github/workflows/ci.yml": [
@@ -3117,35 +518,72 @@
         "filename": ".github/workflows/ci.yml",
         "hashed_secret": "206c80413b9a96c1312cc346b7d2517b84463edd",
         "is_verified": false,
-        "line_number": 101
+        "line_number": 225,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".github/workflows/ci.yml",
+        "hashed_secret": "76e536fe5da8f62021c1622f0fbdaaf753cbad50",
+        "is_verified": false,
+        "line_number": 280,
+        "is_secret": false
       },
       {
         "type": "Basic Auth Credentials",
         "filename": ".github/workflows/ci.yml",
         "hashed_secret": "206c80413b9a96c1312cc346b7d2517b84463edd",
         "is_verified": false,
-        "line_number": 166
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".github/workflows/ci.yml",
-        "hashed_secret": "8bba2c89458b3dbb73bb9868adc36b32b93ec14d",
-        "is_verified": false,
-        "line_number": 166
+        "line_number": 300,
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/ci.yml",
         "hashed_secret": "d4e0e04792fd434b5dc9c4155c178f66edcf4ed3",
         "is_verified": false,
-        "line_number": 206
+        "line_number": 302,
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/ci.yml",
-        "hashed_secret": "9d08ce083538d260048e6ff488aaf954740ab7a6",
+        "hashed_secret": "b71d494da8d930401ba9b32b7cef87295f3eb6d3",
         "is_verified": false,
-        "line_number": 371
+        "line_number": 363,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/ci.yml",
+        "hashed_secret": "6b36216312a7a153bbb73632ab3c565c6e83cc12",
+        "is_verified": false,
+        "line_number": 364,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/ci.yml",
+        "hashed_secret": "4b8fe7c9a34038a4f0cc9e513ca016f0fdcad169",
+        "is_verified": false,
+        "line_number": 365,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/ci.yml",
+        "hashed_secret": "e951d5521257df00f58d409eaacadb46f6433493",
+        "is_verified": false,
+        "line_number": 588,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/ci.yml",
+        "hashed_secret": "89e495e7941cf9e40e6980d14a16bf023ccd4c91",
+        "is_verified": false,
+        "line_number": 593,
+        "is_secret": false
       }
     ],
     ".github/workflows/comprehensive-testing.yml": [
@@ -3154,14 +592,56 @@
         "filename": ".github/workflows/comprehensive-testing.yml",
         "hashed_secret": "9fb7fe1217aed442b04c0f5e43b5d5a7d3287097",
         "is_verified": false,
-        "line_number": 15
+        "line_number": 15,
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/comprehensive-testing.yml",
         "hashed_secret": "affd11b40b1577c37b9427a79f3b7b30691ece4d",
         "is_verified": false,
-        "line_number": 16
+        "line_number": 16,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": ".github/workflows/comprehensive-testing.yml",
+        "hashed_secret": "76e536fe5da8f62021c1622f0fbdaaf753cbad50",
+        "is_verified": false,
+        "line_number": 36,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/comprehensive-testing.yml",
+        "hashed_secret": "b71d494da8d930401ba9b32b7cef87295f3eb6d3",
+        "is_verified": false,
+        "line_number": 219,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/comprehensive-testing.yml",
+        "hashed_secret": "6b36216312a7a153bbb73632ab3c565c6e83cc12",
+        "is_verified": false,
+        "line_number": 220,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/comprehensive-testing.yml",
+        "hashed_secret": "4b8fe7c9a34038a4f0cc9e513ca016f0fdcad169",
+        "is_verified": false,
+        "line_number": 221,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/comprehensive-testing.yml",
+        "hashed_secret": "e17ccea2b34f434ff4c5146b7b7d71dfa8b17a86",
+        "is_verified": false,
+        "line_number": 627,
+        "is_secret": false
       }
     ],
     ".github/workflows/daily-pipeline-validation.yml": [
@@ -3170,21 +650,56 @@
         "filename": ".github/workflows/daily-pipeline-validation.yml",
         "hashed_secret": "89e495e7941cf9e40e6980d14a16bf023ccd4c91",
         "is_verified": false,
-        "line_number": 71
+        "line_number": 71,
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/daily-pipeline-validation.yml",
         "hashed_secret": "206c80413b9a96c1312cc346b7d2517b84463edd",
         "is_verified": false,
-        "line_number": 150
+        "line_number": 150,
+        "is_secret": false
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": ".github/workflows/daily-pipeline-validation.yml",
+        "hashed_secret": "0aa4639b92398421f3b457d231a05fe651860cf9",
+        "is_verified": false,
+        "line_number": 205,
+        "is_secret": false
       },
       {
         "type": "Basic Auth Credentials",
         "filename": ".github/workflows/daily-pipeline-validation.yml",
         "hashed_secret": "206c80413b9a96c1312cc346b7d2517b84463edd",
         "is_verified": false,
-        "line_number": 193
+        "line_number": 205,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/daily-pipeline-validation.yml",
+        "hashed_secret": "bb818facb50c055a28d29af5a882605af29a49a3",
+        "is_verified": false,
+        "line_number": 205,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/daily-pipeline-validation.yml",
+        "hashed_secret": "3a1c7e9c092a19ea1b17c25158b49a716169ffc9",
+        "is_verified": false,
+        "line_number": 281,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": ".github/workflows/daily-pipeline-validation.yml",
+        "hashed_secret": "26b32357bb122f8157a6aa3f1e327763d7a8d3f0",
+        "is_verified": false,
+        "line_number": 282,
+        "is_secret": false
       }
     ],
     ".github/workflows/dependency-updates.yml": [
@@ -3193,21 +708,24 @@
         "filename": ".github/workflows/dependency-updates.yml",
         "hashed_secret": "206c80413b9a96c1312cc346b7d2517b84463edd",
         "is_verified": false,
-        "line_number": 116
+        "line_number": 125,
+        "is_secret": false
       },
       {
         "type": "Basic Auth Credentials",
         "filename": ".github/workflows/dependency-updates.yml",
         "hashed_secret": "206c80413b9a96c1312cc346b7d2517b84463edd",
         "is_verified": false,
-        "line_number": 201
+        "line_number": 215,
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/dependency-updates.yml",
         "hashed_secret": "d4e0e04792fd434b5dc9c4155c178f66edcf4ed3",
         "is_verified": false,
-        "line_number": 203
+        "line_number": 217,
+        "is_secret": false
       }
     ],
     ".github/workflows/migration-check.yml": [
@@ -3216,14 +734,16 @@
         "filename": ".github/workflows/migration-check.yml",
         "hashed_secret": "9fb7fe1217aed442b04c0f5e43b5d5a7d3287097",
         "is_verified": false,
-        "line_number": 201
+        "line_number": 208,
+        "is_secret": false
       },
       {
         "type": "Basic Auth Credentials",
         "filename": ".github/workflows/migration-check.yml",
         "hashed_secret": "9fb7fe1217aed442b04c0f5e43b5d5a7d3287097",
         "is_verified": false,
-        "line_number": 237
+        "line_number": 244,
+        "is_secret": false
       }
     ],
     ".github/workflows/performance-monitoring.yml": [
@@ -3232,14 +752,16 @@
         "filename": ".github/workflows/performance-monitoring.yml",
         "hashed_secret": "206c80413b9a96c1312cc346b7d2517b84463edd",
         "is_verified": false,
-        "line_number": 327
+        "line_number": 327,
+        "is_secret": false
       },
       {
         "type": "Basic Auth Credentials",
         "filename": ".github/workflows/performance-monitoring.yml",
         "hashed_secret": "206c80413b9a96c1312cc346b7d2517b84463edd",
         "is_verified": false,
-        "line_number": 351
+        "line_number": 351,
+        "is_secret": false
       }
     ],
     ".github/workflows/production-deploy.yml": [
@@ -3248,28 +770,24 @@
         "filename": ".github/workflows/production-deploy.yml",
         "hashed_secret": "206c80413b9a96c1312cc346b7d2517b84463edd",
         "is_verified": false,
-        "line_number": 88
+        "line_number": 88,
+        "is_secret": false
       },
       {
         "type": "Basic Auth Credentials",
         "filename": ".github/workflows/production-deploy.yml",
         "hashed_secret": "206c80413b9a96c1312cc346b7d2517b84463edd",
         "is_verified": false,
-        "line_number": 148
+        "line_number": 153,
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/production-deploy.yml",
         "hashed_secret": "d4e0e04792fd434b5dc9c4155c178f66edcf4ed3",
         "is_verified": false,
-        "line_number": 150
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": ".github/workflows/production-deploy.yml",
-        "hashed_secret": "5d146f1417177cccd929426b7d07c0c5c5206518",
-        "is_verified": false,
-        "line_number": 397
+        "line_number": 155,
+        "is_secret": false
       }
     ],
     ".github/workflows/release-management.yml": [
@@ -3278,21 +796,24 @@
         "filename": ".github/workflows/release-management.yml",
         "hashed_secret": "206c80413b9a96c1312cc346b7d2517b84463edd",
         "is_verified": false,
-        "line_number": 253
+        "line_number": 253,
+        "is_secret": false
       },
       {
         "type": "Basic Auth Credentials",
         "filename": ".github/workflows/release-management.yml",
         "hashed_secret": "206c80413b9a96c1312cc346b7d2517b84463edd",
         "is_verified": false,
-        "line_number": 290
+        "line_number": 290,
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/release-management.yml",
         "hashed_secret": "d4e0e04792fd434b5dc9c4155c178f66edcf4ed3",
         "is_verified": false,
-        "line_number": 292
+        "line_number": 292,
+        "is_secret": false
       }
     ],
     ".github/workflows/reusable-test.yml": [
@@ -3301,30 +822,24 @@
         "filename": ".github/workflows/reusable-test.yml",
         "hashed_secret": "206c80413b9a96c1312cc346b7d2517b84463edd",
         "is_verified": false,
-        "line_number": 73
+        "line_number": 73,
+        "is_secret": false
       },
       {
         "type": "Basic Auth Credentials",
         "filename": ".github/workflows/reusable-test.yml",
         "hashed_secret": "206c80413b9a96c1312cc346b7d2517b84463edd",
         "is_verified": false,
-        "line_number": 127
+        "line_number": 133,
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
         "filename": ".github/workflows/reusable-test.yml",
         "hashed_secret": "8e25a23bca2c45907e35a9f2ced928d63d4b64cc",
         "is_verified": false,
-        "line_number": 284
-      }
-    ],
-    ".github/workflows/staging-deploy.yml": [
-      {
-        "type": "Secret Keyword",
-        "filename": ".github/workflows/staging-deploy.yml",
-        "hashed_secret": "d7881955d3f95738cebb9eceb9d468a0bef6a9ac",
-        "is_verified": false,
-        "line_number": 220
+        "line_number": 290,
+        "is_secret": false
       }
     ],
     ".github/workflows/workflow-coordinator.yml": [
@@ -3333,7 +848,18 @@
         "filename": ".github/workflows/workflow-coordinator.yml",
         "hashed_secret": "3e26d6750975d678acb8fa35a0f69237881576b0",
         "is_verified": false,
-        "line_number": 143
+        "line_number": 143,
+        "is_secret": false
+      }
+    ],
+    "Dockerfile.backend": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "Dockerfile.backend",
+        "hashed_secret": "76e536fe5da8f62021c1622f0fbdaaf753cbad50",
+        "is_verified": false,
+        "line_number": 37,
+        "is_secret": false
       }
     ],
     "alembic.ini": [
@@ -3342,7 +868,8 @@
         "filename": "alembic.ini",
         "hashed_secret": "1727362a714475223abe7282c85576599adc7ff9",
         "is_verified": false,
-        "line_number": 53
+        "line_number": 53,
+        "is_secret": false
       }
     ],
     "backend/api/routers/admin.py": [
@@ -3351,16 +878,48 @@
         "filename": "backend/api/routers/admin.py",
         "hashed_secret": "c3147989a901a5bc5a12b9264d4e21e5a3662d63",
         "is_verified": false,
-        "line_number": 49
+        "line_number": 54,
+        "is_secret": false
       }
     ],
-    "backend/etl/simple_unlimited_extractor.py": [
+    "backend/docs/deployment/PHASE2B_WAVE3AB_COMPLETION.md": [
       {
         "type": "Secret Keyword",
-        "filename": "backend/etl/simple_unlimited_extractor.py",
-        "hashed_secret": "89e495e7941cf9e40e6980d14a16bf023ccd4c91",
+        "filename": "backend/docs/deployment/PHASE2B_WAVE3AB_COMPLETION.md",
+        "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
         "is_verified": false,
-        "line_number": 209
+        "line_number": 26,
+        "is_secret": false
+      }
+    ],
+    "backend/docs/deployment/PHASE2B_WAVE3_COMPLETE.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "backend/docs/deployment/PHASE2B_WAVE3_COMPLETE.md",
+        "hashed_secret": "708283c807604023835484455f642125918d5428",
+        "is_verified": false,
+        "line_number": 77,
+        "is_secret": false
+      }
+    ],
+    "backend/docs/deployment/PHASE2B_WAVE3_PLAN.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "backend/docs/deployment/PHASE2B_WAVE3_PLAN.md",
+        "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
+        "is_verified": false,
+        "line_number": 64,
+        "is_secret": false
+      }
+    ],
+    "backend/scripts/compare_bridge_vs_neon.py": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "backend/scripts/compare_bridge_vs_neon.py",
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_verified": false,
+        "line_number": 101,
+        "is_secret": false
       }
     ],
     "backend/security/audit_logging.py": [
@@ -3369,14 +928,16 @@
         "filename": "backend/security/audit_logging.py",
         "hashed_secret": "94732424e16be827cd46aa294394ab3ce93b55f4",
         "is_verified": false,
-        "line_number": 53
+        "line_number": 53,
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
         "filename": "backend/security/audit_logging.py",
         "hashed_secret": "09fa5c71d9f96b70b0e47ad9760e99a1c30178c8",
         "is_verified": false,
-        "line_number": 248
+        "line_number": 248,
+        "is_secret": false
       }
     ],
     "backend/security/data_encryption.py": [
@@ -3385,7 +946,8 @@
         "filename": "backend/security/data_encryption.py",
         "hashed_secret": "09fa5c71d9f96b70b0e47ad9760e99a1c30178c8",
         "is_verified": false,
-        "line_number": 122
+        "line_number": 123,
+        "is_secret": false
       }
     ],
     "backend/security/enhanced_auth.py": [
@@ -3394,7 +956,8 @@
         "filename": "backend/security/enhanced_auth.py",
         "hashed_secret": "c2d5177df2e8161f398a099222ce551d0594cd34",
         "is_verified": false,
-        "line_number": 237
+        "line_number": 237,
+        "is_secret": false
       }
     ],
     "backend/security/input_validation.py": [
@@ -3403,7 +966,8 @@
         "filename": "backend/security/input_validation.py",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 53
+        "line_number": 53,
+        "is_secret": false
       }
     ],
     "backend/security/rate_limiter.py": [
@@ -3412,7 +976,8 @@
         "filename": "backend/security/rate_limiter.py",
         "hashed_secret": "a613756e030149431b0337e8b3a6c62440eb5ddc",
         "is_verified": false,
-        "line_number": 43
+        "line_number": 43,
+        "is_secret": false
       }
     ],
     "backend/security/secrets_manager.py": [
@@ -3421,14 +986,16 @@
         "filename": "backend/security/secrets_manager.py",
         "hashed_secret": "665b1e3851eefefa3fb878654292f16597d25155",
         "is_verified": false,
-        "line_number": 29
+        "line_number": 29,
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
         "filename": "backend/security/secrets_manager.py",
         "hashed_secret": "b757bced171e74b3a6a02db08bf9e3981b1f47b4",
         "is_verified": false,
-        "line_number": 33
+        "line_number": 33,
+        "is_secret": false
       }
     ],
     "backend/security/secrets_vault.py": [
@@ -3437,28 +1004,32 @@
         "filename": "backend/security/secrets_vault.py",
         "hashed_secret": "665b1e3851eefefa3fb878654292f16597d25155",
         "is_verified": false,
-        "line_number": 31
+        "line_number": 31,
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
         "filename": "backend/security/secrets_vault.py",
         "hashed_secret": "c2d5177df2e8161f398a099222ce551d0594cd34",
         "is_verified": false,
-        "line_number": 34
+        "line_number": 34,
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
         "filename": "backend/security/secrets_vault.py",
         "hashed_secret": "b757bced171e74b3a6a02db08bf9e3981b1f47b4",
         "is_verified": false,
-        "line_number": 35
+        "line_number": 35,
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
         "filename": "backend/security/secrets_vault.py",
         "hashed_secret": "76250810404b5ed0dd9b193bda7278d7f166a664",
         "is_verified": false,
-        "line_number": 37
+        "line_number": 37,
+        "is_secret": false
       }
     ],
     "backend/security/security_config.py": [
@@ -3467,7 +1038,8 @@
         "filename": "backend/security/security_config.py",
         "hashed_secret": "9f0eebb9374c9b37602b8a2d8533283ec4d7165b",
         "is_verified": false,
-        "line_number": 160
+        "line_number": 223,
+        "is_secret": false
       }
     ],
     "backend/tests/README.md": [
@@ -3476,30 +1048,8 @@
         "filename": "backend/tests/README.md",
         "hashed_secret": "c94d65f02a652d11c2e5c2e1ccf38dce5a076e1e",
         "is_verified": false,
-        "line_number": 321
-      }
-    ],
-    "backend/tests/async_fixtures.py": [
-      {
-        "type": "Basic Auth Credentials",
-        "filename": "backend/tests/async_fixtures.py",
-        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
-        "is_verified": false,
-        "line_number": 32
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "backend/tests/async_fixtures.py",
-        "hashed_secret": "837366bbabb40e2f9cc5e99a61332ef9c8fc5c39",
-        "is_verified": false,
-        "line_number": 173
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "backend/tests/async_fixtures.py",
-        "hashed_secret": "f409ce90a1cd144912d1df8620215b2dc9fda731",
-        "is_verified": false,
-        "line_number": 276
+        "line_number": 328,
+        "is_secret": false
       }
     ],
     "backend/tests/conftest.py": [
@@ -3508,60 +1058,50 @@
         "filename": "backend/tests/conftest.py",
         "hashed_secret": "6731834487e9dd32ec3df63994d996da1133dbb9",
         "is_verified": false,
-        "line_number": 290
+        "line_number": 468,
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
         "filename": "backend/tests/conftest.py",
         "hashed_secret": "4a6114be939b701c15f42fcdcf7d6c3f56608f03",
         "is_verified": false,
-        "line_number": 291
+        "line_number": 469,
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
         "filename": "backend/tests/conftest.py",
         "hashed_secret": "e52a263d7d2fc7c885d16aeb84553e56815d8ade",
         "is_verified": false,
-        "line_number": 292
+        "line_number": 470,
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
         "filename": "backend/tests/conftest.py",
         "hashed_secret": "e8ad13de19abbd411192686c409c9dfbb401af21",
         "is_verified": false,
-        "line_number": 293
+        "line_number": 471,
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
         "filename": "backend/tests/conftest.py",
         "hashed_secret": "9e32d3fe5d516fe232bfaab01d66436ce6e76d5e",
         "is_verified": false,
-        "line_number": 294
+        "line_number": 472,
+        "is_secret": false
       }
     ],
-    "backend/tests/integration/test_auth_to_portfolio_flow.py": [
+    "backend/tests/integration/test_news_router.py": [
       {
         "type": "Secret Keyword",
-        "filename": "backend/tests/integration/test_auth_to_portfolio_flow.py",
-        "hashed_secret": "c18006fc138809314751cd1991f1e0b820fabd37",
+        "filename": "backend/tests/integration/test_news_router.py",
+        "hashed_secret": "6318553899daae2941718c02508aeee938af1a1c",
         "is_verified": false,
-        "line_number": 158
-      }
-    ],
-    "backend/tests/integration/test_gdpr_data_lifecycle.py": [
-      {
-        "type": "Secret Keyword",
-        "filename": "backend/tests/integration/test_gdpr_data_lifecycle.py",
-        "hashed_secret": "463d8353f4b927fd953e5af7c41084183e8ce5fb",
-        "is_verified": false,
-        "line_number": 203
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "backend/tests/integration/test_gdpr_data_lifecycle.py",
-        "hashed_secret": "c18006fc138809314751cd1991f1e0b820fabd37",
-        "is_verified": false,
-        "line_number": 375
+        "line_number": 38,
+        "is_secret": false
       }
     ],
     "backend/tests/integration/test_phase3_integration.py": [
@@ -3570,16 +1110,26 @@
         "filename": "backend/tests/integration/test_phase3_integration.py",
         "hashed_secret": "7288edd0fc3ffcbe93a0cf06e3568e28521687bc",
         "is_verified": false,
-        "line_number": 125
+        "line_number": 159,
+        "is_secret": false
       }
     ],
-    "backend/tests/test_comprehensive_units.py": [
+    "backend/tests/security/test_jwt_single_verifier_201.py": [
       {
         "type": "Secret Keyword",
-        "filename": "backend/tests/test_comprehensive_units.py",
-        "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
+        "filename": "backend/tests/security/test_jwt_single_verifier_201.py",
+        "hashed_secret": "1532d323d3cdbc3b0475b7fa6d19a513cffe6264",
         "is_verified": false,
-        "line_number": 351
+        "line_number": 174,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "backend/tests/security/test_jwt_single_verifier_201.py",
+        "hashed_secret": "69e62acd366b967810c3760867e807f5c095f5ec",
+        "is_verified": false,
+        "line_number": 175,
+        "is_secret": false
       }
     ],
     "backend/tests/test_data_pipeline_integration.py": [
@@ -3588,23 +1138,18 @@
         "filename": "backend/tests/test_data_pipeline_integration.py",
         "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
         "is_verified": false,
-        "line_number": 160
+        "line_number": 174,
+        "is_secret": false
       }
     ],
     "backend/tests/test_database_integration.py": [
-      {
-        "type": "Basic Auth Credentials",
-        "filename": "backend/tests/test_database_integration.py",
-        "hashed_secret": "c94d65f02a652d11c2e5c2e1ccf38dce5a076e1e",
-        "is_verified": false,
-        "line_number": 46
-      },
       {
         "type": "Secret Keyword",
         "filename": "backend/tests/test_database_integration.py",
         "hashed_secret": "6318553899daae2941718c02508aeee938af1a1c",
         "is_verified": false,
-        "line_number": 586
+        "line_number": 626,
+        "is_secret": false
       }
     ],
     "backend/tests/test_error_scenarios.py": [
@@ -3613,7 +1158,18 @@
         "filename": "backend/tests/test_error_scenarios.py",
         "hashed_secret": "86f8358eb7679df11d700c05d55add124da76009",
         "is_verified": false,
-        "line_number": 37
+        "line_number": 60,
+        "is_secret": false
+      }
+    ],
+    "backend/tests/test_register_populates_username.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "backend/tests/test_register_populates_username.py",
+        "hashed_secret": "544be59237b06209cd71d6009fd33baef79465b6",
+        "is_verified": false,
+        "line_number": 53,
+        "is_secret": false
       }
     ],
     "backend/tests/test_security_compliance.py": [
@@ -3622,35 +1178,40 @@
         "filename": "backend/tests/test_security_compliance.py",
         "hashed_secret": "7a17bc9911a8d3f78c5da0d68d79590d24f1123f",
         "is_verified": false,
-        "line_number": 62
+        "line_number": 74,
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
         "filename": "backend/tests/test_security_compliance.py",
         "hashed_secret": "1089adfb1f11b95df31344030507912b5abdf57a",
         "is_verified": false,
-        "line_number": 68
+        "line_number": 80,
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
         "filename": "backend/tests/test_security_compliance.py",
         "hashed_secret": "c6b874752d7c09d9f7caa3e126d0836877003cea",
         "is_verified": false,
-        "line_number": 139
+        "line_number": 151,
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
         "filename": "backend/tests/test_security_compliance.py",
         "hashed_secret": "58067b8a42c8ab7ab31c772db28262524326f1dc",
         "is_verified": false,
-        "line_number": 463
+        "line_number": 475,
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
         "filename": "backend/tests/test_security_compliance.py",
         "hashed_secret": "05889347b75921b747847832df32a209a0321aec",
         "is_verified": false,
-        "line_number": 501
+        "line_number": 513,
+        "is_secret": false
       }
     ],
     "backend/tests/test_security_integration.py": [
@@ -3659,35 +1220,40 @@
         "filename": "backend/tests/test_security_integration.py",
         "hashed_secret": "e5e9fa1ba31ecd1ae84f75caaa474f3a663f05f4",
         "is_verified": false,
-        "line_number": 114
+        "line_number": 141,
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
         "filename": "backend/tests/test_security_integration.py",
         "hashed_secret": "f274c2abfc310b23431ce4cbea830e7f76b06042",
         "is_verified": false,
-        "line_number": 142
+        "line_number": 170,
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
         "filename": "backend/tests/test_security_integration.py",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 169
+        "line_number": 206,
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
         "filename": "backend/tests/test_security_integration.py",
         "hashed_secret": "a4b48a81cdab1e1a5dd37907d6c85ca1c61ddc7c",
         "is_verified": false,
-        "line_number": 429
+        "line_number": 507,
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
         "filename": "backend/tests/test_security_integration.py",
         "hashed_secret": "3179a65eff2523bbde53c99b299b719c10a35235",
         "is_verified": false,
-        "line_number": 444
+        "line_number": 521,
+        "is_secret": false
       }
     ],
     "backend/tests/test_thesis_api.py": [
@@ -3696,16 +1262,192 @@
         "filename": "backend/tests/test_thesis_api.py",
         "hashed_secret": "e24114b7e08681dc91c43a0a76e8b7c14f8c2fb8",
         "is_verified": false,
-        "line_number": 305
+        "line_number": 307,
+        "is_secret": false
       }
     ],
-    "backend/tests/test_websocket_integration.py": [
+    "backend/tests/unit/test_admin_service.py": [
       {
         "type": "Secret Keyword",
-        "filename": "backend/tests/test_websocket_integration.py",
-        "hashed_secret": "0ea1e65c276f457fa82a25f563643f30b9f6edab",
+        "filename": "backend/tests/unit/test_admin_service.py",
+        "hashed_secret": "dd53ada48334bf2ee8bf49bcbef43c1d6b6b39d7",
         "is_verified": false,
-        "line_number": 32
+        "line_number": 561,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "backend/tests/unit/test_admin_service.py",
+        "hashed_secret": "070088e08ae5ddf383a9050b4b9ca69d3540b439",
+        "is_verified": false,
+        "line_number": 600,
+        "is_secret": false
+      }
+    ],
+    "backend/tests/unit/test_compare_bridge_vs_neon.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "backend/tests/unit/test_compare_bridge_vs_neon.py",
+        "hashed_secret": "775d6dc72d0e45dfe8fceec280f139a15d7fc370",
+        "is_verified": false,
+        "line_number": 195,
+        "is_secret": false
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "backend/tests/unit/test_compare_bridge_vs_neon.py",
+        "hashed_secret": "f3bbbd66a63d4bf1747940578ec3d0103530e21d",
+        "is_verified": false,
+        "line_number": 195,
+        "is_secret": false
+      }
+    ],
+    "backend/tests/unit/test_data_ingestion.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "backend/tests/unit/test_data_ingestion.py",
+        "hashed_secret": "69bc9d437b8ae4a9de7cee84bcc31e623b1e585f",
+        "is_verified": false,
+        "line_number": 259,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "backend/tests/unit/test_data_ingestion.py",
+        "hashed_secret": "2bdd7e619fb9139fe3b73373d5976762a48ae9a5",
+        "is_verified": false,
+        "line_number": 278,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "backend/tests/unit/test_data_ingestion.py",
+        "hashed_secret": "27bf0f601515ecabbc185172c59f15f523a666c7",
+        "is_verified": false,
+        "line_number": 452,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "backend/tests/unit/test_data_ingestion.py",
+        "hashed_secret": "b8111f4b658dc4eedc260536a952a86fd5a527cc",
+        "is_verified": false,
+        "line_number": 715,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "backend/tests/unit/test_data_ingestion.py",
+        "hashed_secret": "00942f4668670f34c5943cf52c7ef3139fe2b8d6",
+        "is_verified": false,
+        "line_number": 742,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "backend/tests/unit/test_data_ingestion.py",
+        "hashed_secret": "8c7e2e23e2dbf32cefa9eb8fbbb18d754672702e",
+        "is_verified": false,
+        "line_number": 1091,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "backend/tests/unit/test_data_ingestion.py",
+        "hashed_secret": "51d64cc68f24a8a604e98bcaf2a05668bf53baa3",
+        "is_verified": false,
+        "line_number": 1122,
+        "is_secret": false
+      }
+    ],
+    "backend/tests/unit/test_ml_extended_agent1.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/tests/unit/test_ml_extended_agent1.py",
+        "hashed_secret": "e8e6c2284ab5bee4de2ee53880c8fc2a4728d3e8",
+        "is_verified": false,
+        "line_number": 864,
+        "is_secret": false
+      }
+    ],
+    "backend/tests/unit/test_monitoring_extended_agent4.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "backend/tests/unit/test_monitoring_extended_agent4.py",
+        "hashed_secret": "fe1bae27cb7c1fb823f496f286e78f1d2ae87734",
+        "is_verified": false,
+        "line_number": 1114,
+        "is_secret": false
+      }
+    ],
+    "backend/tests/unit/test_realtime_price_service.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "backend/tests/unit/test_realtime_price_service.py",
+        "hashed_secret": "d58f8c42247f1cf100bf63f196d93d7d302e8ca9",
+        "is_verified": false,
+        "line_number": 74,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "backend/tests/unit/test_realtime_price_service.py",
+        "hashed_secret": "e9b4dce312643ee0e1bd0561a50d9d5a7e5a2be1",
+        "is_verified": false,
+        "line_number": 81,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "backend/tests/unit/test_realtime_price_service.py",
+        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
+        "is_verified": false,
+        "line_number": 87,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "backend/tests/unit/test_realtime_price_service.py",
+        "hashed_secret": "71fdbe9f60b1157a53c18b7ec93d4041d828aaad",
+        "is_verified": false,
+        "line_number": 689,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "backend/tests/unit/test_realtime_price_service.py",
+        "hashed_secret": "f5fa40b41964c9b19dd2b53884936a1236b8cb45",
+        "is_verified": false,
+        "line_number": 692,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "backend/tests/unit/test_realtime_price_service.py",
+        "hashed_secret": "a62f2225bf70bfaccbc7f1ef2a397836717377de",
+        "is_verified": false,
+        "line_number": 918,
+        "is_secret": false
+      }
+    ],
+    "backend/tests/unit/test_repositories_unit.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "backend/tests/unit/test_repositories_unit.py",
+        "hashed_secret": "6318553899daae2941718c02508aeee938af1a1c",
+        "is_verified": false,
+        "line_number": 104,
+        "is_secret": false
+      }
+    ],
+    "backend/tests/utils/test_db_pool_budget_202.py": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "backend/tests/utils/test_db_pool_budget_202.py",
+        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
+        "is_verified": false,
+        "line_number": 42,
+        "is_secret": false
       }
     ],
     "backend/utils/audit_logger.py": [
@@ -3714,39 +1456,24 @@
         "filename": "backend/utils/audit_logger.py",
         "hashed_secret": "d58ae0e827d7dab9086299add9adebf5a64c501d",
         "is_verified": false,
-        "line_number": 27
+        "line_number": 27,
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
         "filename": "backend/utils/audit_logger.py",
         "hashed_secret": "6d2617864a346482238c04342cf8409cd25e3a69",
         "is_verified": false,
-        "line_number": 49
+        "line_number": 49,
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
         "filename": "backend/utils/audit_logger.py",
         "hashed_secret": "8ef2e57d0ea7ff8a45aff4e3696922b1848860da",
         "is_verified": false,
-        "line_number": 50
-      }
-    ],
-    "backend/utils/bulk_data_loader.py": [
-      {
-        "type": "Secret Keyword",
-        "filename": "backend/utils/bulk_data_loader.py",
-        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
-        "is_verified": false,
-        "line_number": 618
-      }
-    ],
-    "backend/utils/database_maintenance.py": [
-      {
-        "type": "Secret Keyword",
-        "filename": "backend/utils/database_maintenance.py",
-        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
-        "is_verified": false,
-        "line_number": 897
+        "line_number": 50,
+        "is_secret": false
       }
     ],
     "backend/utils/db_read_replicas.py": [
@@ -3755,7 +1482,8 @@
         "filename": "backend/utils/db_read_replicas.py",
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_verified": false,
-        "line_number": 257
+        "line_number": 358,
+        "is_secret": false
       }
     ],
     "backend/utils/db_timescale_init.py": [
@@ -3764,25 +1492,8 @@
         "filename": "backend/utils/db_timescale_init.py",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 29
-      }
-    ],
-    "backend/utils/materialized_views.py": [
-      {
-        "type": "Basic Auth Credentials",
-        "filename": "backend/utils/materialized_views.py",
-        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
-        "is_verified": false,
-        "line_number": 29
-      }
-    ],
-    "backend/utils/query_optimizer.py": [
-      {
-        "type": "Secret Keyword",
-        "filename": "backend/utils/query_optimizer.py",
-        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
-        "is_verified": false,
-        "line_number": 624
+        "line_number": 29,
+        "is_secret": false
       }
     ],
     "config/infrastructure/kubernetes/deployment.yaml": [
@@ -3791,14 +1502,16 @@
         "filename": "config/infrastructure/kubernetes/deployment.yaml",
         "hashed_secret": "3c6959bf80f9b372229b50587a3758ec34b2970f",
         "is_verified": false,
-        "line_number": 358
+        "line_number": 358,
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
         "filename": "config/infrastructure/kubernetes/deployment.yaml",
         "hashed_secret": "1e8c7bc56a8fd805c4fe8d8652a8c444d6e8a448",
         "is_verified": false,
-        "line_number": 412
+        "line_number": 412,
+        "is_secret": false
       }
     ],
     "config/infrastructure/kubernetes/secrets-sealed.yaml": [
@@ -3807,7 +1520,8 @@
         "filename": "config/infrastructure/kubernetes/secrets-sealed.yaml",
         "hashed_secret": "f468241914a8402fe764eb2ed584a13aa6288515",
         "is_verified": false,
-        "line_number": 53
+        "line_number": 53,
+        "is_secret": false
       }
     ],
     "data_pipelines/airflow/dags/utils/technical_indicators_calculator.py": [
@@ -3816,7 +1530,8 @@
         "filename": "data_pipelines/airflow/dags/utils/technical_indicators_calculator.py",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 638
+        "line_number": 638,
+        "is_secret": false
       }
     ],
     "data_pipelines/airflow/dags/utils/test_technical_indicators.py": [
@@ -3825,9723 +1540,8 @@
         "filename": "data_pipelines/airflow/dags/utils/test_technical_indicators.py",
         "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
         "is_verified": false,
-        "line_number": 64
-      }
-    ],
-    "datasets/investment-analysis-platform/agents/state.json": [
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/agents/state.json",
-        "hashed_secret": "c7c1abee23987269e97805a4c845fc0f1fd101a5",
-        "is_verified": false,
-        "line_number": 7
-      }
-    ],
-    "datasets/investment-analysis-platform/api_endpoints/state.json": [
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/api_endpoints/state.json",
-        "hashed_secret": "bfa8e08fb2562700ebab5dd9c95e0c6d70bd32d8",
-        "is_verified": false,
-        "line_number": 7
-      }
-    ],
-    "datasets/investment-analysis-platform/codebase/state.json": [
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/codebase/state.json",
-        "hashed_secret": "dc89990cb8f0190c4bb26235ececb4d77084093e",
-        "is_verified": false,
-        "line_number": 7
-      }
-    ],
-    "datasets/investment-analysis-platform/json_exports/codebase.json": [
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "1403f57da3369ac5526e38affdb7376d2165e5d2",
-        "is_verified": false,
-        "line_number": 9
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "1626a4795c4876d0f9e65bda50060d908a530a0e",
-        "is_verified": false,
-        "line_number": 19
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "7a1ac4a5b565aad9fba8e4377e50539292382a95",
-        "is_verified": false,
-        "line_number": 29
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "89d4b132adee2864b827ffcc543d124910eada69",
-        "is_verified": false,
-        "line_number": 39
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "ab21689e87fb95a926631ff01304aff8b155a216",
-        "is_verified": false,
-        "line_number": 49
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "8d38d44d60a7832298de01c9dc3556a7475c275c",
-        "is_verified": false,
-        "line_number": 59
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "512af6aae431bfabb87c4ecb19ce101c3754a845",
-        "is_verified": false,
-        "line_number": 69
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "b2f7296a571f7af9c27b5b2e3e8e22a0add337ac",
-        "is_verified": false,
-        "line_number": 79
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "67a74306b06d0c01624fe0d0249a570f4d093747",
-        "is_verified": false,
-        "line_number": 89
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "183b37b827d6777ef8f45971a7063d8f60b8a872",
-        "is_verified": false,
-        "line_number": 99
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "cf9d7c6ba43642edbb6a4a7796756fb1b8cf46a2",
-        "is_verified": false,
-        "line_number": 109
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "bd739ad9396ae7dd3adaffd7a5a3c9abff887af2",
-        "is_verified": false,
-        "line_number": 119
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "db505603b42312c1d86f96a57807e764794bbc90",
-        "is_verified": false,
-        "line_number": 129
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "23f029efbe7aaa84143c366494b7e6d12b403d19",
-        "is_verified": false,
-        "line_number": 139
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "b5f16f5a2605ee6d8b5e85f2ae872b40c4799a95",
-        "is_verified": false,
-        "line_number": 149
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "fee823ba4116d2fdbe5095efabfbc92f1217c363",
-        "is_verified": false,
-        "line_number": 159
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "27e5be0fb9f1cb470557f7896d6a36ece1a9e180",
-        "is_verified": false,
-        "line_number": 169
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "ba8d23fc04e1476939d450fa8049f3fe245126ac",
-        "is_verified": false,
-        "line_number": 179
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "6bf3dc6e24364c47dfabdb1a4012cfa5c2ae5e0c",
-        "is_verified": false,
-        "line_number": 189
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "8c0a7062e766256dfad6ec4e8c97c71439ad67d8",
-        "is_verified": false,
-        "line_number": 199
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "4b45e7a8d29195a75c9571123f6cfa29cf4a8322",
-        "is_verified": false,
-        "line_number": 209
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "99fb79380ed5df400fe3897ea47de26f220719bf",
-        "is_verified": false,
-        "line_number": 219
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "8ae043d901668b76e9a05d9397d77eb934d25456",
-        "is_verified": false,
-        "line_number": 229
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "4a1c4b9c8c92d9aa097746ee9c7380464c09f0a9",
-        "is_verified": false,
-        "line_number": 239
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "6981a7bcc1996ea6a9f44b141975aa688e4d5435",
-        "is_verified": false,
-        "line_number": 249
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "af3cd75a89e42b330b8cc4e986f0b2e6e67d79f6",
-        "is_verified": false,
-        "line_number": 259
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "ca4e181230e194c8f9ba7312a0a0be4c46756c17",
-        "is_verified": false,
-        "line_number": 269
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "1e3335f10ffe13e4485fcdea04b0453f7fab7d1e",
-        "is_verified": false,
-        "line_number": 279
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "7f1c21e1e3552032ff9a0f92aa991b9d386f766c",
-        "is_verified": false,
-        "line_number": 289
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "32015ffa3e2c448b5dfe684d6eb9565bcb130e83",
-        "is_verified": false,
-        "line_number": 299
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "5c64d2cfebfb64bd05b79c78a4012df35e93f99e",
-        "is_verified": false,
-        "line_number": 309
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "42f9b72b94b7d7e2cf8efd3bb6ef65827fde78ff",
-        "is_verified": false,
-        "line_number": 319
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "5fe8eed1094c2191834dee23ebf0bbb8758524f6",
-        "is_verified": false,
-        "line_number": 329
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "f87aaefbe04274c7bf12334adeb7199c103153f6",
-        "is_verified": false,
-        "line_number": 339
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "cecfa9d25b7154d670e91a0820db44dea9d2f92d",
-        "is_verified": false,
-        "line_number": 349
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "1764342f10d3556911b5b8eb73c031cd6c7a9b3f",
-        "is_verified": false,
-        "line_number": 359
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "f61497461abd246ba3ff47abd1d91a6e385e0e14",
-        "is_verified": false,
-        "line_number": 369
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "98d463d1fd994c572fd77ba05d502f1c9d2d9351",
-        "is_verified": false,
-        "line_number": 379
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "ee3f3b81372a5a304a118f9164099c95efd612f7",
-        "is_verified": false,
-        "line_number": 389
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "096871460f3ac845e3224d8d1cb6c36cf45ca06f",
-        "is_verified": false,
-        "line_number": 399
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "e6eacfcb5f752272c0ba94390fa16bbe1b97894b",
-        "is_verified": false,
-        "line_number": 409
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "db1d53ed08e98e2dac24728d361d0bd996cf9caa",
-        "is_verified": false,
-        "line_number": 419
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "84fe7160e436392f948c024945b068a5161c0887",
-        "is_verified": false,
-        "line_number": 429
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "0ff6cc8cd81dda376d2acadd0afe0339610fef4b",
-        "is_verified": false,
-        "line_number": 439
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "35aa0862174dee6f6c481606a683039dbaf67969",
-        "is_verified": false,
-        "line_number": 449
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "fb090c22a2658bfb1e90443c8e4af755754936a0",
-        "is_verified": false,
-        "line_number": 459
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "dc1f7bb2820ea4a73042398a463c9917f44b84bd",
-        "is_verified": false,
-        "line_number": 469
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "de285da712218316f7c90cbe0eb175e574e2ef75",
-        "is_verified": false,
-        "line_number": 479
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "bf98004f908d72452f6a9c1ede3e8a0859b76f71",
-        "is_verified": false,
-        "line_number": 489
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "db162bae05b5193579fd776f22f983140e4b060d",
-        "is_verified": false,
-        "line_number": 499
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "66694f0b001df2aaebdc74e6a9fd5e2495f03ab7",
-        "is_verified": false,
-        "line_number": 509
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "84afdae3c672943b51c80cc03e177558b72a0ec1",
-        "is_verified": false,
-        "line_number": 519
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "58aefd242d6d0f1937ca81ff4a0f1580314c34a6",
-        "is_verified": false,
-        "line_number": 529
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "d680b201e0bc28bb6ada3bdacfce7c9c9f49d8e5",
-        "is_verified": false,
-        "line_number": 539
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "57420f41db2235bfb3b5eddd2e85ac20f4c7ee12",
-        "is_verified": false,
-        "line_number": 549
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "3b5e3a3608b1a0ccd604b8c48c07806b12938fbe",
-        "is_verified": false,
-        "line_number": 559
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "23fdc34a4c922a4a7396525db9b2497bcb08544d",
-        "is_verified": false,
-        "line_number": 569
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "b601b5fc671f89001c2bb0618da610e66ea3ee6a",
-        "is_verified": false,
-        "line_number": 579
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "0f6f954ed0be7e73eaecaf9248320e57723e8685",
-        "is_verified": false,
-        "line_number": 589
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "c20bca0250caf78f273577fda05474d1bd636bbe",
-        "is_verified": false,
-        "line_number": 599
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "e0e98f38cb5c17618ff12863b4f85c3ce605bb34",
-        "is_verified": false,
-        "line_number": 609
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "05119629074d13ae63da3bfcb7c8995ef7baa87e",
-        "is_verified": false,
-        "line_number": 619
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "04cce33e35294046afbfe3636b25f8f49d92e2a1",
-        "is_verified": false,
-        "line_number": 629
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "2aadb5b9046bf3eed6cf001026526f046283e1c3",
-        "is_verified": false,
-        "line_number": 639
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "b1bd72240a90cbe7f711542c7068f9c1e5129990",
-        "is_verified": false,
-        "line_number": 649
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "22c54972a076524531814aed448a9fc33d7559d0",
-        "is_verified": false,
-        "line_number": 669
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "03c9ea031940091db636c6f0043f21804ff9cf39",
-        "is_verified": false,
-        "line_number": 679
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "908e4de9d4f133b0ebf3d8146e4aeb35d8fe8575",
-        "is_verified": false,
-        "line_number": 689
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "cb33378696821b3f4ffc1a9bc415ef957dc891cd",
-        "is_verified": false,
-        "line_number": 699
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "71d1f00f5de9e4e197e48a510e249e29da2c9c9e",
-        "is_verified": false,
-        "line_number": 709
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "75f4e4c685b06eb2186af9aad80ceb07b56713dc",
-        "is_verified": false,
-        "line_number": 719
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "8ce772285cec256eeffd7e92fd585d4ac97c3156",
-        "is_verified": false,
-        "line_number": 729
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "799c06e43b8b5d91361d33e3f16b529a0ecdea93",
-        "is_verified": false,
-        "line_number": 739
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "4b6f29581704918cc5e2edbbb4e341dcefb4aab0",
-        "is_verified": false,
-        "line_number": 749
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "1f0b67d2b16cba45e586240f397ea0e931bf0e94",
-        "is_verified": false,
-        "line_number": 759
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "ada04a84ac7fc84e71df1dafb35a9786392e9e2f",
-        "is_verified": false,
-        "line_number": 769
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "193a8de8225bbabfcd74e7f230278026124a1f03",
-        "is_verified": false,
-        "line_number": 779
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "4ae20e86d4d25675530f6e337f0c299857051692",
-        "is_verified": false,
-        "line_number": 789
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "b597f5452dbc54cf39e906fc64f1a7f225227018",
-        "is_verified": false,
-        "line_number": 799
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "bd13876654ed83443e25af4bdb1b6d1fe99d2cfb",
-        "is_verified": false,
-        "line_number": 809
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "9245bb9fa1d0ccfeae646076750e2a03e63860ef",
-        "is_verified": false,
-        "line_number": 819
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "0cca00085ca692287d20955b21f002f3dc818ce9",
-        "is_verified": false,
-        "line_number": 829
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "c3238b3641f1d963527507c7238f549a4815e353",
-        "is_verified": false,
-        "line_number": 839
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "b2fc727aa80fbed2b4ddb7e9a478aeea2917515c",
-        "is_verified": false,
-        "line_number": 849
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "ad779b8bf07ce132c567ff649f0b75bd99c02ec3",
-        "is_verified": false,
-        "line_number": 869
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "80dece7a7430fff22e3960f35c1fc6b31e1ce29e",
-        "is_verified": false,
-        "line_number": 879
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "ffba91996e005347ac5f4575302a848b589a7448",
-        "is_verified": false,
-        "line_number": 889
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "a72322b3a4fd3086539cb2dca7cf0a4e87d8debb",
-        "is_verified": false,
-        "line_number": 899
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "db430814491dc66117b5e049307c3b68ade75f06",
-        "is_verified": false,
-        "line_number": 909
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "938ec1af51e982a9ab0ed525c108366ccf5116b5",
-        "is_verified": false,
-        "line_number": 919
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "5961f100d1d62ce954e62d43469937d7fc164048",
-        "is_verified": false,
-        "line_number": 929
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "e19c6a6567604c479b68b314cf2fa426a327529a",
-        "is_verified": false,
-        "line_number": 949
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "d36614bafd736537030b199787857c33b0e7bef9",
-        "is_verified": false,
-        "line_number": 959
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "e720fa1373d91952e4b6972e52c7b8fb5c88db68",
-        "is_verified": false,
-        "line_number": 969
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "5769cc7a5890385fecc568f405a65034e754ffa2",
-        "is_verified": false,
-        "line_number": 979
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "f8ce3f83e498437ac9163b628feaeb5c42873c82",
-        "is_verified": false,
-        "line_number": 989
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "03669d853da0238e9744d0e1f816fa80481c7e45",
-        "is_verified": false,
-        "line_number": 999
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "6a93f9227135a2758d5c61eb679706fbf853177f",
-        "is_verified": false,
-        "line_number": 1009
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "e3bdff122059288d4f38564d0ccc5ad99afe60cd",
-        "is_verified": false,
-        "line_number": 1019
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "5a69aa21c3c5f96a673c5f1d4b2bd57812607ca1",
-        "is_verified": false,
-        "line_number": 1029
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "4eece543bf7898a17d16c73a0342df0593a5e8b4",
-        "is_verified": false,
-        "line_number": 1039
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "bbb41b7a00754aef5dffe529c73589c2d590efd6",
-        "is_verified": false,
-        "line_number": 1049
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "232e78b7a6251eec10c1b6571539be352e06b765",
-        "is_verified": false,
-        "line_number": 1059
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "6b74b7e56eefacf181961cb66a448e9c107b26b3",
-        "is_verified": false,
-        "line_number": 1069
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "8e4e29d5a1b3937295688c2c5e196fa63a7bcaab",
-        "is_verified": false,
-        "line_number": 1089
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "9120b98382a3bf2a6c6745ddf4220e784a4551cc",
-        "is_verified": false,
-        "line_number": 1099
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "32fa59a9939c29b9ab9ef1cf8e59fed0a213f044",
-        "is_verified": false,
-        "line_number": 1109
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "870522bd1e5f8116112b4b3e1bc5d0134b147591",
-        "is_verified": false,
-        "line_number": 1119
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "0ee72c0f40f45474773986afa1d993cd2d02941b",
-        "is_verified": false,
-        "line_number": 1129
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "90c1e92590375c77a88ee50478280dac5be64924",
-        "is_verified": false,
-        "line_number": 1139
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "8b16b2209813a445dfb7917a2f999cc1271e1739",
-        "is_verified": false,
-        "line_number": 1149
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "487b69263b5ab4f1674b62c7b93380e801fa27e2",
-        "is_verified": false,
-        "line_number": 1159
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "f6ab5a953c89e7026a177fa12613b736d6697844",
-        "is_verified": false,
-        "line_number": 1169
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "f8509c971bbc26b9e52d096514fe1ebb7ded3262",
-        "is_verified": false,
-        "line_number": 1179
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "255b51aaf10d45119c2802f26c3b5c9ba5250f00",
-        "is_verified": false,
-        "line_number": 1189
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "7ba19bf9adfc2a32ca21d85c5aa95fc380f08dd6",
-        "is_verified": false,
-        "line_number": 1199
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "912ddb31c27da1f00c2e8fe62f7bfdd01ea7a2a1",
-        "is_verified": false,
-        "line_number": 1209
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "8a39bfa724d8292026167f4c14985d0980ec081f",
-        "is_verified": false,
-        "line_number": 1219
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "e624c59a9ef247771262fb5842658032cb8eb753",
-        "is_verified": false,
-        "line_number": 1229
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "4b8a984428177589ea83b28a7ae824ec1ebeeca0",
-        "is_verified": false,
-        "line_number": 1249
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "eb62d8f0dcd5c4a90802edae749ebb3caa6d4d68",
-        "is_verified": false,
-        "line_number": 1259
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "fcf8e58606d2ee85a099e3fe65b0c1e017ae5aeb",
-        "is_verified": false,
-        "line_number": 1269
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "56c858ebfa6599e4ef054a634865836cae8e2168",
-        "is_verified": false,
-        "line_number": 1279
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "6302a000b97887fd99763fb0fa80a41b17915707",
-        "is_verified": false,
-        "line_number": 1289
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "0c927007e6b5946569c455068a30ee8ead3fb1b6",
-        "is_verified": false,
-        "line_number": 1299
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "70b6ef2111a275f4b5d0a8e75d2df8c4785cf3df",
-        "is_verified": false,
-        "line_number": 1309
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "929e764cb5e631daf7c7fc2deac5cd6226dd6117",
-        "is_verified": false,
-        "line_number": 1319
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "fa7319685bc493447f2aaddd7a6feb357b173065",
-        "is_verified": false,
-        "line_number": 1329
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "2370653a33e6cd2e1d4fa6b91455dee7b6cafd36",
-        "is_verified": false,
-        "line_number": 1339
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "28533502f96620fbb96d18a42bd77805bd61fae5",
-        "is_verified": false,
-        "line_number": 1349
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "2cb81b2439b19570e6ddc57f86443f848d4b94b0",
-        "is_verified": false,
-        "line_number": 1359
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "8172c947be2c55641175e57772fb3d6e0b8f1838",
-        "is_verified": false,
-        "line_number": 1369
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "dc14828ad8fe10a7c58455d33c47599b57320196",
-        "is_verified": false,
-        "line_number": 1379
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "9a95712ea7a1390ddc125c781cd9429de391524c",
-        "is_verified": false,
-        "line_number": 1389
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "35db9ca3f0277714704673c45700e42fc26836c6",
-        "is_verified": false,
-        "line_number": 1399
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "899ee680228dafd695df1ff840b8b4ab921424fa",
-        "is_verified": false,
-        "line_number": 1409
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "47a2881acabb0b502d752fb5ecb14b037109d24e",
-        "is_verified": false,
-        "line_number": 1419
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "60168f672f93221ca2809fbb98cda020d1d8f1c8",
-        "is_verified": false,
-        "line_number": 1429
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "4ac52d1ebcf2be8818a6458218b4422d55c1f41d",
-        "is_verified": false,
-        "line_number": 1439
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "ee2410de162f151ec8f23780ad2ff8fb87fbccbc",
-        "is_verified": false,
-        "line_number": 1449
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "d46a9ae56840c5ebc564b6e953934a3b5291c4bc",
-        "is_verified": false,
-        "line_number": 1459
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "e0cbb63fc7753c428bf0e38506efb2811c97712d",
-        "is_verified": false,
-        "line_number": 1469
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "21fd3ec963eca1bc518a1e2185bfce508359a447",
-        "is_verified": false,
-        "line_number": 1479
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "a40daa11a4f8907028222b1c15e1ba918a9743d6",
-        "is_verified": false,
-        "line_number": 1489
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "7766d526236f06902fc7008ef5fc0721bbed664f",
-        "is_verified": false,
-        "line_number": 1499
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "74763c7e48eafef5f6283c76975e82b3c1cc61d3",
-        "is_verified": false,
-        "line_number": 1509
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "c5f8193f3c6c830ef54ee489132dc101142623f8",
-        "is_verified": false,
-        "line_number": 1519
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "684a9adfdd66bfc8ff0bb517957fc24008d26160",
-        "is_verified": false,
-        "line_number": 1529
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "c18ab5a923272ba32e9d9c4bd6ee7d58ccdb980d",
-        "is_verified": false,
-        "line_number": 1539
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "d0eefaef34247df2bcd96c2c8e1fd992af27352a",
-        "is_verified": false,
-        "line_number": 1549
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "d1c46d59dd530be0dd7efb97f70845896fa221fb",
-        "is_verified": false,
-        "line_number": 1559
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "0821ea65f03c053c2c0a8f3b6e38b12b0ced5add",
-        "is_verified": false,
-        "line_number": 1569
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "066cd1632473c33e55fc9901580800c91e649648",
-        "is_verified": false,
-        "line_number": 1579
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "aed19eb10c6069f291f208ab37903968baa9f47c",
-        "is_verified": false,
-        "line_number": 1589
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "405afb8355fb6868adde6707107f9942389092a1",
-        "is_verified": false,
-        "line_number": 1599
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "ef2346a1a10ad5be62868486df8ef25f45b2b0f4",
-        "is_verified": false,
-        "line_number": 1609
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "7cb35592cc1a1c44cd7a0c540a2c86d3789d2216",
-        "is_verified": false,
-        "line_number": 1619
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "b4568798310813020804da97342d4f7a27a149f4",
-        "is_verified": false,
-        "line_number": 1629
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "17e7233741ee65d8b1ab14a776801ae4dff40ba0",
-        "is_verified": false,
-        "line_number": 1639
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "e945cd0eed8b737f15c5ac2bd4c0f529827fb6f5",
-        "is_verified": false,
-        "line_number": 1649
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "adcbf71982768d1768d1c6ca7d6432d5927e4d17",
-        "is_verified": false,
-        "line_number": 1659
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "a9cee93ec612633dbc6c80f54d7b5b8b562b283f",
-        "is_verified": false,
-        "line_number": 1669
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "c983084166793b26117e89f5c8cd6c995b1e3f93",
-        "is_verified": false,
-        "line_number": 1679
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "11ae61570e1427c3536bebd88b79b7b92217177b",
-        "is_verified": false,
-        "line_number": 1689
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "fbeede1baf5d45ebc4c476137a87e636096210c2",
-        "is_verified": false,
-        "line_number": 1699
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "b8196f06a6be6ec8fa793837073285ef27f9bb90",
-        "is_verified": false,
-        "line_number": 1709
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "38b8560a560172c7458d23fed7ef6b18969f4a39",
-        "is_verified": false,
-        "line_number": 1719
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "3000ab5fe62d69e26940888c59c83ac5803494fe",
-        "is_verified": false,
-        "line_number": 1729
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "7408ec0966d62631c895b962e844f2de378c6d5d",
-        "is_verified": false,
-        "line_number": 1739
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "240835cd22aaad9d736a9e203bd9875d537d4b41",
-        "is_verified": false,
-        "line_number": 1749
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "a8974dd613e53b3a8821421f77e026bd2aff9be6",
-        "is_verified": false,
-        "line_number": 1759
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "40a97dd704832e5b19df6a00e3caa16c38b0b5fa",
-        "is_verified": false,
-        "line_number": 1769
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "b2690857f722611f553e489c76a761de61ea8a84",
-        "is_verified": false,
-        "line_number": 1779
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "791a3a2623a02e669ed2c55e125d3b9e4f85071c",
-        "is_verified": false,
-        "line_number": 1789
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "c1febe565cd95d50fda1f4ff5dd6a55227a2c8af",
-        "is_verified": false,
-        "line_number": 1799
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "f5ff047b5c18899cf1a5cbcbc42a819598ea2fab",
-        "is_verified": false,
-        "line_number": 1809
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "0deda3ac96ff69b2d15f4d5bfc542f548d2d0fb1",
-        "is_verified": false,
-        "line_number": 1819
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "12563ed84f40d78b64128fa0446201512e2a1e3e",
-        "is_verified": false,
-        "line_number": 1829
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "140a4668759c824d65288cd4891255e4b5ce7398",
-        "is_verified": false,
-        "line_number": 1839
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "66da1ef50ac71a18868492847c3508717b592d36",
-        "is_verified": false,
-        "line_number": 1849
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "656d4372ce5c08f274359d93838bd1589b9aaa91",
-        "is_verified": false,
-        "line_number": 1859
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "be4bf6bdbfd88449f018c2530e0be2ab558bc987",
-        "is_verified": false,
-        "line_number": 1869
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "8066e51b42b8fee9c054dd824f8fe2500223e91f",
-        "is_verified": false,
-        "line_number": 1879
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "6e6905ad8501b673510f778f85a6ffd67e851ecf",
-        "is_verified": false,
-        "line_number": 1889
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "6336d6bee35f51e46aab47fcd50de9b99264b1b9",
-        "is_verified": false,
-        "line_number": 1899
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "221aea302825ce0005cc9add1369c489bc0ee9b2",
-        "is_verified": false,
-        "line_number": 1909
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "369419ec2fbd16fdd8117a84f9001d4732972dc8",
-        "is_verified": false,
-        "line_number": 1919
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "9c560f10c1a67125324884d5b5a39de7be2e9208",
-        "is_verified": false,
-        "line_number": 1929
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "b92b8be9512ce220e18e59c3918585f7345ac68d",
-        "is_verified": false,
-        "line_number": 1939
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "0e3ef09ccbaf1094c30b0be76ccef59bdf100f1d",
-        "is_verified": false,
-        "line_number": 1949
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "331f8251da188f3a7083b35458f20fa40c709908",
-        "is_verified": false,
-        "line_number": 1959
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "126a5178b9e0077759d186beab608268ced71f67",
-        "is_verified": false,
-        "line_number": 1969
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "8af5ff81b612b9ec9806c72a78cfd7857f2dcdd2",
-        "is_verified": false,
-        "line_number": 1979
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "9d73c8941f65998082b85667d0fbd774d0bbb0c8",
-        "is_verified": false,
-        "line_number": 1989
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "f9f870fc9386f5c01f04b9d71f7f6f5e411cd63e",
-        "is_verified": false,
-        "line_number": 1999
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "480be5558c9aa55546fa86dcfaeed09e53455a32",
-        "is_verified": false,
-        "line_number": 2009
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "2e95ef6858eaa6aee00e81854b3ebb78f8675111",
-        "is_verified": false,
-        "line_number": 2019
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "b727c8cc3a444a069be748be09fe4221fa1ca6ee",
-        "is_verified": false,
-        "line_number": 2029
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "8541bebd01ab86ed288560fd06acef39dcfe8b52",
-        "is_verified": false,
-        "line_number": 2039
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "31f039cc49a7256c40fadb6b096b6721fb98b6e5",
-        "is_verified": false,
-        "line_number": 2049
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "a3b5a5f25753e10f62d7133ddab273e79f7fae01",
-        "is_verified": false,
-        "line_number": 2059
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "51a8889eb913184eb3efdc2edae6e200f76c78fb",
-        "is_verified": false,
-        "line_number": 2069
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "68f16b016ea3aaad01e1b3a4a9f5f537256a238c",
-        "is_verified": false,
-        "line_number": 2079
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "19663773c702147d8bb37628b480d35106f08c47",
-        "is_verified": false,
-        "line_number": 2089
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "133ec1e649516d54a1bbda9d9327de274682a48b",
-        "is_verified": false,
-        "line_number": 2099
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "44ad69003ed72fc543fb8f03a163dc65dc9ca297",
-        "is_verified": false,
-        "line_number": 2109
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "7c1708ddc46f3faf18ffd9d3f159cb05ab3ca57e",
-        "is_verified": false,
-        "line_number": 2119
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "cb8dd88a891ef1d220127ef2751ac463e7b5d6d0",
-        "is_verified": false,
-        "line_number": 2129
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "07b85f52e7b3858c90a96d49cd30970d8092ba22",
-        "is_verified": false,
-        "line_number": 2139
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "c161b914477caf404dab2ac810f0c73d6478226b",
-        "is_verified": false,
-        "line_number": 2149
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "83952c6afae28ef3f51e2a79b138d3ae0c4a691f",
-        "is_verified": false,
-        "line_number": 2159
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "25831d9132ba0262f22c04bb06b436e575f666c0",
-        "is_verified": false,
-        "line_number": 2169
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "6507d722cbbf1ec8bc77f0b06d115ad760017beb",
-        "is_verified": false,
-        "line_number": 2179
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "68ca8144eafbd104ec12d62146c10212300008f3",
-        "is_verified": false,
-        "line_number": 2189
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "af11f981ba52891c91cdf9089e3ac0331f5d031f",
-        "is_verified": false,
-        "line_number": 2199
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "484f5318e4ec07700beed09d76339ba16b434889",
-        "is_verified": false,
-        "line_number": 2209
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "38eab13726f5a848f1888c67e1deb9e86963b8cd",
-        "is_verified": false,
-        "line_number": 2219
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "df0e2d76a195609a085387c03f4200f51c279dbe",
-        "is_verified": false,
-        "line_number": 2229
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "d844ecdaca7843c18f29dc70f12ee6012f907a1d",
-        "is_verified": false,
-        "line_number": 2239
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "1ba442c925f96b49e10005eb662a737a51700793",
-        "is_verified": false,
-        "line_number": 2249
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "d0857b299a55f1c8fb026e9be3ae83e266ff30fc",
-        "is_verified": false,
-        "line_number": 2259
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "2c43d37aa73e0f2c7af05f5356a01757ee22d4e6",
-        "is_verified": false,
-        "line_number": 2269
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "d6d46e81afb346c3c3f2c4e7f3df662f59810987",
-        "is_verified": false,
-        "line_number": 2279
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "5a1e16febe70cf14165f506510627737f18f290e",
-        "is_verified": false,
-        "line_number": 2289
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "b4dd4bff1c7512e22943cd51afa26d18e5cef2db",
-        "is_verified": false,
-        "line_number": 2299
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "14d5fb60c287d970ae20c560320f114b915e445a",
-        "is_verified": false,
-        "line_number": 2309
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "bf37733af0e60b3966e0d91db678dfc84fa20fb1",
-        "is_verified": false,
-        "line_number": 2319
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "f6c67bd075e34ef2a21f195e140bfdd9df3a7d8d",
-        "is_verified": false,
-        "line_number": 2329
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "11ef64b27ea43b014050b790c160c83cc62b11a9",
-        "is_verified": false,
-        "line_number": 2339
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "408b64668db0250a64e26086d080e8d67883cfc0",
-        "is_verified": false,
-        "line_number": 2349
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "493ce5d89bcdd4bff85392e88b6d6d8ac0cff894",
-        "is_verified": false,
-        "line_number": 2359
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "d66614a87d5985fd7faa1edd2d28833cf430e7d0",
-        "is_verified": false,
-        "line_number": 2379
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "dfa987d2548452f48f0dbe0e7133b5a08dd90c00",
-        "is_verified": false,
-        "line_number": 2389
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "3f26eff0b582ec63d575a038f361a9e788384a79",
-        "is_verified": false,
-        "line_number": 2399
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "d0b4612fb4197942824bea3083d628e4e81b821e",
-        "is_verified": false,
-        "line_number": 2409
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "077dcc080fb33517e758646b2f1ce4a7111661bc",
-        "is_verified": false,
-        "line_number": 2419
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "9549a22939060b051ddc032d4dd09359f12daca2",
-        "is_verified": false,
-        "line_number": 2429
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "5ce50cdc9a53e6ce03a0294d55563437ada54cdf",
-        "is_verified": false,
-        "line_number": 2439
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "92defe88b4c1bafd98aa8135152713ab2a4746a1",
-        "is_verified": false,
-        "line_number": 2449
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "bdbd59e9ff7856cdf63799b3c5871f2921a6e2ea",
-        "is_verified": false,
-        "line_number": 2459
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "12ee2114c7ca4fb2e5cd5d4a91790fff31719d8a",
-        "is_verified": false,
-        "line_number": 2479
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "7c401272b347854a6796f92145c4737d743fc2b5",
-        "is_verified": false,
-        "line_number": 2489
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "62e86346e5cf5ef85e82c79dd1fc907bcdeb306e",
-        "is_verified": false,
-        "line_number": 2499
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "42f1f8cf64b30179c373b3b1c90bc5acea010ee4",
-        "is_verified": false,
-        "line_number": 2509
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "7f66cafabcf25b7656b744aa32fcbb63600a27f6",
-        "is_verified": false,
-        "line_number": 2519
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "247237ad0133d49529dab39e67859258015c0d94",
-        "is_verified": false,
-        "line_number": 2529
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "e7511c670b0aa9075ab376545daf10a15001d5c8",
-        "is_verified": false,
-        "line_number": 2539
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "dafebda34e0f6c679d5c1eb7ba46d91f3ef9c067",
-        "is_verified": false,
-        "line_number": 2549
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "ac8ef062d7b1fa29ba3a8afe4df5a6847d11d438",
-        "is_verified": false,
-        "line_number": 2559
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "e2ab601e62642196e91c9e4c3d0f678c86d9ff14",
-        "is_verified": false,
-        "line_number": 2569
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "1c983711aec49125cb86a5ea5bcc8dadd38afa4d",
-        "is_verified": false,
-        "line_number": 2579
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "ae707b0ef8239545c08b0b102c6a22a4a3c98994",
-        "is_verified": false,
-        "line_number": 2589
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "f2bad75dbca67568a8165600e215dace225ad425",
-        "is_verified": false,
-        "line_number": 2599
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "063329e6778ee600b1f0cc38bf01119b1b9202eb",
-        "is_verified": false,
-        "line_number": 2609
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "4c436a89dd32da9efc471fdd2facb4c1157df9f1",
-        "is_verified": false,
-        "line_number": 2619
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "64a9e798790aa3b9157fec808eb44ff32b5ef34e",
-        "is_verified": false,
-        "line_number": 2629
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "ea7449ad0730034415a796ce92e7964f16824085",
-        "is_verified": false,
-        "line_number": 2639
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "bc89008986a8429c6d7ae29375938e1ba8e81734",
-        "is_verified": false,
-        "line_number": 2649
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "3b9de342a100c8496042e779d62665652a1ef113",
-        "is_verified": false,
-        "line_number": 2659
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "54c3769622699c2f3f393ea5278f23b02118128c",
-        "is_verified": false,
-        "line_number": 2669
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "be389c7c6f8fc3bc10f42c0974a5bfffa5c251ec",
-        "is_verified": false,
-        "line_number": 2689
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "d73f2bdb956935eb4c0d7f79b339c18a6db8c18d",
-        "is_verified": false,
-        "line_number": 2699
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "f586ab78223b443166b3822b99f848f6233ab756",
-        "is_verified": false,
-        "line_number": 2709
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "1397d961b057e34dc5a4914473165567e89a55a1",
-        "is_verified": false,
-        "line_number": 2719
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "eb0584aab9f48c03aac3556c029bcccb7a9859c3",
-        "is_verified": false,
-        "line_number": 2729
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "ed5d637cf6585e79861d96b27a777205d0377881",
-        "is_verified": false,
-        "line_number": 2739
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "5eec72ec3b6d9c33e6847a442c49c04a21f28f31",
-        "is_verified": false,
-        "line_number": 2749
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "a1a8db7d5acbfa3a5a64b9bf042b236b42a428d3",
-        "is_verified": false,
-        "line_number": 2759
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "646574b370db731599b364decaad0c65070a0b33",
-        "is_verified": false,
-        "line_number": 2769
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "45a429ac1599f85cdee3c4250855e79584c34999",
-        "is_verified": false,
-        "line_number": 2779
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "352259ccfa17fa823fd1d705741e41ae163133be",
-        "is_verified": false,
-        "line_number": 2789
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "4c3c201ed9c4eb9600b25e1dd346f5bf82872b40",
-        "is_verified": false,
-        "line_number": 2799
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "967f4dec4c344804a55b1fff67f1e5ce80547def",
-        "is_verified": false,
-        "line_number": 2809
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "621bed835d7537fef443b59c2fad6953c5008970",
-        "is_verified": false,
-        "line_number": 2819
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "a39e39696f756ce74098b6fddf75b2ce46b1abe6",
-        "is_verified": false,
-        "line_number": 2829
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "02840635bd6c2a96e9caff3e005212780cbc6912",
-        "is_verified": false,
-        "line_number": 2839
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "f945d18baae51b3dcfe8845ac7827e458d1ddeb6",
-        "is_verified": false,
-        "line_number": 2849
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "f859ed7d6eb93004f1f996259581758f05e26e00",
-        "is_verified": false,
-        "line_number": 2859
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "2325706c38fcff44255be6436e09c604478a2daf",
-        "is_verified": false,
-        "line_number": 2869
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "027f9434b1b0ac2bdd555b699fa2f2270b756c28",
-        "is_verified": false,
-        "line_number": 2879
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "6111fa2e4fc537aafc2e046647375b5f6d4545c2",
-        "is_verified": false,
-        "line_number": 2889
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "1d043244d8531d3e495403038e98ce5d2adabd75",
-        "is_verified": false,
-        "line_number": 2899
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "f86d98c8742c928afe404e872a2eb8f51f04ed33",
-        "is_verified": false,
-        "line_number": 2909
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "a697026019692dba68fb241c76dd6429185fdb10",
-        "is_verified": false,
-        "line_number": 2919
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "7c81660374f9fe2b500a3ea429d8331a3400c3d2",
-        "is_verified": false,
-        "line_number": 2929
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "dd779b9c6c574767ef50407daaef43940b67a2ed",
-        "is_verified": false,
-        "line_number": 2939
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "fbf53eebc2a8b1d19357ea066a98a79953315714",
-        "is_verified": false,
-        "line_number": 2949
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "606eb84badbefe0114fa2db068319be40f84ddeb",
-        "is_verified": false,
-        "line_number": 2959
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "fc7cea6c0e9419db79961ab1c8a8c706249b5982",
-        "is_verified": false,
-        "line_number": 2969
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "f5e1065736dbddf1ecc69b92054b649ecc7d6e86",
-        "is_verified": false,
-        "line_number": 2979
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "5e2a8af13888a87d1479ffaea6869bc2b48c007d",
-        "is_verified": false,
-        "line_number": 2999
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "fe0391a821aea83ac4689b75a2304bf045c49bca",
-        "is_verified": false,
-        "line_number": 3009
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "a58432762d60e9a350be8ce79cd4502687a0b3a3",
-        "is_verified": false,
-        "line_number": 3019
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "104df38b9fdf55d75c6b57013c5c228752fb7369",
-        "is_verified": false,
-        "line_number": 3029
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "d1f5dbb5f95613ae389635d69093e6b7d4d287b9",
-        "is_verified": false,
-        "line_number": 3039
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "35cbb75fdf7b6f8d3f32492277fa2b9e4ab45a76",
-        "is_verified": false,
-        "line_number": 3049
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "c6356b251cb9250de7f01a569d2295752aebfb62",
-        "is_verified": false,
-        "line_number": 3059
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "16cd183c65ea4ded0c91d7e8d38633e9217a24f9",
-        "is_verified": false,
-        "line_number": 3069
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "5b4c93ab04ec59095ec82cfbbf4f842b9fa0cbee",
-        "is_verified": false,
-        "line_number": 3079
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "08fa0f1ea10cf4ac4f03569867e25de1208c19b1",
-        "is_verified": false,
-        "line_number": 3089
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "4c5a5425b28b4d7a4ad7c2197485583e6f63d8f2",
-        "is_verified": false,
-        "line_number": 3099
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "7dda149c76bed09997c885d0667f440828965a2e",
-        "is_verified": false,
-        "line_number": 3109
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "b170dc46f882c6298063ff6ef62e214f097722dc",
-        "is_verified": false,
-        "line_number": 3119
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "24674b716af1c8fbce5f923b5101b52860cc785d",
-        "is_verified": false,
-        "line_number": 3129
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "0699df847b9986050309ed996f6f30fb92ac29a7",
-        "is_verified": false,
-        "line_number": 3139
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "3131bf6850a9abb720594ce711689884449a59fd",
-        "is_verified": false,
-        "line_number": 3149
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "54ec9622a96d645503d5d8d7c9e8d699e1edbac0",
-        "is_verified": false,
-        "line_number": 3159
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "a9c90300feb127bf0aaedf639a41aef2daa3b9d7",
-        "is_verified": false,
-        "line_number": 3169
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "e1782ac60b2ff3904009075be217b9253dbca7a7",
-        "is_verified": false,
-        "line_number": 3179
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "12923600f08a4a398b0ff1b48e519b0eaebc1809",
-        "is_verified": false,
-        "line_number": 3189
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "f44ac3fb71fb69a1d0f190b353d56db5bbdb9cac",
-        "is_verified": false,
-        "line_number": 3199
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "e39ae31de9f29590b1238836371d912ba39cded9",
-        "is_verified": false,
-        "line_number": 3209
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "95c3a4f43e5fca836df32bfb86fca4b9fb2d6554",
-        "is_verified": false,
-        "line_number": 3219
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "0c0dae053f384fa4bc5daa2c6e8d470eb449e37b",
-        "is_verified": false,
-        "line_number": 3229
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "8b95e9eddc2da2298e596ef2c0d281bb529eb2bf",
-        "is_verified": false,
-        "line_number": 3239
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "169f7ebf08a7f3464288f222921d698e60b4485e",
-        "is_verified": false,
-        "line_number": 3249
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "f3a2e132547191528f547c66bc85341d90e60d71",
-        "is_verified": false,
-        "line_number": 3259
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "e25fc0434a104ecf7a0b68cb39ef0a87041ad8fe",
-        "is_verified": false,
-        "line_number": 3269
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "5fa9f86b0db6884bcf37fe7a613952b93f477353",
-        "is_verified": false,
-        "line_number": 3279
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "4ecde504e417b2dee59eae7a1d74e4211d991902",
-        "is_verified": false,
-        "line_number": 3289
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "fd1ce06febfe6b32eabe2fea7853d329020e2511",
-        "is_verified": false,
-        "line_number": 3299
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "37213e3bc684d815ff0d3f55aac0b793945817c8",
-        "is_verified": false,
-        "line_number": 3309
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "8696397d0c9b878ef1aaa02989e97d95830b8a3e",
-        "is_verified": false,
-        "line_number": 3319
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "94bf9b8dc6a7722e9b0abfb9c714f861b1ad3dc2",
-        "is_verified": false,
-        "line_number": 3329
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "b80bb216ff6f55366fbd50dd45a70c0fa9e86625",
-        "is_verified": false,
-        "line_number": 3339
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "0b8a1d4631ae5d7acd019190a917bfd55784d9b3",
-        "is_verified": false,
-        "line_number": 3349
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "a70cefd379247ebf36ba469bd5eda4bbca46a5b5",
-        "is_verified": false,
-        "line_number": 3359
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "5c134437333e70bca218378435ac4cc2f0931c7c",
-        "is_verified": false,
-        "line_number": 3369
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "cc022d6513d4c6421a732d6d15c98a74584b93bd",
-        "is_verified": false,
-        "line_number": 3389
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "3ccb7c710e8155ffd50a25c188407a0d2b3c0c88",
-        "is_verified": false,
-        "line_number": 3399
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "ee4865ae28e1323de32dc5ab7d37adabf2dd6ab4",
-        "is_verified": false,
-        "line_number": 3409
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "174c3fe05cb6f65e41b13863004ee01810987b01",
-        "is_verified": false,
-        "line_number": 3419
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "e844a0a836e90de990512c1d2b8cafc1018fe3a1",
-        "is_verified": false,
-        "line_number": 3429
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "e0be838483ec4b953f496067a3067afc8bf2f899",
-        "is_verified": false,
-        "line_number": 3439
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "1ff67ab45617529ee3590099f28136266cc033b2",
-        "is_verified": false,
-        "line_number": 3449
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "a1ec5715df9e1f29f8e2ae3ccf4a16673c5c8b3b",
-        "is_verified": false,
-        "line_number": 3459
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "570b9af71cd92593d39b16f382488cc940f83263",
-        "is_verified": false,
-        "line_number": 3469
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "7a1dcb3d70a3b909fba4ecc8c225d60abf180ac3",
-        "is_verified": false,
-        "line_number": 3479
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "7c0b0b719e2a130e1e6fd3e4f8c50e5bd56971b4",
-        "is_verified": false,
-        "line_number": 3489
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "b5d12f8bcca5fc88655f7339e93f1bf82b28c6c1",
-        "is_verified": false,
-        "line_number": 3499
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "af89f1ab885b55cb4ca591bca5d380eb2ece4bc6",
-        "is_verified": false,
-        "line_number": 3509
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "89e359dde2b4ffb01125477979385742a7d679f1",
-        "is_verified": false,
-        "line_number": 3519
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "d97e21b00607a9cea4eb444798ecd38fc04ea4a9",
-        "is_verified": false,
-        "line_number": 3529
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "a420e9a1ec203c1f122942b5beaa695a9c812f26",
-        "is_verified": false,
-        "line_number": 3539
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "f02777d9b0ee5b857d915fb97ddceca01ae94fed",
-        "is_verified": false,
-        "line_number": 3549
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "873564a9eefaa989988d6449563828fc6a53d6d1",
-        "is_verified": false,
-        "line_number": 3559
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "669f54b9a52e9fa5dc98760f53bb8f10ffdada9e",
-        "is_verified": false,
-        "line_number": 3569
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "2b294ef11dd0417755ec85696056786c1022d3fb",
-        "is_verified": false,
-        "line_number": 3579
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "6aba59f5d73e6abf21302cbbe951ac0983fe1f04",
-        "is_verified": false,
-        "line_number": 3589
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "32870028ccbe641cb4f4741154d3b09d24cb005e",
-        "is_verified": false,
-        "line_number": 3599
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "4fbc179259024e4034c43c167ded9412c7c4dcac",
-        "is_verified": false,
-        "line_number": 3609
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "1b61c40629dfd00b93093d8b745317ccd22641af",
-        "is_verified": false,
-        "line_number": 3619
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "4806230389e702b61c7197a85ce20f67b9398b1a",
-        "is_verified": false,
-        "line_number": 3629
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "174d7e5c7060fb16a183e723f8b030de9f0d138a",
-        "is_verified": false,
-        "line_number": 3639
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "9796169c55673b6edfc70fd10dbebefd820aa285",
-        "is_verified": false,
-        "line_number": 3649
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "b0d1a0aa4b2fce53bc9e7b3d58d4c843d31ac086",
-        "is_verified": false,
-        "line_number": 3659
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "d8bbf2160dce1ac4669871bdc036f2457b626a5b",
-        "is_verified": false,
-        "line_number": 3669
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "81ff227a119c170325fa6de6519d5d9a7de73d5a",
-        "is_verified": false,
-        "line_number": 3679
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "3ea2163b63bd96ea873950d93d647dfa8976c539",
-        "is_verified": false,
-        "line_number": 3689
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "4a5a7811dbc2bbb922bcb0b2fbcd77799ac1b06c",
-        "is_verified": false,
-        "line_number": 3699
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "7c10b40bc1060481b24f3d46c4cb985a98e02d97",
-        "is_verified": false,
-        "line_number": 3709
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "7c36ebb3da031092f68fd9e59c5917a5de1d9c0b",
-        "is_verified": false,
-        "line_number": 3719
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "32b658eee47c99358488f51d493496a2e06ac50e",
-        "is_verified": false,
-        "line_number": 3729
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "a80959ea3a2f1877f07777a85f7237a32427b7a2",
-        "is_verified": false,
-        "line_number": 3739
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "e8c31f35948af7e1b479b7627fbb192bbbac283f",
-        "is_verified": false,
-        "line_number": 3749
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "f10cbcd2b8250240c72000157b1539734220d518",
-        "is_verified": false,
-        "line_number": 3759
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "6e88b59ba21e1b3ef15c88002df1c31e77fb95e5",
-        "is_verified": false,
-        "line_number": 3769
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "cb7ae72deca6aa1363943cf3954478e94fb86548",
-        "is_verified": false,
-        "line_number": 3779
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "633c268cae595c1335dd1d503d6919c6d677635a",
-        "is_verified": false,
-        "line_number": 3789
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "78ff871db202f80a8038aa3740cc49cc8bf1029e",
-        "is_verified": false,
-        "line_number": 3799
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "ee768cefd00d19aeaa0e57955929829b33e73fb7",
-        "is_verified": false,
-        "line_number": 3809
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "457111bbbec2878800d7d0942f2d79326abd556e",
-        "is_verified": false,
-        "line_number": 3819
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "b2aaff302d78e74cd39de2f3404dd7e484ceb446",
-        "is_verified": false,
-        "line_number": 3839
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "31b9498309ec86784f6fcf5aa35b52b2fc244887",
-        "is_verified": false,
-        "line_number": 3849
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "d766bed4901ab43f0c939dd0eed3a57c626b7787",
-        "is_verified": false,
-        "line_number": 3859
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "2588587cb0ea7253f44b9d79425f8c1be74ae91e",
-        "is_verified": false,
-        "line_number": 3869
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "9788803bc6a477d34563029c84f135137f58a086",
-        "is_verified": false,
-        "line_number": 3879
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "822e3b2add7d41d5dcfe3c7137f07e88e2ec68f4",
-        "is_verified": false,
-        "line_number": 3889
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "f8c14d158df28adcd424d38aa284b230e22ac9ed",
-        "is_verified": false,
-        "line_number": 3899
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "a9c2e96975f00bf7e21d5e14f29e3fffee3f7274",
-        "is_verified": false,
-        "line_number": 3909
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "380e339d465410f083ff7a21f7b5199f7e56a182",
-        "is_verified": false,
-        "line_number": 3919
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "35fab28b54fe659cbd3e8ced64051eca455b1627",
-        "is_verified": false,
-        "line_number": 3929
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "cc0c84a319986787f834b9fd3244fc7d2416aa2f",
-        "is_verified": false,
-        "line_number": 3939
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "587d801f8c9bb458108d5fd54dcb8c5d5158479c",
-        "is_verified": false,
-        "line_number": 3949
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "c66c104c8efd4a3a4a4ba035bc0cdb74dc2815ce",
-        "is_verified": false,
-        "line_number": 3959
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "7ea78fc7b9e6a07995514cf9d29676d1cb70a8b2",
-        "is_verified": false,
-        "line_number": 3969
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "1679c88f371783aa10d7b08703c05d0513d1a687",
-        "is_verified": false,
-        "line_number": 3979
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "df27b23661198f7a446f925539aaa678ac3c29a6",
-        "is_verified": false,
-        "line_number": 3989
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "3676b5428b09220278fae88ba44bf7068b7b34b1",
-        "is_verified": false,
-        "line_number": 3999
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "b90ee83636db12070628f17f2b5c04e3bbd91932",
-        "is_verified": false,
-        "line_number": 4009
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "103d9a93477ce171acfac9fab1a7e144ff38725d",
-        "is_verified": false,
-        "line_number": 4019
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "f9791aaa2edd5e47e596cecda7b5f84edfd888eb",
-        "is_verified": false,
-        "line_number": 4029
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "63118608f781379665272a87147800e449b5c657",
-        "is_verified": false,
-        "line_number": 4039
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "7ebe51ea714825b11558fe5a22e64b900015b59b",
-        "is_verified": false,
-        "line_number": 4049
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "cb982efb4d6237a35811378a18d6954460e4610e",
-        "is_verified": false,
-        "line_number": 4059
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "b9577be1c7562cbb04d050363381df7aa4a315bf",
-        "is_verified": false,
-        "line_number": 4069
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "769e6331c45c474a3b65e920755f87cf3f03131f",
-        "is_verified": false,
-        "line_number": 4079
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "5cbad5df6fcf964ec4674e80a83c18aed1e74bdc",
-        "is_verified": false,
-        "line_number": 4089
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "6148fe533aa7cc08f5c6a6acb89308bb7adafe09",
-        "is_verified": false,
-        "line_number": 4099
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "b3d5faa644f5e6752c15a2ce46a5bef9cb50495d",
-        "is_verified": false,
-        "line_number": 4109
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "22d8893cd6f7345995e8a6b18aa38bb70a024264",
-        "is_verified": false,
-        "line_number": 4119
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "5181fab8303efc22d2e1d5f5b0c9feca861bf869",
-        "is_verified": false,
-        "line_number": 4129
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "866dab47ece5ed9bed6ad0e48aa5627b849b0704",
-        "is_verified": false,
-        "line_number": 4139
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "3ca3ba5ce054c91b3e9ed6c89e6d6f0d5a020b00",
-        "is_verified": false,
-        "line_number": 4149
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "564dd98b7d0c956322052b6cbde1c44fa5ae3ef0",
-        "is_verified": false,
-        "line_number": 4159
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "ed97b4310fbe3c655fbea500949332aa2418fd12",
-        "is_verified": false,
-        "line_number": 4169
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "1eb05948b7ec60923309c27623eb62e33088c218",
-        "is_verified": false,
-        "line_number": 4179
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "9dc6bca903b477794d9951865796f1e2a664cf33",
-        "is_verified": false,
-        "line_number": 4189
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "63f16e50b2522a4cf76e7b7a995ccf2dbd9f60f8",
-        "is_verified": false,
-        "line_number": 4199
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "8b81f33aafbfc58cd6d09ac5673bf2a4eb8a7487",
-        "is_verified": false,
-        "line_number": 4209
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "61bab47c6a4fdc908ba2be4a6e5e6048092ed17f",
-        "is_verified": false,
-        "line_number": 4219
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "1d498ff6707235dae1f9e9492bd4d76a9fe141fe",
-        "is_verified": false,
-        "line_number": 4229
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "cdeffa3110ae6fccee2c867e82129ec2be8e0cc8",
-        "is_verified": false,
-        "line_number": 4239
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "6cb4ac6ef29bf194114cff113073691e1f621793",
-        "is_verified": false,
-        "line_number": 4249
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "f61f4b2a09aa6e6215c1be30372b22fdb5ab370c",
-        "is_verified": false,
-        "line_number": 4259
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "f88cbd46f44d6bba033bde5c731706df7c21601c",
-        "is_verified": false,
-        "line_number": 4269
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "22bf90dbdd3a8f85199d07d37f19e0506a142c35",
-        "is_verified": false,
-        "line_number": 4279
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "3287b2a36266cf2ffe70d49a2f1e325ee68d5d65",
-        "is_verified": false,
-        "line_number": 4289
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "3065a4893f20de0790c5b84744a47328f0c1185c",
-        "is_verified": false,
-        "line_number": 4299
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "1315896f58ea531b5bd184d3172e27ebf88b0241",
-        "is_verified": false,
-        "line_number": 4319
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "6fbeb946136cbc738fc3890008a1e0b195239b7f",
-        "is_verified": false,
-        "line_number": 4329
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "1206a0ea26a9560592305eb43da430fa3006afaa",
-        "is_verified": false,
-        "line_number": 4339
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "3be1b34f5604b5faa52aa06cae443f0f3d793165",
-        "is_verified": false,
-        "line_number": 4349
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "4502406d99c992d090ffc0f07eb8c20f1e11d249",
-        "is_verified": false,
-        "line_number": 4359
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "3a3703b714e6daea7b196e8cf023c73ea673fa93",
-        "is_verified": false,
-        "line_number": 4369
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "6215befa62788e8f4eb369de601e1b71fbdaa2be",
-        "is_verified": false,
-        "line_number": 4379
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "1863603c15d1daa12d36ef09307d0967abb345bc",
-        "is_verified": false,
-        "line_number": 4389
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "da86d2c63f3fce984c653028a5f2b7533bca8578",
-        "is_verified": false,
-        "line_number": 4399
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "01e91b7f11ec434e8884ea11c2703168daeebccc",
-        "is_verified": false,
-        "line_number": 4409
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "daa358742e5f7af8957d12aa4d5c7e1d0b5ab49c",
-        "is_verified": false,
-        "line_number": 4419
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "26c576e5dc1b69872d6887edcfd592c3e2923131",
-        "is_verified": false,
-        "line_number": 4429
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "6b326cc669b7de9f668621877ec88d749d0a57d4",
-        "is_verified": false,
-        "line_number": 4439
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "ae04320f2158f711a0368925802c9fdfcf53d3af",
-        "is_verified": false,
-        "line_number": 4449
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "5320491c3b0ade28c2bb1788125d58a187ca9648",
-        "is_verified": false,
-        "line_number": 4459
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "2c0a719ab2783f631421029baf9c9fa64579476c",
-        "is_verified": false,
-        "line_number": 4469
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "8ba4c352a30099502562443282360f74123267f0",
-        "is_verified": false,
-        "line_number": 4479
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "2b1de6c26e33decfa54cb22976492587df726300",
-        "is_verified": false,
-        "line_number": 4489
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "b8663a2b759f1b1071f9b67695a620ae201acfa5",
-        "is_verified": false,
-        "line_number": 4499
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "4c7a32acc65614f04221232d502ae0c7f3853ee7",
-        "is_verified": false,
-        "line_number": 4509
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "7182b4a55e6758b75397912bdcc30179c052c8cb",
-        "is_verified": false,
-        "line_number": 4519
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "a9e733930f0cc0d4739e98d8662846233b8a0535",
-        "is_verified": false,
-        "line_number": 4529
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "636e4b77182f21a3ee0058c917293b032024cbcd",
-        "is_verified": false,
-        "line_number": 4539
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "d447c34d57b01e5b67938832b763b7eb41a8cf27",
-        "is_verified": false,
-        "line_number": 4549
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "4335666422f0d7906f8e3a3735005ea4b02bf2af",
-        "is_verified": false,
-        "line_number": 4559
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "93fe78b9792c013483882e7c6cc7d1925325345c",
-        "is_verified": false,
-        "line_number": 4569
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "1887e9b1ee9992a567cac49e9483348d33214790",
-        "is_verified": false,
-        "line_number": 4579
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "de95bc178320037829bb9ad8766235a2ce18a8bb",
-        "is_verified": false,
-        "line_number": 4589
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "c481c4ea115a180a01ae735fb5bac763f9c2550b",
-        "is_verified": false,
-        "line_number": 4599
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "d88e4d1dfd40ff3a1408a03e32f461af96ef846d",
-        "is_verified": false,
-        "line_number": 4609
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "821d36d0164a41d76aff05b47140a7713c18bd0f",
-        "is_verified": false,
-        "line_number": 4619
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "84c9e55fe3c84bed92e7701fa0b665965c4b9b54",
-        "is_verified": false,
-        "line_number": 4629
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "b6f862c084d374dfb8b852bb2892975d0c8bf397",
-        "is_verified": false,
-        "line_number": 4639
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "9775f25265848dfc547da5d780d13a271e3f0281",
-        "is_verified": false,
-        "line_number": 4649
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "9e13b499eaeb0999e00629ea4fdfc904384ac1be",
-        "is_verified": false,
-        "line_number": 4659
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "19b41f3815f2919c3301934e27522a228a62c4cc",
-        "is_verified": false,
-        "line_number": 4669
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "abb4328f94d41d869757bff6a4193c765f787b60",
-        "is_verified": false,
-        "line_number": 4679
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "e0a8005c03efe94f0015fb9f9edf778a3fc03d05",
-        "is_verified": false,
-        "line_number": 4689
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "9dc7ca3c96be2a67d4dc26f1968f1bedc1fc6dd6",
-        "is_verified": false,
-        "line_number": 4699
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "03dc87a0b115712f09dd3d6b477f4f864097e7d6",
-        "is_verified": false,
-        "line_number": 4709
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "60c79248a0da8666d55a88042c245d31a54c3365",
-        "is_verified": false,
-        "line_number": 4719
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "248a9b7af7420ad7c935eb7a23dde3e121575e20",
-        "is_verified": false,
-        "line_number": 4729
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "8df61d20de5ddbee04b820257ab2adc13aa12bcd",
-        "is_verified": false,
-        "line_number": 4739
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "1828caa77d12cfcbf82d623757bb8bed3936d3f4",
-        "is_verified": false,
-        "line_number": 4749
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "a698bd62d0a3d956836af39736072a18b80df531",
-        "is_verified": false,
-        "line_number": 4759
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "64e3ebf9423602d3ff2c82147a548713760dd104",
-        "is_verified": false,
-        "line_number": 4769
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "ba1efc15b252373d0e3e020b93db360c91477c2a",
-        "is_verified": false,
-        "line_number": 4779
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "59139bfbc197e19baee064c11b432d441722e6b8",
-        "is_verified": false,
-        "line_number": 4789
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "888c7d38522db138036a7b736586a0cd7cadc8db",
-        "is_verified": false,
-        "line_number": 4799
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "38fed1b8d20465e5cfd0451cf33f8aa010845df0",
-        "is_verified": false,
-        "line_number": 4809
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "c825c4c230c3916daa8dda14a3555eb05d50cb4d",
-        "is_verified": false,
-        "line_number": 4819
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "a92718f642c75b545c9f94e2e701df0ad3da8543",
-        "is_verified": false,
-        "line_number": 4829
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "36a9e734eb6bf532ea6f233cec53bbb1ce696ebe",
-        "is_verified": false,
-        "line_number": 4839
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "447ad8bc29d9f49720cf4b10d1f2e48bf53f5ad0",
-        "is_verified": false,
-        "line_number": 4849
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "9b9764a697617936baf7f546be0799256e589f7e",
-        "is_verified": false,
-        "line_number": 4859
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "a0ef130c6bd93329b5fa51f01f3bf5b47d56456e",
-        "is_verified": false,
-        "line_number": 4869
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "5641361a171ae5e7f77b07f4498e7ee12d3489af",
-        "is_verified": false,
-        "line_number": 4879
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "fdde7fb0a68d9346596f58e0b28d67138f02630b",
-        "is_verified": false,
-        "line_number": 4889
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "d549702170a25533d1bd90f5c1acfae0071253c4",
-        "is_verified": false,
-        "line_number": 4899
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "aa531abf1bd5f5cd7dffbf0ece265be4e4996d43",
-        "is_verified": false,
-        "line_number": 4909
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "6de7668b424a295076c51ed102bc1f44ac16685c",
-        "is_verified": false,
-        "line_number": 4919
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "a4a1a84beb8b8caec1f4c1dfc011e4f9b0ab5198",
-        "is_verified": false,
-        "line_number": 4929
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "f65fd15148d845db1be73bf1e533fb3da2bd21a1",
-        "is_verified": false,
-        "line_number": 4939
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "a1e4442e870b118f9ba5b090de666052d558dfd3",
-        "is_verified": false,
-        "line_number": 4949
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "5abc74b50c48322a92129b61f0af39fe9db7992d",
-        "is_verified": false,
-        "line_number": 4959
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "55156db4118d239263cf5b5be4b3ee098563a0a3",
-        "is_verified": false,
-        "line_number": 4969
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "50742da4c4765518678de49631f67377d8d4906c",
-        "is_verified": false,
-        "line_number": 4979
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "d85bbf683aae05fe9eec08e2b5999dddc33088a2",
-        "is_verified": false,
-        "line_number": 4989
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "0d918673b0eefb9855376688a86253b9b5fabe4b",
-        "is_verified": false,
-        "line_number": 4999
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "6233ca08c04c826f31c04e804a609f141192ae69",
-        "is_verified": false,
-        "line_number": 5009
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "964e0a1b0986570393dd054dc59863be315d8c30",
-        "is_verified": false,
-        "line_number": 5019
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "4a85c397a0bda340ceac8db0fb8d732941ce9fc2",
-        "is_verified": false,
-        "line_number": 5029
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "7927596101e1eb1e1f88eccb0f121535a7b8ce79",
-        "is_verified": false,
-        "line_number": 5039
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "117f2fbe4c6d2183e88b0116fb987b11f6a58f4d",
-        "is_verified": false,
-        "line_number": 5049
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "215538d0073fafbfc386a4bdabe4da2246458773",
-        "is_verified": false,
-        "line_number": 5059
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "63175ac57d969e57d38a01d5800798156632546d",
-        "is_verified": false,
-        "line_number": 5069
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "2050f9f18974480afaf9196394c52a4565da08d5",
-        "is_verified": false,
-        "line_number": 5079
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "0e8669ba155297d2be93790816e1b60bb3c86762",
-        "is_verified": false,
-        "line_number": 5089
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "27136fab095ab4a27ba1f2019a01de0b6d47d72c",
-        "is_verified": false,
-        "line_number": 5099
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "5c7d33cc17fe6f026e7542471a8e4408658c34e1",
-        "is_verified": false,
-        "line_number": 5109
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "eed567072623d49660dcc33b89216427a552f60c",
-        "is_verified": false,
-        "line_number": 5119
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "2ef7d2f6688392d2af3fb7e79f7710e17a85d25d",
-        "is_verified": false,
-        "line_number": 5129
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "849d236c3dd15681d9e43196accbcd1c3fb1872a",
-        "is_verified": false,
-        "line_number": 5139
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "194987ab372a8179931e900920686d0048572b9e",
-        "is_verified": false,
-        "line_number": 5149
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "ce6f33bdc8d5ac0222164d6aa9023a0d5690586c",
-        "is_verified": false,
-        "line_number": 5159
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "e0054ede61cf09fa66b088bb558fed27ba74274e",
-        "is_verified": false,
-        "line_number": 5169
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "291cc972f20bab26cbe8bfbb1fee8bf96409e33b",
-        "is_verified": false,
-        "line_number": 5179
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "b6c06469f5e37f93830839d2ea2b29985f5a9a67",
-        "is_verified": false,
-        "line_number": 5189
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "d32c1dfabac457e40968bb072a2d02cbc22d188a",
-        "is_verified": false,
-        "line_number": 5199
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "b9730dc15e2c39d726725a102bf6c6b46edbb6ab",
-        "is_verified": false,
-        "line_number": 5209
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "0b6585e1d8bdff7ab68ef31d172e99c02eabd45b",
-        "is_verified": false,
-        "line_number": 5219
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "8d5335af19392a2482a635ae244182f3a3bd125b",
-        "is_verified": false,
-        "line_number": 5229
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "79d649a8e21ddb35f2724a7429f9e836ef7859b6",
-        "is_verified": false,
-        "line_number": 5239
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "eeebd3f8146441ab0201e38dd60856d608b3f0a0",
-        "is_verified": false,
-        "line_number": 5249
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "c79b98fb4dd9f4d6ed9dda8f2019fbc8b420c20f",
-        "is_verified": false,
-        "line_number": 5259
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "1f406403c90b1a3c4fdde83121c943321a6f6991",
-        "is_verified": false,
-        "line_number": 5269
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "910febbd7cf94aafbc3d13588177751e917335ec",
-        "is_verified": false,
-        "line_number": 5279
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "6d7eb999929ae38c6ee9b106dcfd86eee6fa3df5",
-        "is_verified": false,
-        "line_number": 5289
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "853a1db91a47bb03d203c03ceb23ccced8255d7d",
-        "is_verified": false,
-        "line_number": 5299
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "cfe701020e921f6acde2911a215701fa2b5c7f28",
-        "is_verified": false,
-        "line_number": 5309
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "18bb93f7bd9efeceea2785941a3e8e11c9d9aba3",
-        "is_verified": false,
-        "line_number": 5319
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "3fdc03f31541980f0e1ea728ae153fc2ef6b6df7",
-        "is_verified": false,
-        "line_number": 5329
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "7ffa3ea95fe8f9dccb68f1381a952b8732bfc3ed",
-        "is_verified": false,
-        "line_number": 5339
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "61eb28e707610bf0017883583520d959f9fab6fe",
-        "is_verified": false,
-        "line_number": 5349
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "0764f5a4c6b30d21c6ea4a5e68ffce1503f2d65c",
-        "is_verified": false,
-        "line_number": 5359
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "38e619bde420ac029d6d8066a122706e9ea4dda1",
-        "is_verified": false,
-        "line_number": 5369
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "ebabf7317202498f14e9db81e0ab247551978b09",
-        "is_verified": false,
-        "line_number": 5379
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "d77075588084cea8065de0048cc4b59a2862356c",
-        "is_verified": false,
-        "line_number": 5389
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "862d51be63975e498969a71fae00426d13653032",
-        "is_verified": false,
-        "line_number": 5399
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "4d04a6721fafb066b7c64b93c4252369a334cac1",
-        "is_verified": false,
-        "line_number": 5409
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "d951b79451d20d10805c7df30e18fae9bd42f90e",
-        "is_verified": false,
-        "line_number": 5419
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "763174162a8771cf63922b4dbca037282c832ad6",
-        "is_verified": false,
-        "line_number": 5429
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "afd68230d13637017b675bf88b26abe9462f1c6c",
-        "is_verified": false,
-        "line_number": 5439
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "6adbf0c281e753debad3a12b818a098f4c5b9274",
-        "is_verified": false,
-        "line_number": 5449
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "d87ba57559d0d68b2ae10b34d0158c3fc8a3ba9f",
-        "is_verified": false,
-        "line_number": 5459
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "984248315d7198d42dea73867beb0d3747b03752",
-        "is_verified": false,
-        "line_number": 5469
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "558c3b68105093951dbcd7eafbc783a8a322a256",
-        "is_verified": false,
-        "line_number": 5479
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "e8930c67f2189a1f386870f9998b637730c61550",
-        "is_verified": false,
-        "line_number": 5489
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "cd770f25dcd2070319791bf9711f117f0e5cf8d3",
-        "is_verified": false,
-        "line_number": 5499
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "aae2440fd2c3a1191333c83b85e38867ce73bc82",
-        "is_verified": false,
-        "line_number": 5509
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "f7580d337ad490af243eeea9c9a8ca4321e47f76",
-        "is_verified": false,
-        "line_number": 5519
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "e1f265e7983c696ff58c3bf4097acbf50820ddac",
-        "is_verified": false,
-        "line_number": 5529
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "467e17a282b07460bae5d9444f7ec2062371c424",
-        "is_verified": false,
-        "line_number": 5539
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "bfa1e19fe0c8ac41ea2d0ea4f1c5fa07c98d58df",
-        "is_verified": false,
-        "line_number": 5549
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "ba638dad61af397478fe615b834e85fd5f12c4ee",
-        "is_verified": false,
-        "line_number": 5559
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "97cf23caaa15767cc8f3e79b1a2ee5522b69700e",
-        "is_verified": false,
-        "line_number": 5569
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "2679abcdf7271fb1aa908268584ffda9b9e038ea",
-        "is_verified": false,
-        "line_number": 5579
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "4ecaffcf5457d80364f1699301cf77a0ef6d97c9",
-        "is_verified": false,
-        "line_number": 5589
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "6f5c8ed78f93dd35e5f0609f23b6609718c19233",
-        "is_verified": false,
-        "line_number": 5599
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "401c15492212c890039b4dfabf73ff97c4194fd5",
-        "is_verified": false,
-        "line_number": 5609
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "8cefabeee36257645503589958d89cafde7aad55",
-        "is_verified": false,
-        "line_number": 5619
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "681c9f9fe74876974dea2fc712bbe8b323e61119",
-        "is_verified": false,
-        "line_number": 5629
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "c3e4a8b71172da8a3f2e697f03863359d677221e",
-        "is_verified": false,
-        "line_number": 5639
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "6236b8f7c4d91387ef565bf95c89668e7b8aa2a5",
-        "is_verified": false,
-        "line_number": 5649
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "3383bf7214f07a26e6c910b617d52ee264ac6aaf",
-        "is_verified": false,
-        "line_number": 5659
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "93ca1e49b9f03a68f258e963660976a80c3db5e7",
-        "is_verified": false,
-        "line_number": 5669
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "d19bb61449ffbeb7cf747148d07ba07b6072dc3f",
-        "is_verified": false,
-        "line_number": 5679
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "d54f2db7edb1951360474b84b2d0580b4e4b462c",
-        "is_verified": false,
-        "line_number": 5689
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "6df2304c904768d693de10985fa006b297e2c8c9",
-        "is_verified": false,
-        "line_number": 5699
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "73fdb785e6225632b1a48504dcf560de640406b7",
-        "is_verified": false,
-        "line_number": 5709
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "c91215925081aaef4d1fc0b9908c2b3d5bf98897",
-        "is_verified": false,
-        "line_number": 5719
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "ada96ae20cedfd98126e7872acddbf6aad762a69",
-        "is_verified": false,
-        "line_number": 5729
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "48847f5031c5d41c11f3054984a2d77c73e82667",
-        "is_verified": false,
-        "line_number": 5739
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "b6f52966b48164d386f12f9186d55abf14baf993",
-        "is_verified": false,
-        "line_number": 5749
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "9fbeb1cdc8fed67a0df3dc2960a737861f18fee0",
-        "is_verified": false,
-        "line_number": 5759
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "f41ba63086e95ad132cc58b1d8ecf93047facb18",
-        "is_verified": false,
-        "line_number": 5769
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "cb674912a3b8cce8aae0b17739c05af0bbc4ebeb",
-        "is_verified": false,
-        "line_number": 5779
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "d183889076ba67e8eca3cba6a80ac16395b7813c",
-        "is_verified": false,
-        "line_number": 5789
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "02ee72e4a9e14b165f1199c433492a8c8333f253",
-        "is_verified": false,
-        "line_number": 5799
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "ed389502d64021168fdc71c21824a08045b88cd6",
-        "is_verified": false,
-        "line_number": 5809
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "5ad96b55b95f728bfaf42de90cd0c169c0e346bd",
-        "is_verified": false,
-        "line_number": 5819
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "644315cb32e657a2fa653e4821922d551490f499",
-        "is_verified": false,
-        "line_number": 5829
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "cde2fa57aa27e4f6a6d3a14bd41000b91cd9023f",
-        "is_verified": false,
-        "line_number": 5839
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "fd5cb3fab28576f09f40e2b055f9fbafaec1928f",
-        "is_verified": false,
-        "line_number": 5849
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "eb1ca288f7ea2ea3367fb6b2b230fd40e79a2f03",
-        "is_verified": false,
-        "line_number": 5859
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "07b59f36b9128c69a149b53e11383b79376c3029",
-        "is_verified": false,
-        "line_number": 5869
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "0d3ade1882970e38ae0fdcf57a758869bbe92920",
-        "is_verified": false,
-        "line_number": 5879
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "0af57a3f2220909e683dbf7e72636b269619ec72",
-        "is_verified": false,
-        "line_number": 5889
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "3be8c7c39a4713e9886b574e57cba0d2cf3c6b12",
-        "is_verified": false,
-        "line_number": 5899
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "bb3cd1f80d08bf703e86ecfe03e34473b7c203fc",
-        "is_verified": false,
-        "line_number": 5909
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "85a0faa4a1ef1c1c056849e232258f38bcda3280",
-        "is_verified": false,
-        "line_number": 5919
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "d841d3a0601e1c6c4e4061a7a1a3784893c40acc",
-        "is_verified": false,
-        "line_number": 5929
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "b5adf4e36d62ac3f41472a17831839feeaf5e2c3",
-        "is_verified": false,
-        "line_number": 5939
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "a67d36cb87457ef1db605bd991724b3f946e5871",
-        "is_verified": false,
-        "line_number": 5949
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "3ffa6a7ddec1af87913a3671d36750f4e7d7b4e3",
-        "is_verified": false,
-        "line_number": 5959
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "bcba2435c37cc4ceb60b1d581123235795c13d81",
-        "is_verified": false,
-        "line_number": 5969
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "d21eb9c6beeef9c056743beb32eb4562916e58ee",
-        "is_verified": false,
-        "line_number": 5979
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "58915fb65741d72de795a76f6f03f9c5e27968e4",
-        "is_verified": false,
-        "line_number": 5989
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "4e19e82267b0bd5256bfd899d0db15b2ac09cdb3",
-        "is_verified": false,
-        "line_number": 5999
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "5c3707ba37ed589c077097da4e7e009ea88917f2",
-        "is_verified": false,
-        "line_number": 6009
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "0e02e3c76ba73d41fe014bba21fe177a6c592430",
-        "is_verified": false,
-        "line_number": 6019
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "d64ae8ef0c600e8815c7f2131209b0a029936b45",
-        "is_verified": false,
-        "line_number": 6029
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "6660935a313d1f3775a3ccbfb06b6e1fab2f34d2",
-        "is_verified": false,
-        "line_number": 6039
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "92c25ffa308a490939087f6e9c20c51d2d95993d",
-        "is_verified": false,
-        "line_number": 6049
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "a1d7543f8319a336dcc6ef0102c68f0a21db6f88",
-        "is_verified": false,
-        "line_number": 6059
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "c57820ac2e8be15badafee54e64d49c65944fd4b",
-        "is_verified": false,
-        "line_number": 6069
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "24c592e1409394f452ddb5cc799f9b13934daaf4",
-        "is_verified": false,
-        "line_number": 6079
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "8f532fbc201d383cafeaa8addad1aa9682a1f866",
-        "is_verified": false,
-        "line_number": 6089
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "d80481507935a819ab40a2a548e606dbf2466f33",
-        "is_verified": false,
-        "line_number": 6099
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "f3b565f75f64fef84fa7804209b3aff2779e7368",
-        "is_verified": false,
-        "line_number": 6109
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "8ae5ea6adab2e6fe7abb429fa1b01df0af573119",
-        "is_verified": false,
-        "line_number": 6119
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "cfbccd3a9718d42adc25cbc31c55f6e71c54b971",
-        "is_verified": false,
-        "line_number": 6129
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "529ebf151872c34cf3477c406957919296fa7e33",
-        "is_verified": false,
-        "line_number": 6139
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "b3fd6c9432b53d27ba9238f9ce4707c3e9ffb7aa",
-        "is_verified": false,
-        "line_number": 6149
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "87d85fb8959ea602156be7b5eb408a9c0bbb3c43",
-        "is_verified": false,
-        "line_number": 6159
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "00b77afc179cd175f4854e97f960acf5d7dea5fa",
-        "is_verified": false,
-        "line_number": 6169
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "b5f39684fbd20bf1a00b08afe3364e0bb6bd29ce",
-        "is_verified": false,
-        "line_number": 6179
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "7c4801761ef5ba976ca7aceab001a9ac85c189f0",
-        "is_verified": false,
-        "line_number": 6189
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "95d1909005f41c6a148e826609c43a090b9dcd0b",
-        "is_verified": false,
-        "line_number": 6199
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "11e76f4a699b0c2e5390b344650d90b1b5f085e7",
-        "is_verified": false,
-        "line_number": 6209
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "7ad1a362b9bed8e55ef1ced6d79d0c10da2ea270",
-        "is_verified": false,
-        "line_number": 6219
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "3c3831a882a977128bdfb626efb8cf8f0e29dc78",
-        "is_verified": false,
-        "line_number": 6229
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "bec8422bc185094036dd31c5699780da15416caa",
-        "is_verified": false,
-        "line_number": 6239
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "68b26931b8b0345544bb32e91f7759d109491e43",
-        "is_verified": false,
-        "line_number": 6249
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "0e5eb35e423a9387b9baeddbd6621747e9ba2329",
-        "is_verified": false,
-        "line_number": 6259
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "e406790e71b537ace8d5f0c862c10348c3566530",
-        "is_verified": false,
-        "line_number": 6269
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "da755cff2a26710cdf773a973311b695f9d685d9",
-        "is_verified": false,
-        "line_number": 6279
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "653e4262570630c03f9ef59022d61f1c8e540f0c",
-        "is_verified": false,
-        "line_number": 6289
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "db606dbf00695ab1c62e9b76bfc009f80425d302",
-        "is_verified": false,
-        "line_number": 6299
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "f6efbb36c2882066276aa2e23f8ce64c5ef89ee1",
-        "is_verified": false,
-        "line_number": 6309
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "bfa33a28eb81c93d47b7009297c493fa68408801",
-        "is_verified": false,
-        "line_number": 6319
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "e8cff254a4057bcc786c636f660217111a27e676",
-        "is_verified": false,
-        "line_number": 6329
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "79c0f4b0c674da3cbceb3da03fa8baed3942e1ae",
-        "is_verified": false,
-        "line_number": 6339
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "95d65e591f4794710d209f03190c3ba4d3c69c38",
-        "is_verified": false,
-        "line_number": 6349
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "2a24ba7960278f576734b06cf531e77b45465477",
-        "is_verified": false,
-        "line_number": 6359
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "ef428565d1c2145282048bf147370f329c10c8fb",
-        "is_verified": false,
-        "line_number": 6369
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "61ffe3faf967c2c01451da092a17702f6110f1a7",
-        "is_verified": false,
-        "line_number": 6379
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "35909fe3c76057f04702a2a98443d89bedcb3e6d",
-        "is_verified": false,
-        "line_number": 6389
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "9253ae7086ca880fee4f5be06dc98aae80de3e13",
-        "is_verified": false,
-        "line_number": 6399
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "598ffa81264d142bbc6eaf637354567703d037dd",
-        "is_verified": false,
-        "line_number": 6409
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "ebcbf885ee9c251cd7d1e992b136b71b6cc02d3a",
-        "is_verified": false,
-        "line_number": 6419
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "daefc5e6b52c5530dddda33979da2303f23a16a3",
-        "is_verified": false,
-        "line_number": 6429
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "3786b44459f97e4f71d4e641992a78d131973a7b",
-        "is_verified": false,
-        "line_number": 6439
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "cda00fa755a5a0ea75d9e4ddb275eb597cd2d932",
-        "is_verified": false,
-        "line_number": 6449
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "e4dde1243646062a78b0a3154097f26603a98b09",
-        "is_verified": false,
-        "line_number": 6459
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "df98d0eeddeea7cd86008c3a1c15ac85ff318dc0",
-        "is_verified": false,
-        "line_number": 6469
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "0088ece9949d76c4b6e4f2b00541aa2579d2d16f",
-        "is_verified": false,
-        "line_number": 6479
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "1dae8c93446571b7aebc07e139e3f72de6189f2d",
-        "is_verified": false,
-        "line_number": 6489
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "5999ba2a24cd0f77f789de22c9bb9f01cee0f2cf",
-        "is_verified": false,
-        "line_number": 6499
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "fb724b345377e4bb6f5561d92a05af980e886123",
-        "is_verified": false,
-        "line_number": 6509
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "ae94430d2b8e0fa57fef6cdf53e1040776237781",
-        "is_verified": false,
-        "line_number": 6519
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "87b929f0549ec3ed1b5c69a81582d64657a79f4e",
-        "is_verified": false,
-        "line_number": 6529
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "79da10728d5d0d804abc654e97b436ace2d2d4c6",
-        "is_verified": false,
-        "line_number": 6539
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "df642e36e903fdf6e731682a36dfec97864319f2",
-        "is_verified": false,
-        "line_number": 6549
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "024cb39a8e7ce0cb3cf2dbfbadfcbfec54cfd991",
-        "is_verified": false,
-        "line_number": 6559
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "9f2c74de6148d68adeed2ca7f8f4a7de7e29d228",
-        "is_verified": false,
-        "line_number": 6569
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "2d32dfcaa06de33c7337b8fe3b93097b2bb5d18d",
-        "is_verified": false,
-        "line_number": 6579
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "9e739101369765500c58577f6308954751e8e88f",
-        "is_verified": false,
-        "line_number": 6589
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "61dc820b5a47b9d48dd73f0989052d53acce73cd",
-        "is_verified": false,
-        "line_number": 6599
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "903bb884dc4ec8e8f187afdb7db40a7146f3fe67",
-        "is_verified": false,
-        "line_number": 6609
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "3275ce58eb0a90a68c2159383511f3e1f7c10824",
-        "is_verified": false,
-        "line_number": 6619
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "fa8eff3cfa625f93e621ea344b3ea075707e575f",
-        "is_verified": false,
-        "line_number": 6629
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "c78a607a7b1b1531b018fa57ddd69acd4a699b15",
-        "is_verified": false,
-        "line_number": 6639
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "2f068341d70f8a031ecee2bf122249e7154310cf",
-        "is_verified": false,
-        "line_number": 6649
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "9c90dbe9f2eb1a9c4d8fce6564b3575ae636489b",
-        "is_verified": false,
-        "line_number": 6659
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "a4c1687493df70686746cf198cc74c85d5134bb8",
-        "is_verified": false,
-        "line_number": 6669
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "f57a092b8be461d9739b99baa210df7a20568a36",
-        "is_verified": false,
-        "line_number": 6679
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "745be36ee6e60ab77cb31ab991aea75a38d97cc5",
-        "is_verified": false,
-        "line_number": 6689
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "f3fb4db649cbfb15cb7530228bd143f830c38665",
-        "is_verified": false,
-        "line_number": 6699
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "78ca0a6193c60f2d6396814743cb0dc9898faa95",
-        "is_verified": false,
-        "line_number": 6709
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "4657050e5b0b4f03af32b103eff3cef20041d3d8",
-        "is_verified": false,
-        "line_number": 6719
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "6cea4d97f6394fed025444b5932b5de8524ef42a",
-        "is_verified": false,
-        "line_number": 6729
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "4f777233d9de1cadd3fbcf380c94aca0e7275ac0",
-        "is_verified": false,
-        "line_number": 6739
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "c1a0c98ce72ede2529cb62e20923c41ee645d57a",
-        "is_verified": false,
-        "line_number": 6749
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "464bc68f2a688a1ef740efbb6b4b2dcaee559856",
-        "is_verified": false,
-        "line_number": 6759
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "5882c8724c0d71916bfb8958ebb6878ce40978a5",
-        "is_verified": false,
-        "line_number": 6769
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "e08ddea2a61dcd5eb1281ed5262e7b950f053d5c",
-        "is_verified": false,
-        "line_number": 6779
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "6f865055ae472cd7b0052dd3f41166835529d234",
-        "is_verified": false,
-        "line_number": 6789
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "8984e84af852e2529aff36e7daed98d34a7b87c4",
-        "is_verified": false,
-        "line_number": 6799
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "8af1fdfa97518a14bcd8ce860057ffb7a875906c",
-        "is_verified": false,
-        "line_number": 6809
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "f8dcbcdd69554be8dd699d8f1b6304c0e2e3aadd",
-        "is_verified": false,
-        "line_number": 6819
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "c8ae716d7437c23f2e100efc064dcfcff2403267",
-        "is_verified": false,
-        "line_number": 6829
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "ec05d73d6354a78e52a917c17585d535b563d1f4",
-        "is_verified": false,
-        "line_number": 6839
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "a4598f1c88baf21ad4c762530d275fa2452012e6",
-        "is_verified": false,
-        "line_number": 6849
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "8f1bf84c95063be109384d8867bf88ef90833866",
-        "is_verified": false,
-        "line_number": 6859
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "7891d753da480fa048710b2367256853a2a80384",
-        "is_verified": false,
-        "line_number": 6869
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "87d8b34f92237219a3f57ae356ab13f04b0f13fc",
-        "is_verified": false,
-        "line_number": 6879
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "27bca0dc33aae9c378d3681db05394cb6b00fae0",
-        "is_verified": false,
-        "line_number": 6889
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "b95d59c27e5a1e9886a88238b045d70de262ccae",
-        "is_verified": false,
-        "line_number": 6899
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "5493e70a36d3e65079a52bb943f7d95baa553b48",
-        "is_verified": false,
-        "line_number": 6909
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "e023c88b5036f5d762a6b9beba864c7acb1a92e6",
-        "is_verified": false,
-        "line_number": 6919
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "b4dfded94799e8448a4d82c7ba852ccd4248da8c",
-        "is_verified": false,
-        "line_number": 6929
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "77f77a8a3ee2370aa6b3dabe914a5d6ca94d6764",
-        "is_verified": false,
-        "line_number": 6939
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "593774a7c66f3c4dc3dfdb01a736e6f40d9428a2",
-        "is_verified": false,
-        "line_number": 6949
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "82f6077f014aa298bfb26737c62724925616346e",
-        "is_verified": false,
-        "line_number": 6959
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "8f6a3504d05386a28019a5c2eaffcf17c7b22ede",
-        "is_verified": false,
-        "line_number": 6969
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "cf73eecfdbb303671d93013f1640ae7396e4a00e",
-        "is_verified": false,
-        "line_number": 6979
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "cceed6ba29ac121fcebb83e36b84efdd560d72a4",
-        "is_verified": false,
-        "line_number": 6989
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "5dd33f696a7fcbac6f81b01f553e69f23ff22b0e",
-        "is_verified": false,
-        "line_number": 6999
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "c09cf5808b2257d0b29fc72ec242f1940b597a0c",
-        "is_verified": false,
-        "line_number": 7009
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "9f73fc314b1b832d0b3018e3d606654a33cef61a",
-        "is_verified": false,
-        "line_number": 7019
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "79d7178979c6ad35b16e959f303a9d19674e0499",
-        "is_verified": false,
-        "line_number": 7029
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "497f255941b2a62e6bf331d627be3c0636444186",
-        "is_verified": false,
-        "line_number": 7039
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "42f5dfab11f411b05e528fb4a2430f7782a1c155",
-        "is_verified": false,
-        "line_number": 7049
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "3c4baf979ec99e105263c07063dc7a24c5149766",
-        "is_verified": false,
-        "line_number": 7059
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "e62b2b33ff8cf4d9f8d227a95faf263fd0d00a9f",
-        "is_verified": false,
-        "line_number": 7069
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "15ca1b7ee484e84e1ba4bd2040cd32db1490cbd5",
-        "is_verified": false,
-        "line_number": 7079
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "9422edea156448cdae90c158b6a36846d5a4e03a",
-        "is_verified": false,
-        "line_number": 7089
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "2a37778befed7d7237c0f4d1059f97c3fde77d5c",
-        "is_verified": false,
-        "line_number": 7099
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "1589fc71e14ca76592353632d18c40731a69bfc8",
-        "is_verified": false,
-        "line_number": 7109
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "91ff09db78199497cdcfce11f8f10ab4e82ae08b",
-        "is_verified": false,
-        "line_number": 7119
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "436615060d5c460e4d4e9b49c890828835a0a2b6",
-        "is_verified": false,
-        "line_number": 7129
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "427301141a1a8b152562224bff9ea8c4279649fa",
-        "is_verified": false,
-        "line_number": 7139
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "0019b4199e7149faa0c8c7ee04aa2e2f7f81bc88",
-        "is_verified": false,
-        "line_number": 7149
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "9cfd2de7de066320a6950a7618a00e24de27b842",
-        "is_verified": false,
-        "line_number": 7159
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "85861dd5fb68898b7926dea4ad6c526e870705d7",
-        "is_verified": false,
-        "line_number": 7169
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "d4d066fc93a2b026ce668dc27ef57d307512696a",
-        "is_verified": false,
-        "line_number": 7179
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "a21787d2c20c909eab61c035807a612f1382f94a",
-        "is_verified": false,
-        "line_number": 7189
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "815d72a640b41f29b73f5a1053f27cc5712afb7d",
-        "is_verified": false,
-        "line_number": 7199
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "7d3f681ee11666330cec07e275c7ea73b5df052a",
-        "is_verified": false,
-        "line_number": 7209
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "6bbece4c2478b4597bb7d97c25beba34b358e44f",
-        "is_verified": false,
-        "line_number": 7219
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "e28ed5115e7322fb1d4d3e585dceba0b9fcde94a",
-        "is_verified": false,
-        "line_number": 7229
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "12ea771f6f968b7346c82997182c914fdc0a9762",
-        "is_verified": false,
-        "line_number": 7239
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "11aaa173f4437c6a75c7831830ff09d0a3b75797",
-        "is_verified": false,
-        "line_number": 7249
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "0c0290e9e364c3c363f83e8d968c0fd37c0230e5",
-        "is_verified": false,
-        "line_number": 7259
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "90bdd71b2a034bdb17d817b3987cd8e47df93c0b",
-        "is_verified": false,
-        "line_number": 7269
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "18a38076d4796f4e4c9cf3f14534b8a082486cd4",
-        "is_verified": false,
-        "line_number": 7279
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "eff8e787c9e8defe2f421b1ab5605330909c5177",
-        "is_verified": false,
-        "line_number": 7289
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "eee491b7f7c7b3df428ea258f226d57c65032bac",
-        "is_verified": false,
-        "line_number": 7299
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "abb1432aae1d3b78fb17b285365b690bce01e2cc",
-        "is_verified": false,
-        "line_number": 7309
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "9ed625c5604c6e3d1d91a3568b9a0c0d1be08632",
-        "is_verified": false,
-        "line_number": 7319
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "c418963f1bc619fe7fb257fb052a3253c2a3f289",
-        "is_verified": false,
-        "line_number": 7329
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "95eda1526b8ce69066446890f7d5117bd2623b6b",
-        "is_verified": false,
-        "line_number": 7339
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "db6b1d07071328d84f7afba9ec6f7a47e10393c0",
-        "is_verified": false,
-        "line_number": 7349
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "2ca3d56fde43e667f8ef17df13ab3d0316a9e4a5",
-        "is_verified": false,
-        "line_number": 7359
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "6b675497e1f86763511a4640fe08ef17caf10c13",
-        "is_verified": false,
-        "line_number": 7369
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "0c70e06e763657e51c57f02986ecd12a2ffdc807",
-        "is_verified": false,
-        "line_number": 7379
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "e4b8f4ec1e3e9c8821766dc8e1d7eb69756cd843",
-        "is_verified": false,
-        "line_number": 7389
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "52ad340aa4e4452745971a1d4fce5ebbfc4fe72b",
-        "is_verified": false,
-        "line_number": 7399
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "ab20ad17b8d37b8a6eb5d4d322c8cf0412a61af2",
-        "is_verified": false,
-        "line_number": 7409
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "32d78589c1520d41193d51d6b705f35f99b4acc8",
-        "is_verified": false,
-        "line_number": 7419
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "68b55774a35480c1d8d49d730a1ef64e236aca77",
-        "is_verified": false,
-        "line_number": 7429
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "c12cdf4a3614b4c1b3d0ffd9f14de4528f91253b",
-        "is_verified": false,
-        "line_number": 7439
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "ba73f6743fc5fa9296a28a335fce60a42ac8b73c",
-        "is_verified": false,
-        "line_number": 7449
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "ec2a5eb2340b10239c197d76ccd5c1ec0964b1b7",
-        "is_verified": false,
-        "line_number": 7459
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "febada7a7e2c2fcf71921084f0e43b10f54f183f",
-        "is_verified": false,
-        "line_number": 7469
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "42bce1b7df76e2f285ea9e4aa4557be2766e48c4",
-        "is_verified": false,
-        "line_number": 7479
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "6705ddbb8e6f82b7e51c347479c11d6fe536e32c",
-        "is_verified": false,
-        "line_number": 7489
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "eb48e48ce78991b13f28f569f271f36a41536bbc",
-        "is_verified": false,
-        "line_number": 7499
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "c07d3526d2e40f77307bf499f5f27dde5ebbc0e9",
-        "is_verified": false,
-        "line_number": 7509
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "791033b459264f5760fa5e6453b26af7f21a66c9",
-        "is_verified": false,
-        "line_number": 7519
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "3046830d7474e0d9ae97b67b738dd4c1770402b2",
-        "is_verified": false,
-        "line_number": 7529
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "e7e5f54098571afcc876d595921a962fd71d728c",
-        "is_verified": false,
-        "line_number": 7539
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "3521c18fa34db2668227c9ec1bfd4d4fce0f4b7e",
-        "is_verified": false,
-        "line_number": 7549
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "0fc9113080fad32f2a4d3d2499c73db5d4a8c891",
-        "is_verified": false,
-        "line_number": 7559
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "922f2adfe27f0b03a8d16955837bf76812ffd6c0",
-        "is_verified": false,
-        "line_number": 7569
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "ef6f9fcea38f0cda42372ae9a6278cc63f825f88",
-        "is_verified": false,
-        "line_number": 7579
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "4dc1c686f75c3b15c41b73766c6baec35a489ea1",
-        "is_verified": false,
-        "line_number": 7589
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "c685ee209ee4b0c96cf36f3185a0661a15f4cffc",
-        "is_verified": false,
-        "line_number": 7619
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "f9e056fcabf29b3c2261586f4a0a551d9d0c34d7",
-        "is_verified": false,
-        "line_number": 7629
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "06052e7fa3a640c6ceaa864872d2a4fb5f01c9fd",
-        "is_verified": false,
-        "line_number": 7639
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "1df6cfe4e9577ab9ccf30d4ddab9774b5001dcbc",
-        "is_verified": false,
-        "line_number": 7649
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "de1144c89b4e31118a9922182f1c4f79089d9ce9",
-        "is_verified": false,
-        "line_number": 7659
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "a18efcfec0ec0e5c0148f953d427babd9be4e5f2",
-        "is_verified": false,
-        "line_number": 7669
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "c618a786d419d805a0e2824538ca3c1f3f399b57",
-        "is_verified": false,
-        "line_number": 7679
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "89566e746097fdab6d71fb9c75ff31c000bb0b2f",
-        "is_verified": false,
-        "line_number": 7689
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "db8d5e37aeb82dda3fa436367e4223698035f938",
-        "is_verified": false,
-        "line_number": 7699
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "33a72635a4c7de84e4f081add2d9e5a1ba0f8c6b",
-        "is_verified": false,
-        "line_number": 7709
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "207200fe38a3a7b5213edddef87acb19d2616b45",
-        "is_verified": false,
-        "line_number": 7719
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "915a918d2e7280373645caa37d95c07df4c941af",
-        "is_verified": false,
-        "line_number": 7729
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "4803f5c5a7199c926016c1ebeffaf85cc3d67827",
-        "is_verified": false,
-        "line_number": 7739
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "a6f6e66bde6926fe35448fb4dadeb2cdd34c13b3",
-        "is_verified": false,
-        "line_number": 7749
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "1bb9e8c2c87eb1b054632f094f39a8ce8a92388d",
-        "is_verified": false,
-        "line_number": 7759
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "0b94a2ca6eaa0534091978611bae03e4461e9011",
-        "is_verified": false,
-        "line_number": 7769
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "f3d1db5abc49db54356cf8f2c375c7e87b046512",
-        "is_verified": false,
-        "line_number": 7779
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "db9c7f4ab3b3581e7deff1bc91f2f5c37f501a85",
-        "is_verified": false,
-        "line_number": 7789
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "d5ce656fa26d131b8e2527eced1753cff45e25e8",
-        "is_verified": false,
-        "line_number": 7799
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "5b1aca377ed14f112443b6dea3687f163f6a5ff6",
-        "is_verified": false,
-        "line_number": 7809
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "1e57a484f13ba92609ddefefd90ec6ba7b5b3bb4",
-        "is_verified": false,
-        "line_number": 7819
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "16d2f1b6c7785891f72ace26dd5a43025bcb9057",
-        "is_verified": false,
-        "line_number": 7829
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "08c9ac00715919446a4578ca780cd723ca3b50d8",
-        "is_verified": false,
-        "line_number": 7839
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "d2c690581dba206ae8c0d192833d092c55808308",
-        "is_verified": false,
-        "line_number": 7849
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "86183f7f20a5526231f7b23cebc6d70c6dca9ec9",
-        "is_verified": false,
-        "line_number": 7859
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "3ea741b0994123f7423c51c030352d590108d872",
-        "is_verified": false,
-        "line_number": 7869
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "bbffec6f8c6dc784bd8bb61fbe46ef2b74b46d67",
-        "is_verified": false,
-        "line_number": 7879
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "07b0d0dd4c9453eb37158f529a5f1a037c95eacd",
-        "is_verified": false,
-        "line_number": 7889
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "b8611a12f1a9630b3a3bee6a13f1dfe5e5f59e2e",
-        "is_verified": false,
-        "line_number": 7899
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "516a60b91374817bf97ffe680f7e115e02f8a303",
-        "is_verified": false,
-        "line_number": 7909
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "2a4b762a86c201fcfb4ebba08dd51dfdd62443ba",
-        "is_verified": false,
-        "line_number": 7919
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "6da37b23c3758b15b35384b74023f69d0f998afb",
-        "is_verified": false,
-        "line_number": 7929
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "a609d6a53f6fea67f635ebc33df2511f43a06880",
-        "is_verified": false,
-        "line_number": 7939
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "cbe280e8ded61dd83be2d010b31c8f88bf60512a",
-        "is_verified": false,
-        "line_number": 7949
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "66a6a00af221b5cadf85e918caed411361058c02",
-        "is_verified": false,
-        "line_number": 7959
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "6d37491420835603ea4d43f61c37f517f251d9c4",
-        "is_verified": false,
-        "line_number": 7969
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "61784beeda7e3ff995892a4cefed497b078e1c36",
-        "is_verified": false,
-        "line_number": 7979
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "cca0fa02d330a0b36cdbd0bc268e615772031f45",
-        "is_verified": false,
-        "line_number": 7989
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "8554f389620855e5ab407205205881d364cb9dfe",
-        "is_verified": false,
-        "line_number": 7999
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "6b1eb95c135b422d60f67b1caa727c588565e726",
-        "is_verified": false,
-        "line_number": 8009
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "27d88a2d417dff6c82f8fcdfef49597f63ba53cd",
-        "is_verified": false,
-        "line_number": 8019
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "f31d39134a3a5df4a526fc185144f25b1acdf155",
-        "is_verified": false,
-        "line_number": 8029
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "f52cd196971181fc6bbb0b5431109bd0223f0f3e",
-        "is_verified": false,
-        "line_number": 8039
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "d07351275dba4e040c77372e3eb4c289630cde6e",
-        "is_verified": false,
-        "line_number": 8049
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "1ff0d2542af1abd55aa04e758c8cf1d31897d553",
-        "is_verified": false,
-        "line_number": 8059
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "dd07c505e794b1ae92c54a8f4c921cd6b4bbda17",
-        "is_verified": false,
-        "line_number": 8069
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "c0090efabb2a611a2d67874f4c419ee95f82c869",
-        "is_verified": false,
-        "line_number": 8079
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "7e06167704d4381d63fc54a16363ca0e468c19b8",
-        "is_verified": false,
-        "line_number": 8089
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "a6b030278f064ca7b311920de6df0ae1fdb75a61",
-        "is_verified": false,
-        "line_number": 8099
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "03ff917357e784e6129197183fa2f49976f2f7d6",
-        "is_verified": false,
-        "line_number": 8109
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "341130a5b84bb437e3c866f20daa6fe3e968b729",
-        "is_verified": false,
-        "line_number": 8119
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "e4b25527449e70c4e06e0f9e6656b5fa34c55d95",
-        "is_verified": false,
-        "line_number": 8129
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "62a65dfe681bb1002acd17394972aad718c48c1a",
-        "is_verified": false,
-        "line_number": 8139
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "c73aa2e5fabd3473503ceea5bf6a702124f7ded9",
-        "is_verified": false,
-        "line_number": 8149
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "62a1098a1c0e661650d5054a9a2cc50f6b5040de",
-        "is_verified": false,
-        "line_number": 8159
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "b286c54e4fe878cf4045d67aa14eeef76f9be126",
-        "is_verified": false,
-        "line_number": 8169
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "2d72ad9b31e7617b0b21b7b18a26d58aa205d841",
-        "is_verified": false,
-        "line_number": 8179
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "0a55fe7f36e2ba1a715a98dc3b2178982c07a9b5",
-        "is_verified": false,
-        "line_number": 8189
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "abb96adb70f9c7cf3d6be1ec9cb2e40c0486dc3d",
-        "is_verified": false,
-        "line_number": 8199
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "2f05728fb2d85f78dc5af3e1cbd4f794859e4a3c",
-        "is_verified": false,
-        "line_number": 8209
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "cf7e0462f4320a685ebbc98b8bd9adc092a740e1",
-        "is_verified": false,
-        "line_number": 8219
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "aaa1673a4c1ae42c20d17b681725f6f01ab61fcb",
-        "is_verified": false,
-        "line_number": 8229
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "46a989cdc2221c96b67a987d7af7796745a47b2c",
-        "is_verified": false,
-        "line_number": 8239
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "baf82fafcd71b15a075feafd5ff1c535baed342b",
-        "is_verified": false,
-        "line_number": 8249
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "4156dbd605ef58fa6eba5f4305d871e9005ee0a5",
-        "is_verified": false,
-        "line_number": 8259
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "5775cfcd6f35561ec931a7c90c1d87fe006a1b0f",
-        "is_verified": false,
-        "line_number": 8269
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "a419566f0cbe4e3e2429e71d6e8566cc8a188ff2",
-        "is_verified": false,
-        "line_number": 8279
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "8282bb8f476966324a52b82250aeb6559306a0c7",
-        "is_verified": false,
-        "line_number": 8289
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "9db0b2cca5d15aeb53c34d56ce8993f5b84f3fbb",
-        "is_verified": false,
-        "line_number": 8299
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "bea1ac7bf421dae613bdb7a0f26f0a476e6b440a",
-        "is_verified": false,
-        "line_number": 8309
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "16a350ac2fa283f90eea6fbb4d9d8e23f45632da",
-        "is_verified": false,
-        "line_number": 8319
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "e542103209bee474e39e69d9e2574f2d82200a07",
-        "is_verified": false,
-        "line_number": 8329
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "61fae3563851ccd0d48946455ea57d49ac81d06d",
-        "is_verified": false,
-        "line_number": 8339
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "8f573bd6b139f678be01777170b0c9e92e569e0a",
-        "is_verified": false,
-        "line_number": 8349
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "cbbb4e6bf55972fc110b3d166a7bce033fa5f3ec",
-        "is_verified": false,
-        "line_number": 8359
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "267c7c079b9d81e2e8f87a59ec7426b8cb7269a6",
-        "is_verified": false,
-        "line_number": 8369
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "42353319531e1127f545d5fe560b1dfe67d5dff8",
-        "is_verified": false,
-        "line_number": 8379
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "9d88bdc314c9d8d0392facc41cd94fc0519eb6f5",
-        "is_verified": false,
-        "line_number": 8389
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "d2f35120954c9362dedaf8b7ca634652a21b7b81",
-        "is_verified": false,
-        "line_number": 8399
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "5141712760b6f8738255e8537f65d3e622cbe1e5",
-        "is_verified": false,
-        "line_number": 8409
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "ec79a07d7c17fc486f4f49bfe2e75c0b51140622",
-        "is_verified": false,
-        "line_number": 8419
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "6362f019e14bbf20d1e6ad806084ed8b884c127e",
-        "is_verified": false,
-        "line_number": 8429
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "a7e00ef60ba7d925c5a3a676eb6dae55ac011669",
-        "is_verified": false,
-        "line_number": 8439
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "c73aa1276d6f4de3c6fe52fd64e698098495ac37",
-        "is_verified": false,
-        "line_number": 8449
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "1385660e9388e45a145d5a275de33375df9b939c",
-        "is_verified": false,
-        "line_number": 8459
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "d81ce9e263187faedf3213a33b171bae059e24b3",
-        "is_verified": false,
-        "line_number": 8469
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "76862025cebf4a087d520725042b31bbc8be619e",
-        "is_verified": false,
-        "line_number": 8479
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "377cf491e0da3a93ba99ea2408d2600af7c123d7",
-        "is_verified": false,
-        "line_number": 8489
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "16b464fb34fc00a449ea15f45bdf93ef34bd35ac",
-        "is_verified": false,
-        "line_number": 8499
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "b114f6a238b42c2120743243701962b7dcf3a0d5",
-        "is_verified": false,
-        "line_number": 8509
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "0cb27adf6dfe307d0b1ec61fdd2caf2fc802fefb",
-        "is_verified": false,
-        "line_number": 8519
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "9d82b32db2b75c5d82453965a1a2131c37a48cf5",
-        "is_verified": false,
-        "line_number": 8529
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "bc3c6661e3b6d1c7c08dff5e28b14ff13008dbf3",
-        "is_verified": false,
-        "line_number": 8539
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "98a9b1048e76ea3a1171f0b0b1d494c3b04453d2",
-        "is_verified": false,
-        "line_number": 8549
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "7fdfb7da6cb7d26430217564219aa93ec0ad8385",
-        "is_verified": false,
-        "line_number": 8559
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "67e057848a2a6c0c5c4a567b0be3a5220c555ddc",
-        "is_verified": false,
-        "line_number": 8569
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "5bbe589a1facd555bc6f18bde628d5f2e32af1d0",
-        "is_verified": false,
-        "line_number": 8579
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "b1bbe9d4e5aa77f18095557f4152997d56213c15",
-        "is_verified": false,
-        "line_number": 8589
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "b1b2c585b0348fb53adce329c66e9e74951a1f48",
-        "is_verified": false,
-        "line_number": 8599
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "f83351a1b921c3a891c46d60aa4b6b75d9d71045",
-        "is_verified": false,
-        "line_number": 8609
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "4f4db97d4304166affe4dd6bcde0fcebf02c1fbc",
-        "is_verified": false,
-        "line_number": 8619
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "1453475e85b7450a532542fa4678ceb137576d15",
-        "is_verified": false,
-        "line_number": 8629
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "573383c3ba016a38ac029324a63539a917410dd8",
-        "is_verified": false,
-        "line_number": 8639
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "3601e4957f1869060d968ad6784beafd6eec1a21",
-        "is_verified": false,
-        "line_number": 8649
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "f05ef01b16b54dd2960c10371eaeabdcf79bfc4d",
-        "is_verified": false,
-        "line_number": 8659
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "c568a5d53365823403d8cd7ee857551f0634e501",
-        "is_verified": false,
-        "line_number": 8669
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "a5092d68122504f04063b80d6ca5d42fdbdc9882",
-        "is_verified": false,
-        "line_number": 8679
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "fa22689c4db036e8fd479fa50bc3b3245a0c7f39",
-        "is_verified": false,
-        "line_number": 8689
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "885acf2cd1e1c96e59746004de65ebcaac954d22",
-        "is_verified": false,
-        "line_number": 8699
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "0825e5e8f47f6649a0c036694221a812df028919",
-        "is_verified": false,
-        "line_number": 8709
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "174cb84e3751ba451d68dfa02463a4db6c69baa6",
-        "is_verified": false,
-        "line_number": 8719
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "8dd518846da1264583fdb37212ccba8b70647903",
-        "is_verified": false,
-        "line_number": 8729
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "80e3a04a6297eb4c9fe0aac006763a96556c71dd",
-        "is_verified": false,
-        "line_number": 8739
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "afc2e355f5bd6ea925aac95bb240b4e978e961c4",
-        "is_verified": false,
-        "line_number": 8749
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "7a46ef1db7b635be367b0868d719282bbef35446",
-        "is_verified": false,
-        "line_number": 8759
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "c6fbb91f2fa103c2ad8d431adc2960796b3a9390",
-        "is_verified": false,
-        "line_number": 8769
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "998544e0b262c5e03a2770c163ca1723b1a7783a",
-        "is_verified": false,
-        "line_number": 8779
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "ede7347f662ab8f28117d6d07e70bdf0abf8c785",
-        "is_verified": false,
-        "line_number": 8789
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "92d80bf4a0f716434a4adfa5decba38d8d351abe",
-        "is_verified": false,
-        "line_number": 8799
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "d9221016eee8c9fe51cbeb09eb6a1f5eb1379e2d",
-        "is_verified": false,
-        "line_number": 8809
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "930e5c1e89e5ef8a82ac62f58b9975d8837725cd",
-        "is_verified": false,
-        "line_number": 8819
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "29ad684e80f2f79c9a21af39c6a1cff4844d2665",
-        "is_verified": false,
-        "line_number": 8829
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "5b5efddb2afdc841aec2245428c7665a4a56d38b",
-        "is_verified": false,
-        "line_number": 8839
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "e2d7b04f02e9910894e829e40253843e4acda9a2",
-        "is_verified": false,
-        "line_number": 8849
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "ca0bae6adf3d94e41c8c06e2f25d2ab4ea616b86",
-        "is_verified": false,
-        "line_number": 8859
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "23978a044a7378ab33a88a375f2bc34146186a2b",
-        "is_verified": false,
-        "line_number": 8869
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "af48651639c63b4b67f78bd5be335431b1f0e7b0",
-        "is_verified": false,
-        "line_number": 8879
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "0f74782bbb07fb39bd8714d4635771142ad32c0e",
-        "is_verified": false,
-        "line_number": 8889
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "fa53a92e6ec639b81572d53ea7d1388738abf97e",
-        "is_verified": false,
-        "line_number": 8899
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "75b843bd600e562b8f8d5de4867c624b92207eb3",
-        "is_verified": false,
-        "line_number": 8909
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "c8336a4a539d2cc2fde874dbce0d772da8202ab2",
-        "is_verified": false,
-        "line_number": 8919
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "70344a346638a574cd637467288050dfacb78ad2",
-        "is_verified": false,
-        "line_number": 8929
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "72e6c9bd0e9e21399d917dafb4929af12400ceed",
-        "is_verified": false,
-        "line_number": 8939
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "9e66d1c846d945782b88d362657745e317469351",
-        "is_verified": false,
-        "line_number": 8949
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "41a241fd66f998ab2eb6c642c18f7c79ae32f675",
-        "is_verified": false,
-        "line_number": 8959
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "6875c3ec68ec0ecc777a03b6e86bab2dc98cca61",
-        "is_verified": false,
-        "line_number": 8969
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "f9c81c14a533ae3102fddc2fd03e60a00f7e1f70",
-        "is_verified": false,
-        "line_number": 8979
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "8f0658bfd5cba3680e51b8aaa413eef939656248",
-        "is_verified": false,
-        "line_number": 8989
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "ae6c8285d7caebafa077035aee6496cd30dc0dbd",
-        "is_verified": false,
-        "line_number": 8999
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "0175f0fee128eeebb7df0c7b9080442d509434f8",
-        "is_verified": false,
-        "line_number": 9009
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "dd9b859ca34ec6e22800cb0cfb3c370cc758c379",
-        "is_verified": false,
-        "line_number": 9019
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "5643be7f62bf06031e86e7115038e4f6b983b785",
-        "is_verified": false,
-        "line_number": 9029
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "4153ea25ee20f96020768ac621cb35f32a66daa1",
-        "is_verified": false,
-        "line_number": 9039
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "2316f3f0c1e5cfca142ec3ab3182b63fbe94fb0f",
-        "is_verified": false,
-        "line_number": 9049
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "036de490fa1a2a887ebab8f4d8cf1ad36ec06cae",
-        "is_verified": false,
-        "line_number": 9059
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "e189658fba630dcc1890b185fafa873681eddebf",
-        "is_verified": false,
-        "line_number": 9069
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "f4573e277915451dff82b889926d88e653ee6984",
-        "is_verified": false,
-        "line_number": 9079
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "6e55d4c6ac736291b1a5a598836e8f2c25fb5348",
-        "is_verified": false,
-        "line_number": 9089
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "ff8769e1252b101ff23803468604a2e365f09834",
-        "is_verified": false,
-        "line_number": 9099
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "ed8eb71dfc8ff413f00c6aae947a84289bb2cadc",
-        "is_verified": false,
-        "line_number": 9109
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "3388d77d585269b80dd39507370c98ed923aaed1",
-        "is_verified": false,
-        "line_number": 9119
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "000d0682010acd3e86f47e46e0c0270d580c9141",
-        "is_verified": false,
-        "line_number": 9129
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "16943115e455fe0ec614121808e50571c6807427",
-        "is_verified": false,
-        "line_number": 9139
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "7525bb14c8a26fc71c9afdefced21208d2f6cbda",
-        "is_verified": false,
-        "line_number": 9149
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "117d08441b2ff8afef01b2b59b77f8f081d3ae56",
-        "is_verified": false,
-        "line_number": 9159
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "e247cf97b7bcca2415fe89928129a35e1e6ef5db",
-        "is_verified": false,
-        "line_number": 9169
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "58e6d3fe2de2fffba293a82af89e38dfb2da3575",
-        "is_verified": false,
-        "line_number": 9179
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "e8c93c8a1efb96b68c32f7cd0b0c67e893326b28",
-        "is_verified": false,
-        "line_number": 9189
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "f5748fc0b48dec78f2aba23af03a8ff9bc72c0fe",
-        "is_verified": false,
-        "line_number": 9199
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "3bd1bada930c4f71488b9f5b057dd7dd75e90ba4",
-        "is_verified": false,
-        "line_number": 9209
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "4f0c88da39466825279abca45ca994e4aa8826b5",
-        "is_verified": false,
-        "line_number": 9219
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "232c7c8c09be2cb96d65ee4661a680932c357c52",
-        "is_verified": false,
-        "line_number": 9229
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "b17daa15cd9af7e7e9a3f8a4d07bc6e414b8ea84",
-        "is_verified": false,
-        "line_number": 9239
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "25bf61be7b312c5092c659a9bc06b0a4aae7706a",
-        "is_verified": false,
-        "line_number": 9249
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "e16522926c1a61ef020ce89bef52e255ce4d5a20",
-        "is_verified": false,
-        "line_number": 9259
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "c1018ffa7c740de511790ed5c98e970f8dea3f1a",
-        "is_verified": false,
-        "line_number": 9269
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "e1d1f7ac4a36100e92eff0495a167c0d3fe185c0",
-        "is_verified": false,
-        "line_number": 9279
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "7a2fcf8263e28184b0eab397f1e9bee3d00da0ce",
-        "is_verified": false,
-        "line_number": 9289
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "fb72cad1046adf68e74359e5bb7204ded42f153a",
-        "is_verified": false,
-        "line_number": 9299
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "cf90c4fe6930b07f4477319b2e7af762b27d68ff",
-        "is_verified": false,
-        "line_number": 9309
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "3e61a2ef144da0e8b7c05fc37ff5435113545757",
-        "is_verified": false,
-        "line_number": 9319
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "a11c23910dbd265af0a5cba977aa81113a4365b9",
-        "is_verified": false,
-        "line_number": 9329
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "effcc972a2f7a450d78c0344cd45a84b0f8f7444",
-        "is_verified": false,
-        "line_number": 9339
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "016608b367880ed4419443511aa55b39a7d54dbe",
-        "is_verified": false,
-        "line_number": 9349
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "f893274343dd5da2fa4d230ebfe106081d0fea23",
-        "is_verified": false,
-        "line_number": 9359
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "e18979b73306b19fca0be0c32a37b538d92245b4",
-        "is_verified": false,
-        "line_number": 9369
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "92ffd0255a2d89e269e2420ba52b1a7b92fd1ddf",
-        "is_verified": false,
-        "line_number": 9379
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "8206695ad28fbdd18e07fb4e092895473f00fed3",
-        "is_verified": false,
-        "line_number": 9389
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "36f1bc5d26cb9ae43c654e6301e2f54ec47b8f88",
-        "is_verified": false,
-        "line_number": 9399
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "ad7f1b05e65a7350187de065e1a3cb1fc9095410",
-        "is_verified": false,
-        "line_number": 9409
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "1d5fb4b3d5106d591034ce5a78a0e471285750bc",
-        "is_verified": false,
-        "line_number": 9419
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "2884ade7dcc7bfdeb4622646caf6d6de22a6cedf",
-        "is_verified": false,
-        "line_number": 9429
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "25bbb2cb6ee1535a2c21d26a27c0d7a8c2d93e53",
-        "is_verified": false,
-        "line_number": 9439
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "111f4cacb7ba82dc387f9f7cb2bf7617022ee55c",
-        "is_verified": false,
-        "line_number": 9449
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "7d3a7ebe37932a7984f0f307493db1551944dd69",
-        "is_verified": false,
-        "line_number": 9459
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "5bd3c0feef9b2e80c1855f4159e724db18f92a87",
-        "is_verified": false,
-        "line_number": 9469
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "ff729cc9efcae3abcc6adcc078b3508952a4daa4",
-        "is_verified": false,
-        "line_number": 9479
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "8bb1f925db1baa2fb29583f2b6bfc71160ca92eb",
-        "is_verified": false,
-        "line_number": 9489
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "5e329efe3d00b20b9d606b7b70a13cc4705dd3f5",
-        "is_verified": false,
-        "line_number": 9499
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "df02bb576b9339bd814aecf47df09199b0d8060d",
-        "is_verified": false,
-        "line_number": 9509
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "377e969d833d0b5aae275372e8114d99b4d4f51e",
-        "is_verified": false,
-        "line_number": 9519
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "9056c899110ebceee1bb223808666f416219c247",
-        "is_verified": false,
-        "line_number": 9529
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "370aaacf5bb6d450a4ec3beb737c08c001f3b9ca",
-        "is_verified": false,
-        "line_number": 9539
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "13282fd603cc5a7aa73ef65702bb3663acb99e4f",
-        "is_verified": false,
-        "line_number": 9549
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "ef2bc4e90b3985225b63ebba9edb4aa5a9b2807d",
-        "is_verified": false,
-        "line_number": 9559
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "bbaf5035844949507b214712b5a405aeb26c25dc",
-        "is_verified": false,
-        "line_number": 9569
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "5e3c75d63e341e1b26944b1e61535e0a64bab409",
-        "is_verified": false,
-        "line_number": 9579
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "313b0523c190d9a3212885bd4a553e49e10e3d88",
-        "is_verified": false,
-        "line_number": 9589
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "dc893602cc81cc762cc32c0133a82cbfcc01f96d",
-        "is_verified": false,
-        "line_number": 9599
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "3d03f57c12bcaab6e697a0955be487c2fe7f24ee",
-        "is_verified": false,
-        "line_number": 9609
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "ce3fd3ea7d1031192dcd1548c283beac9921d36a",
-        "is_verified": false,
-        "line_number": 9619
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "af3b693d5e93919cf131a302b72824efd64e5132",
-        "is_verified": false,
-        "line_number": 9629
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "4bea50b6377e7664922db123d66a880292728515",
-        "is_verified": false,
-        "line_number": 9639
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "b51144279eef569e3214c5eabfc742c29028d9f1",
-        "is_verified": false,
-        "line_number": 9649
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "c80d67385cfe13b53d132a8ff669e19ac2ba78af",
-        "is_verified": false,
-        "line_number": 9659
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "74a19cb7061c46dd76b3ca34ee16c36343ceba68",
-        "is_verified": false,
-        "line_number": 9669
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "3828dbe1f49560d8e1edb3679fbbc9f8d9057fad",
-        "is_verified": false,
-        "line_number": 9679
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "0040480b03c231e1c9b0368582238ddac28d3580",
-        "is_verified": false,
-        "line_number": 9689
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "aedc4cd7a45db0075ce487f4c41ec2f79fc3ee69",
-        "is_verified": false,
-        "line_number": 9699
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "58dffddda2b2874e4c389435555f572c893adfdb",
-        "is_verified": false,
-        "line_number": 9709
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "bd57891dbb8d020e7ae7fe4df54442e033b07a20",
-        "is_verified": false,
-        "line_number": 9719
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "ea94af04fde55109361bc90011bf599cb09f3a2f",
-        "is_verified": false,
-        "line_number": 9729
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "2d0a25a2dbf6ad55907862046ba5d3872cd8bdff",
-        "is_verified": false,
-        "line_number": 9739
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "4f10f0932b0b0218cb94332a99dd2c43f4edca02",
-        "is_verified": false,
-        "line_number": 9749
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "e28b1d673f90c123300a8bb58839a964bf51b39f",
-        "is_verified": false,
-        "line_number": 9759
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "7ef4467fd4a92b07ee992ce55a2004f05859478c",
-        "is_verified": false,
-        "line_number": 9769
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "dc349fe6ac9a77dfff3f67fe2b0d04b40287a3a1",
-        "is_verified": false,
-        "line_number": 9779
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "6a23984ef18ae81f40e0dea4889bd0f476b57b8a",
-        "is_verified": false,
-        "line_number": 9789
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "e15f3e68253bf2bff33ee80564b4dd6ed78cd102",
-        "is_verified": false,
-        "line_number": 9799
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "54ffb06e656cb721334d4cf3a05c5d07aa6a8610",
-        "is_verified": false,
-        "line_number": 9809
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "4f92004e39232e98659a797983410c1d8a070681",
-        "is_verified": false,
-        "line_number": 9819
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "4281dcc75268b5a38e691ea59318919fcd4ddfa0",
-        "is_verified": false,
-        "line_number": 9829
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "a106ce46a590be9430ae140c78a485d9597267d3",
-        "is_verified": false,
-        "line_number": 9839
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "1ffbe24432f519644b4aeac895cb9b2801474bd6",
-        "is_verified": false,
-        "line_number": 9849
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "a6920fac494ae07872b96a9fd6b26aee4f16fc4d",
-        "is_verified": false,
-        "line_number": 9859
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "a329394775da473e0a1c9cb28a04ebc805482aaf",
-        "is_verified": false,
-        "line_number": 9869
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "508fc73c17c280acc7fe98747e4155a017aa14ad",
-        "is_verified": false,
-        "line_number": 9879
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "49524d0e73db8202e50536b76ba578b0cf473c11",
-        "is_verified": false,
-        "line_number": 9889
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "2bff9123b0bd5efc3ae71c09c2f67937a30342d0",
-        "is_verified": false,
-        "line_number": 9899
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "935f6f816380667c22896cfba36819a0007c2bfd",
-        "is_verified": false,
-        "line_number": 9909
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "70733b57d05aa069c10646855bc80b9418be84c5",
-        "is_verified": false,
-        "line_number": 9919
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "eaf7a341ed37eccd265769e11292b66ec56ebff1",
-        "is_verified": false,
-        "line_number": 9929
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "0239384bd905fb4693d89455d1ee5463c8306414",
-        "is_verified": false,
-        "line_number": 9939
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "fc5de5bfe0c44ffb0ef04270a6a0094788bc2d14",
-        "is_verified": false,
-        "line_number": 9949
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "93929906ebc82683f4a0ef03404ff18c08f253f4",
-        "is_verified": false,
-        "line_number": 9959
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "385149c942797a92ad102d936433de5b3b74e3a2",
-        "is_verified": false,
-        "line_number": 9969
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "14b1cd8e286a30bd6b8875d403603cdb64dfa8a7",
-        "is_verified": false,
-        "line_number": 9979
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "d3d73efbabc5edb370ffaf2f5fc0eeff88e6d0c5",
-        "is_verified": false,
-        "line_number": 9989
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "e210b0b2e4c6af45550f232ad27901f1e63daacf",
-        "is_verified": false,
-        "line_number": 9999
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "d4b09f43cb8d7ac5a103daca3622ff22479bc75d",
-        "is_verified": false,
-        "line_number": 10009
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "c57bcd8ff392271a68307f82cac4dd71f6258706",
-        "is_verified": false,
-        "line_number": 10019
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "fcfdd8b48fcaa3b9f5d011706c7dc0612819533f",
-        "is_verified": false,
-        "line_number": 10029
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "424b827362d1cb8ce29d69b5d929616655a0c5e1",
-        "is_verified": false,
-        "line_number": 10039
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "cf2863d2bb034b2d662325b978b10fd2ae3c3da4",
-        "is_verified": false,
-        "line_number": 10049
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "38e5e1994f6e033eb9c6dda42f76a2c87102db84",
-        "is_verified": false,
-        "line_number": 10059
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "4216aaaa1fbf291257717d240732db8edc276dce",
-        "is_verified": false,
-        "line_number": 10069
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "ea5e22a4d59208b9a8b57e6b17e231fe93917615",
-        "is_verified": false,
-        "line_number": 10079
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "9d8298f8b9dec182137bbde842a27b11b4f40794",
-        "is_verified": false,
-        "line_number": 10089
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "adba751fde529ebecf43308dfce955d205386f08",
-        "is_verified": false,
-        "line_number": 10099
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "49687488261a26aeadb250688bdc13d0bfaf7dc0",
-        "is_verified": false,
-        "line_number": 10109
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "01bb3cb9ec2ec67006b1bb10e9c7b07b304ac894",
-        "is_verified": false,
-        "line_number": 10119
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "88afcc3485a5a188bde65ba30f0350f41643ea1e",
-        "is_verified": false,
-        "line_number": 10129
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "5b7ac97b279ad6010c71847d357f9c41a9338031",
-        "is_verified": false,
-        "line_number": 10139
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "cf1262189d9adb03ac80e6cdb58ad36d81352a23",
-        "is_verified": false,
-        "line_number": 10149
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "a3400578dd72be0cb0bf8851699c954e45b85768",
-        "is_verified": false,
-        "line_number": 10159
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "ab3077b90a6ad64fd307773ea97cdc7e0cd9acb9",
-        "is_verified": false,
-        "line_number": 10169
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "5c53972c33519a1f2d3e62c3cb664a739432f824",
-        "is_verified": false,
-        "line_number": 10179
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "cee35f971542379d3ca27dc59766e751f8871b69",
-        "is_verified": false,
-        "line_number": 10189
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "4b1c94f0c5a65bca9b8cb1620599feaee5e82c8f",
-        "is_verified": false,
-        "line_number": 10199
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "2ab404fc8b842e49e076d569d0406100c99e7ed0",
-        "is_verified": false,
-        "line_number": 10209
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "4e7e4be936061e4ed9496b63460e0dcd2f44c4a8",
-        "is_verified": false,
-        "line_number": 10219
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "1e9cc51aa9875f751093a12e25a4ecb8d319f0fc",
-        "is_verified": false,
-        "line_number": 10229
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "578293e9bbce12b6fb255a6cd4075fa6a01d3b39",
-        "is_verified": false,
-        "line_number": 10239
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "bf3bd7ec6bd15409e3b750c8b2ce5dc422cd4dd4",
-        "is_verified": false,
-        "line_number": 10249
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "9dc965b5ebea65772cc08c2afbaf03cdc1348e21",
-        "is_verified": false,
-        "line_number": 10259
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "ec3f36ef0f3c3ad3f9e4651b97c9f133e3fe2c91",
-        "is_verified": false,
-        "line_number": 10269
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "7096c3d037dbfcfcda8477eeb0755230c8a5da25",
-        "is_verified": false,
-        "line_number": 10279
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "2dd3224401b3bba098fe8d5feb8aa2b6b3b6bf4c",
-        "is_verified": false,
-        "line_number": 10289
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "23cc7ccb1a682a9ab5af27e0b95507bec7d4055a",
-        "is_verified": false,
-        "line_number": 10299
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "511d18d836f4adabcdeac9c8771e4c8aeaf31e84",
-        "is_verified": false,
-        "line_number": 10309
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "c1326df9c085536611b16cb6ff67c056cd8232d2",
-        "is_verified": false,
-        "line_number": 10319
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "f2074ff1008a18d2d786bf476251b5f548afc141",
-        "is_verified": false,
-        "line_number": 10329
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "14ace41bdbe7b054884bd88bc51a1888ad6a9719",
-        "is_verified": false,
-        "line_number": 10339
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "b0751d95b15ea9637545bd69e284d26390044d46",
-        "is_verified": false,
-        "line_number": 10349
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "674aca25ee8f79bc99728c30cc22d3a7f4853384",
-        "is_verified": false,
-        "line_number": 10359
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "079e25a33a106c0203c823a73888a87f5d2096ce",
-        "is_verified": false,
-        "line_number": 10369
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "8e4af704786fcd7a2b6a0b63c14cbe47d3c20de5",
-        "is_verified": false,
-        "line_number": 10379
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "2654839b4f513853a9e3079aa3b027506bd89c26",
-        "is_verified": false,
-        "line_number": 10389
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "ecd731b0b0639d80bdbf150339931cbf6dabf693",
-        "is_verified": false,
-        "line_number": 10399
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "96163fa11562df876b56f20949439c1143e42a75",
-        "is_verified": false,
-        "line_number": 10409
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "5f0b90b0e0db76149353cde35b0d507fa97f9974",
-        "is_verified": false,
-        "line_number": 10419
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "1bbec85e6612cf6f329d38b0fa117b135b52e6a5",
-        "is_verified": false,
-        "line_number": 10429
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "e12ce5339c1c1e8e3bd70840f365e1d0a7033ddd",
-        "is_verified": false,
-        "line_number": 10439
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "0f54d72be70bfdf80494ddf490832f7f34b68441",
-        "is_verified": false,
-        "line_number": 10449
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "51238909dd9813c5ef76c1d92b6bc8e54d946342",
-        "is_verified": false,
-        "line_number": 10459
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "745326e0c8a35b6709f16f6b59c2027385c2a66c",
-        "is_verified": false,
-        "line_number": 10469
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "991461ca306fe0bf78ddc25a8b039b19c913d04c",
-        "is_verified": false,
-        "line_number": 10479
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "41e98b535292006fc3a8b35b78cee7c7f1aeab51",
-        "is_verified": false,
-        "line_number": 10489
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "dc856cd67032e5f0a77be07c43d289f6035c347c",
-        "is_verified": false,
-        "line_number": 10499
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "7fecd61e991eb90a0ebd89a033ffd9c645cbfd04",
-        "is_verified": false,
-        "line_number": 10509
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "c5eb757439399f81150cdfaf7159466ab83824dc",
-        "is_verified": false,
-        "line_number": 10519
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "faad247f360bc5ef69424e97c3a0d6c5c20c76dd",
-        "is_verified": false,
-        "line_number": 10529
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "41c32d880666e01f3c64fa6c930c3d174b463777",
-        "is_verified": false,
-        "line_number": 10539
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "deb463f5e04db33c2d227e7b9cfbf6cd1e7663ec",
-        "is_verified": false,
-        "line_number": 10549
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "c99488352a0c3f458887b42ef9e4dd9df7b044dc",
-        "is_verified": false,
-        "line_number": 10559
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "983b7fb0980dbaeea04902d91892b486dfca1509",
-        "is_verified": false,
-        "line_number": 10569
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "2c9189cc12ce321c573346e4c3fae369eceb5fcf",
-        "is_verified": false,
-        "line_number": 10579
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "d32c740c7cc02ce19a9580ee4baa76ef13b60e19",
-        "is_verified": false,
-        "line_number": 10589
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "44d84a37b496849404f18843f70f952b7cb31cd5",
-        "is_verified": false,
-        "line_number": 10599
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "6283f21aa9e8475d4dd4d38bb47c49329e87b122",
-        "is_verified": false,
-        "line_number": 10609
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "d840aefa09542313911509570e09b4bbcd9f3dd6",
-        "is_verified": false,
-        "line_number": 10619
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "b2cf0b75ae2eddd98b0d1b7f7cdff842a7d48d8b",
-        "is_verified": false,
-        "line_number": 10629
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "05d9f7d89d656a1718ed16a449c2debf212b706a",
-        "is_verified": false,
-        "line_number": 10639
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "79b2cca960e656f3113e6368250a6f1f7644e52b",
-        "is_verified": false,
-        "line_number": 10649
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "82efa5b8cd488b0a05b387a81d6529f11e826808",
-        "is_verified": false,
-        "line_number": 10659
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "104a1c6fb6911c6a520b8257eef803375849363e",
-        "is_verified": false,
-        "line_number": 10669
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "4734c10471de0f1fc39b05c5769f9e1e7aea404b",
-        "is_verified": false,
-        "line_number": 10679
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "b3180b612c666a0847f98286de2b69901f5bd094",
-        "is_verified": false,
-        "line_number": 10689
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "ec844b1ba7dee6eedc5a784fdd8743cb1269447e",
-        "is_verified": false,
-        "line_number": 10699
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "033263ff6e83951fd7dde6f7393272027346fa25",
-        "is_verified": false,
-        "line_number": 10709
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "6d732586e73eae6382c1cdb99e4b8a0ea637a571",
-        "is_verified": false,
-        "line_number": 10719
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "833a4def789ce6c762d00804ab9d71e52c0a0181",
-        "is_verified": false,
-        "line_number": 10729
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "8bf5fae04f84f3e19cd406a266132eeb3b3ea4a7",
-        "is_verified": false,
-        "line_number": 10739
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "79c5dbf8edd3391ddf344fb43fde52426a955d4d",
-        "is_verified": false,
-        "line_number": 10749
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "33b14dc1b8c40ee3a7ab4a800254cfe458e808c8",
-        "is_verified": false,
-        "line_number": 10759
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "bc4ecc0a6eba97ae5f9264e1ab2e7dbc39b6ec85",
-        "is_verified": false,
-        "line_number": 10769
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "d048097bd167422679a3f0e143fc404c42418c3d",
-        "is_verified": false,
-        "line_number": 10779
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "304dcb8d083cb685d7d921d8ac10bd7606c2bbbb",
-        "is_verified": false,
-        "line_number": 10789
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "8d27a53d075ff1122942a0efac10bdcf3de71f14",
-        "is_verified": false,
-        "line_number": 10799
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "59e60088225c5d9400103aa34282f27434fd3eba",
-        "is_verified": false,
-        "line_number": 10809
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "3d61bbb7192a784643afac32a3817c30e8fd533a",
-        "is_verified": false,
-        "line_number": 10819
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "df06a16a33865c007486b3b7621698c70d7360e7",
-        "is_verified": false,
-        "line_number": 10829
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "ab81ac89beee77d9f52662b4c19d266f6a7caf8d",
-        "is_verified": false,
-        "line_number": 10839
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "a04395867f74802a0f4891faf7a50a48e0ab8a35",
-        "is_verified": false,
-        "line_number": 10849
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "89c3a254bcc9d190fa0c5e68d68d61f4b63b3829",
-        "is_verified": false,
-        "line_number": 10859
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "c574d6a0ee56b9352a1090e3cec42c916c5340e3",
-        "is_verified": false,
-        "line_number": 10869
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "16e13eff6fb74a12664d935248970298b5d923e5",
-        "is_verified": false,
-        "line_number": 10879
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "7b7c5c2a351fcb5508c4bc1bd141928fa88e9db0",
-        "is_verified": false,
-        "line_number": 10889
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "36b0f4e0536cd994e5f33079fcd642a92b64c2b3",
-        "is_verified": false,
-        "line_number": 10899
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "7facfeaf13c0721eddf0fcc303af1eeac7486758",
-        "is_verified": false,
-        "line_number": 10909
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "776aabf865e556acad89b4b6a767601c330d9482",
-        "is_verified": false,
-        "line_number": 10919
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "8644fa5b63851aca44b3dfada469258635e32e5e",
-        "is_verified": false,
-        "line_number": 10929
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "63bc52e94f66b0211a5fb5dc1485dbf0fc229a0d",
-        "is_verified": false,
-        "line_number": 10939
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "42ede18fad90d884ddf348b2f51a60f63008dbc1",
-        "is_verified": false,
-        "line_number": 10949
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "4519cf454a3e95bfb19c565cc85307121371c6fe",
-        "is_verified": false,
-        "line_number": 10959
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "d579d09c55efa33f2fe96a3f3a1642c07bce2c0d",
-        "is_verified": false,
-        "line_number": 10969
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "69fe5f87e682ffec9aebad1c4e30800efb3eb217",
-        "is_verified": false,
-        "line_number": 10979
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "f203bcce5fb2967bbb01f3d1efad1ebe13d38c7c",
-        "is_verified": false,
-        "line_number": 10989
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "8fe0f74e29a115287d29dc38763e72bbdc2561f3",
-        "is_verified": false,
-        "line_number": 10999
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "0966399b34f797329e566efe982a86a78819e5be",
-        "is_verified": false,
-        "line_number": 11009
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "a3d9bb75f6af17fd1f091d7397bbdbe71728aa69",
-        "is_verified": false,
-        "line_number": 11019
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "6e37caf42d6fe88a8ab65035d9779d0409d2dbb0",
-        "is_verified": false,
-        "line_number": 11029
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "b7130a6699889fe90c3f58025174b07516de6695",
-        "is_verified": false,
-        "line_number": 11039
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "2b2005cad8fc6c1e451bc5874aa332072435bd61",
-        "is_verified": false,
-        "line_number": 11049
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "64037e1f55216a7ddd4ca72a68501af212b40f22",
-        "is_verified": false,
-        "line_number": 11059
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "55afca476e2ca2773022913d20152225dec16c15",
-        "is_verified": false,
-        "line_number": 11069
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "b41bfd2723a13f14f6fcd31abd7c36aad1a290cc",
-        "is_verified": false,
-        "line_number": 11079
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "55d42a212fb7f1c3b80f86123356d114c64fdec7",
-        "is_verified": false,
-        "line_number": 11089
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "6fdad115a1de702d0f96cae837cc77cb60689794",
-        "is_verified": false,
-        "line_number": 11099
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "481f2c1e8f080f12877f1967b0d936a3aa6219e4",
-        "is_verified": false,
-        "line_number": 11109
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "74869312fe491c9f288b9c1a33d579e235b690dc",
-        "is_verified": false,
-        "line_number": 11119
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "a90770f832212c9d9ad04a88bdd0b465c68b3887",
-        "is_verified": false,
-        "line_number": 11129
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "6dbbd39ee22edf21db7745d7db21eb82f6dd5f68",
-        "is_verified": false,
-        "line_number": 11139
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "5e15721e14013e0373c953e72b64e2f62fb6effd",
-        "is_verified": false,
-        "line_number": 11149
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "fca686a75b314d19c8db8a56fc5ed07e59adade9",
-        "is_verified": false,
-        "line_number": 11159
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "617dddb327d944c8db33489fb1888710fd4a646d",
-        "is_verified": false,
-        "line_number": 11169
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "55ece85f593f2a57105f386995fe0840ffb58ee0",
-        "is_verified": false,
-        "line_number": 11179
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "6de5a003d3987c3fe1c2c8a505c20840711aa721",
-        "is_verified": false,
-        "line_number": 11189
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "ed67de095f4cb80d24e229124a3fe4026e0b80c2",
-        "is_verified": false,
-        "line_number": 11199
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "1d2e19e76744780a30fcd052c789ef75e321157b",
-        "is_verified": false,
-        "line_number": 11209
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "24fe26c7c68aa3cd6fe9feab6a92085c2dd68d9c",
-        "is_verified": false,
-        "line_number": 11219
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "5d072d3feca68c131c4f9c5642fe9d46b3d586e2",
-        "is_verified": false,
-        "line_number": 11229
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "2da20d0c4316e7a692e9a953dce6ef2434413bfc",
-        "is_verified": false,
-        "line_number": 11239
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "21c61b9886c118dfb70ab091c5207c4375152230",
-        "is_verified": false,
-        "line_number": 11249
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "90058a796c2728dc2a7d67876c1bbe68b4dc45fc",
-        "is_verified": false,
-        "line_number": 11259
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "dc4645b84214d2e0773f2d7de7304299f0c155bf",
-        "is_verified": false,
-        "line_number": 11269
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "aab0043239aa825fc714c2f0af88bb772f087a85",
-        "is_verified": false,
-        "line_number": 11279
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "5b941849dbf19d856388977a18715ae7f2ec9d17",
-        "is_verified": false,
-        "line_number": 11289
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "142face45aefb718e9218da61738ece284642983",
-        "is_verified": false,
-        "line_number": 11299
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "772a71b19ca767370ccd12608ad202248d3eabc5",
-        "is_verified": false,
-        "line_number": 11309
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "58177c620e7cafa21295eb6f48bb45aa58f1c582",
-        "is_verified": false,
-        "line_number": 11319
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "a59353f5fc6a1468cfaeccc5f5a6a0f7c93ac503",
-        "is_verified": false,
-        "line_number": 11329
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "3905530084df133ec620764c169b62d00b3eb950",
-        "is_verified": false,
-        "line_number": 11339
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "5b59356cb53f65fc027f7504e4de31559e67b4bf",
-        "is_verified": false,
-        "line_number": 11349
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "a149f1fae774f6dd2348d29183d2a4fbe5ad8a15",
-        "is_verified": false,
-        "line_number": 11359
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "e6dae7d8bf92926664e4d54bc00f39fa56942f8e",
-        "is_verified": false,
-        "line_number": 11369
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "b27f883fec813f092fae1143a138bc2aac33ff80",
-        "is_verified": false,
-        "line_number": 11379
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "a994025ad37138e759c7c66fa95ae55a93bfee95",
-        "is_verified": false,
-        "line_number": 11389
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "0f10bc4e948c96af69e00bc020c93f0c1b7be7a0",
-        "is_verified": false,
-        "line_number": 11399
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "8f261259f354a18fd2f72ce18bfd6eab4c4be90e",
-        "is_verified": false,
-        "line_number": 11409
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "6ff30b29c4b1ef0a350fd6c84494c02177489776",
-        "is_verified": false,
-        "line_number": 11419
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "5be51b27af01303391e44fa22f8591d27d3b4532",
-        "is_verified": false,
-        "line_number": 11429
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "0b26f40112ddebba6fdb60cde0a01f442c6254a0",
-        "is_verified": false,
-        "line_number": 11439
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "f0b0920b9df0ee4743be6e1d270575b37629dd7f",
-        "is_verified": false,
-        "line_number": 11449
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "b94132af6955d7becc83d3f44e13fec39448eead",
-        "is_verified": false,
-        "line_number": 11459
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "cdbaaa77d8172f619d0c8a7b90a227b135918498",
-        "is_verified": false,
-        "line_number": 11469
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "82be5e8101f1b91c2312e933b889e08aa524318c",
-        "is_verified": false,
-        "line_number": 11479
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "48d194bd909420882ee460cda296a4afc23abb3e",
-        "is_verified": false,
-        "line_number": 11489
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "7d02e7c1c155e5830cf297dbcff557a65a9052cf",
-        "is_verified": false,
-        "line_number": 11499
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "3cdb2b49e92cff438ea77f8fcb39a99fb7832d15",
-        "is_verified": false,
-        "line_number": 11509
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "c82c2e11ab3fb350adfb99185c2f5cf9986cc6b5",
-        "is_verified": false,
-        "line_number": 11519
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "57bee7e0d2f64728ac5ab8e47d42ff997ee3b3e8",
-        "is_verified": false,
-        "line_number": 11529
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "eaf8ff53fbf171919339ba763036b9191b273390",
-        "is_verified": false,
-        "line_number": 11539
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "db0efbd6b287d663febd79e78f2685eeb572b82c",
-        "is_verified": false,
-        "line_number": 11549
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "335ec84f2b9bf9cf1705e5e8f9a71781ba4fe47e",
-        "is_verified": false,
-        "line_number": 11559
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "25688a643ea451299d2dc7bfef36b74f93088ee1",
-        "is_verified": false,
-        "line_number": 11569
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "c88c8dc3efee8add353ca0ca33f084744d9a42e5",
-        "is_verified": false,
-        "line_number": 11579
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "7f476f23dc2bc94c840f7b70f4cacccbd5249066",
-        "is_verified": false,
-        "line_number": 11589
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "d25ed8a7367c1766653b6aa3b79678479cbe71c4",
-        "is_verified": false,
-        "line_number": 11599
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "dc20efa2ea306318a8feb2ab64f1f32ef0a818a6",
-        "is_verified": false,
-        "line_number": 11609
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "5b9f19f88390ec3b06ef324b1fd4325c92cfc90e",
-        "is_verified": false,
-        "line_number": 11619
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "c16254ee598309e59800b8cc0e8a1d3f4bffafaf",
-        "is_verified": false,
-        "line_number": 11629
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "c49fd164655c313ea55b1bc453d33138bced06e7",
-        "is_verified": false,
-        "line_number": 11639
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "eb48e903c47a43feaafcbc71123172c699730e53",
-        "is_verified": false,
-        "line_number": 11649
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "132b0b87ec04853d1786e8518735e020cf991638",
-        "is_verified": false,
-        "line_number": 11659
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "fd54a3b2cc1af1224dfac929ad010ff729f4f291",
-        "is_verified": false,
-        "line_number": 11669
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "86edd60b53d6ca0a841c31203d0edc598a9428fb",
-        "is_verified": false,
-        "line_number": 11679
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "c0e48ae7039c972088ce7d53a51d5ccbd3341b90",
-        "is_verified": false,
-        "line_number": 11689
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "c5622d4c40991f78a2337c41875a49b5e87823d8",
-        "is_verified": false,
-        "line_number": 11699
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "5fd24bb0760ee641454fc87c22011a2082c3fcf6",
-        "is_verified": false,
-        "line_number": 11709
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "0a37dac6247cfd2ab165f9946a5e579c69b078c0",
-        "is_verified": false,
-        "line_number": 11719
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "527aed7a53effce72de6315dcd983f018dfc0b79",
-        "is_verified": false,
-        "line_number": 11729
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "f623858399c7be7bb2479e0c0db7b9214e73d4fc",
-        "is_verified": false,
-        "line_number": 11739
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "f15d0a7ed70aea9043c8cda0bd970bb160622557",
-        "is_verified": false,
-        "line_number": 11749
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "ed6d9785e038cb31309ddb55b1c1650a2abea0c3",
-        "is_verified": false,
-        "line_number": 11759
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "066e182b5aca7d54bf0334293bea74dae9210a1f",
-        "is_verified": false,
-        "line_number": 11769
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "70edc8d69a3528595e2044cc6a38a1fddc55df5e",
-        "is_verified": false,
-        "line_number": 11779
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "f57c64323669f99e17e0c08265ddca75faf4c5dc",
-        "is_verified": false,
-        "line_number": 11789
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "76c011489e4820a1db84c271c578ac4bac87357c",
-        "is_verified": false,
-        "line_number": 11799
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "7bd0fc3fe90c9f4af5a4581274581baa51a006f7",
-        "is_verified": false,
-        "line_number": 11809
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "f2ce300c16004a1fd5bf58cf2bc73f5c12de2e8a",
-        "is_verified": false,
-        "line_number": 11819
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "b18effadae86365bf218a29fdfc06fdd00c814c8",
-        "is_verified": false,
-        "line_number": 11829
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "833a4da52615e8955ce36719fbd9a41e42119c67",
-        "is_verified": false,
-        "line_number": 11849
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "e1c98c63eab081936f766195f647314dcb328525",
-        "is_verified": false,
-        "line_number": 11859
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "a2379346262c7d6a65827c90ccc77ef100db13b6",
-        "is_verified": false,
-        "line_number": 11869
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "29190820b7701d6457c7c2205efdfb56257872cd",
-        "is_verified": false,
-        "line_number": 11879
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "50eca845f2c554a25bde1ffbeab9160823ca702c",
-        "is_verified": false,
-        "line_number": 11889
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "0051b726b62c89943254d7e8c51d8a98c626b42a",
-        "is_verified": false,
-        "line_number": 11899
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "e111ec3c2901f0e3b78c2b3b5b52e88a8275bd1a",
-        "is_verified": false,
-        "line_number": 11909
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "572f7278591aa9758b1c427a4f94d9e904e16622",
-        "is_verified": false,
-        "line_number": 11919
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "aee497e983dc0cc160e8c395ddda24782ece78b5",
-        "is_verified": false,
-        "line_number": 11929
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "46ee269965bd13b49ca592985846e576004b8438",
-        "is_verified": false,
-        "line_number": 11939
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "d0bb3e9c29582d1e9357f544cfdeba89f9be28f1",
-        "is_verified": false,
-        "line_number": 11949
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "cf2fadde6f3866ebd3fbe97bd9d6497ace4a7885",
-        "is_verified": false,
-        "line_number": 11959
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "442be4e5467d9088939413d14e17262482265fd7",
-        "is_verified": false,
-        "line_number": 11969
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "9be6766b0d19ecbce59852ab2280de843059812e",
-        "is_verified": false,
-        "line_number": 11979
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "423512602dd5b26ce191cb0375194e1e25e49259",
-        "is_verified": false,
-        "line_number": 11989
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "efdc23e873c6b241cd7ff8122ffb3ad007b901e6",
-        "is_verified": false,
-        "line_number": 11999
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "58a2147f39b0b31ad4a1a5ca64956a6ea98e8c99",
-        "is_verified": false,
-        "line_number": 12009
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "7e3759eb8604d5aa4d7fb4bcaf350411964486e9",
-        "is_verified": false,
-        "line_number": 12019
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "c0aba90ff76fdcf2aa2ed41a6769dc343a1fb8d5",
-        "is_verified": false,
-        "line_number": 12029
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "ba2af86a51ac1649755a31b630b9a700a6f1f5d9",
-        "is_verified": false,
-        "line_number": 12039
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "4e04c336a9497f70352c63703dca7bbbf80c8fd2",
-        "is_verified": false,
-        "line_number": 12049
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "c858abb5e049094793f25a6e8717342ada078ceb",
-        "is_verified": false,
-        "line_number": 12059
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "490383e0698ee511a2dfd61912f8e1bdcda2628e",
-        "is_verified": false,
-        "line_number": 12069
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "8c1be357d19385e60f5fae632fdb14f8dbee96f0",
-        "is_verified": false,
-        "line_number": 12079
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "3e5abbe49f709f84ff2486ec328f2b6d802a5833",
-        "is_verified": false,
-        "line_number": 12089
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "78269660db83290daf099480515e8049f15506a4",
-        "is_verified": false,
-        "line_number": 12099
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "e0fb9d27cf0cfb09267cbc8df9583fef90707b8e",
-        "is_verified": false,
-        "line_number": 12109
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "4041e1b15d51b04dd1b4839d1b0fda882d1e8ae8",
-        "is_verified": false,
-        "line_number": 12119
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "0d507e8b3e85cfe07d5dc859eee99ed969ad580f",
-        "is_verified": false,
-        "line_number": 12129
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "e46bd54478b80eab4a5f1e634377ae15c1259d7e",
-        "is_verified": false,
-        "line_number": 12139
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "18e3312170838acff8b6e2a3f824dccd565ab2fe",
-        "is_verified": false,
-        "line_number": 12149
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "402f7200eed35604ef8e826d4f300588d4dc413f",
-        "is_verified": false,
-        "line_number": 12159
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "9510386e7b37e641cf8a7798c34de08fef2109bc",
-        "is_verified": false,
-        "line_number": 12169
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "e82afb1173a8c817df28f3cd379c3563a0adef1f",
-        "is_verified": false,
-        "line_number": 12179
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "3897d7f1a3efab556efc12028681ce851117b318",
-        "is_verified": false,
-        "line_number": 12189
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "ae0bcc29b6d4d79a1d1a2639ed9e207e0cd8ede4",
-        "is_verified": false,
-        "line_number": 12199
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "7da1d67afa18747d682fbb347ed851c629a109b2",
-        "is_verified": false,
-        "line_number": 12209
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "3dbfbb5d5877665d4e8ad195eacf42329d05e9df",
-        "is_verified": false,
-        "line_number": 12219
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "70ac67c39a725be186a8bbd895a3d39d614d2b25",
-        "is_verified": false,
-        "line_number": 12229
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "fe2b140f37128d57a2391b83045ca8115f7628cb",
-        "is_verified": false,
-        "line_number": 12239
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "8f6d9e8eaf0dd8aa1993c15767811fe9e5ba32b6",
-        "is_verified": false,
-        "line_number": 12249
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "fe82f4f20ed6199935f6c23fe4253bdcba1de79e",
-        "is_verified": false,
-        "line_number": 12259
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "24f39c75a22cb1705ddf480e4c5ebd03910b0c5c",
-        "is_verified": false,
-        "line_number": 12269
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "6d7b41277f9a500ca0198df463d2d3aa84556f39",
-        "is_verified": false,
-        "line_number": 12279
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "2390843ac8f8e8614128df584b34584cb1a1c803",
-        "is_verified": false,
-        "line_number": 12289
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "0fa9d1bdb1a450b1992723983054194907bf3891",
-        "is_verified": false,
-        "line_number": 12299
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "b2e84429fa9b37710a593189f8b18b83c2b0a629",
-        "is_verified": false,
-        "line_number": 12309
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "58e55795cffaaad39eabef1a1ba50dea8512c269",
-        "is_verified": false,
-        "line_number": 12319
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "15476a155072ba514a8f5247856bca04bc395d64",
-        "is_verified": false,
-        "line_number": 12329
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "f74b1366588401f6096f03ce0e388fea1674b733",
-        "is_verified": false,
-        "line_number": 12339
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "7df5244e5808c9166cfcd7828d40cee21ce2a3be",
-        "is_verified": false,
-        "line_number": 12349
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "519168fa6a2c13d34a5e8b362cce63ddc8d71223",
-        "is_verified": false,
-        "line_number": 12359
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "f3ca1896d9758dc277bc4bb4f32ea7238e64865c",
-        "is_verified": false,
-        "line_number": 12369
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "ca970d97e562193d47267260067d15d86dc72d37",
-        "is_verified": false,
-        "line_number": 12379
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "bc7d2cdf82179b0a39af3e37f917f5cf3b2e2736",
-        "is_verified": false,
-        "line_number": 12389
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "d3e43909ccc24968ad6e29c2bf515f74b80dfacf",
-        "is_verified": false,
-        "line_number": 12399
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "e060913c218d7853fba2c8453060bd3cf3e939b9",
-        "is_verified": false,
-        "line_number": 12409
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "0d36d5c3411fc9589172f3ea917c27eda6d3e038",
-        "is_verified": false,
-        "line_number": 12419
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "c02b41a897e484aca07c0710890973a28377f448",
-        "is_verified": false,
-        "line_number": 12429
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "ae820ee7324f1fd02c7cea590e0713b6d63065c4",
-        "is_verified": false,
-        "line_number": 12439
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "9dca38181429668c8b5eb9db701fdb6f0537a9e0",
-        "is_verified": false,
-        "line_number": 12449
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "f647d30cc28438dcbf0b8dd45a484f0aac3db7c0",
-        "is_verified": false,
-        "line_number": 12459
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "5462f285abfe199879a8de3424ec9750c542352b",
-        "is_verified": false,
-        "line_number": 12469
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "760a5ef4361538113e8509b267174544c6e7894e",
-        "is_verified": false,
-        "line_number": 12479
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "1d00fa31efdf84612ef49646ae26eb84a9abd948",
-        "is_verified": false,
-        "line_number": 12489
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "d86a5a493b532eaa3ad35fe7d75e52f7fcb36773",
-        "is_verified": false,
-        "line_number": 12499
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "3eada6b47e255132bf858bcf8b89c44bd273b147",
-        "is_verified": false,
-        "line_number": 12509
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "335690160843f4e9851b9fc38c72af9a8e5becaa",
-        "is_verified": false,
-        "line_number": 12519
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "f38c633486353f3bb9945621e03989b9d5714180",
-        "is_verified": false,
-        "line_number": 12529
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "1596b7d36ddaee7c98e76386601316034824c9ee",
-        "is_verified": false,
-        "line_number": 12539
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "a603da79b4c9a8b46317ef3dace4bccd9e75081b",
-        "is_verified": false,
-        "line_number": 12549
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "40244792440b8b5fadb72851221cedf873cd7ef0",
-        "is_verified": false,
-        "line_number": 12559
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "5326a64f1a15e9dbf0503b97b18e3437a2d8a057",
-        "is_verified": false,
-        "line_number": 12569
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "29bc8182946252dee2f4a5d1a8ad720717540042",
-        "is_verified": false,
-        "line_number": 12579
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "3d6556868ba5f28ae082923ea1fd82439cd9f300",
-        "is_verified": false,
-        "line_number": 12589
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "83af8cc3c1a98ecac9d19f5840f0a739fc9dcfb5",
-        "is_verified": false,
-        "line_number": 12599
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "3d83647a79abcaada49d34c5f218b11c67474fe7",
-        "is_verified": false,
-        "line_number": 12609
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "621883aa312f9e8cfa99e1134e879c5336fa17d3",
-        "is_verified": false,
-        "line_number": 12619
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "c1ca11f48783158ed9367172795b733bbc6f0dad",
-        "is_verified": false,
-        "line_number": 12629
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "5a8491092496d51d3ddb7234b3ae07a22772d8d7",
-        "is_verified": false,
-        "line_number": 12639
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "96a6399fd6dc9d6990c8dee92a5215bc488fc612",
-        "is_verified": false,
-        "line_number": 12649
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "c1640024d6a530df0e6666c069562e15c1d7826e",
-        "is_verified": false,
-        "line_number": 12659
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "32bc660552d175cec47e88b635fb588476bc9c31",
-        "is_verified": false,
-        "line_number": 12669
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "1190443c3f463b29e2743542c721ed953ee64c66",
-        "is_verified": false,
-        "line_number": 12679
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "e1c4bdc7b0c8de06bd4ffbb035b0a7ee0822f4e1",
-        "is_verified": false,
-        "line_number": 12689
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "163c1dbfe94d8b2b7a835c8342ad020b11508243",
-        "is_verified": false,
-        "line_number": 12699
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "5359ca603feffdb42164672d39db114ec745629c",
-        "is_verified": false,
-        "line_number": 12709
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "fc4e44f46b81b34b5c3041c8f651535ab00fddb3",
-        "is_verified": false,
-        "line_number": 12719
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "ecf356bd95c5f8cdcb6ad919eb2e52dbaac2527a",
-        "is_verified": false,
-        "line_number": 12729
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "4bf47d32589368dc41a17b2b6d9ec6b7151d8b94",
-        "is_verified": false,
-        "line_number": 12739
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "f9ccfe1bb33b8bebd3440f2dcee11ac1569a6ecf",
-        "is_verified": false,
-        "line_number": 12749
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "1b6bda06b56bc68673774a9314168bbebd4e4b27",
-        "is_verified": false,
-        "line_number": 12759
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "f7dc71255fde81cf06f1ade100c50c3597a023e6",
-        "is_verified": false,
-        "line_number": 12769
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "3fef75b37ff9cc0c2d67ba585d4552bd6f42af7e",
-        "is_verified": false,
-        "line_number": 12779
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "92ca6d9f9031ce8334c7a578b44264ee05d15c70",
-        "is_verified": false,
-        "line_number": 12789
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "a0eee1bcfa4697b23e1341fb0579623fbb264a67",
-        "is_verified": false,
-        "line_number": 12799
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "f767a3ee34dc74eddfdb1c6751023b64906f6f27",
-        "is_verified": false,
-        "line_number": 12809
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "5e8c91f26ba8aede40943e4c0e0da8bdc745bd2f",
-        "is_verified": false,
-        "line_number": 12819
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "3fa59b17b2a10578d5f9d0c1355660b3e9d37790",
-        "is_verified": false,
-        "line_number": 12829
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "c402229d0b13b17198317d34f14048db5ecb8d15",
-        "is_verified": false,
-        "line_number": 12839
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "97074b8cfd84b0633928ca939da1798040e1904d",
-        "is_verified": false,
-        "line_number": 12849
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "2aa65bc1596d0eabf404cc1c582b5da696e22b71",
-        "is_verified": false,
-        "line_number": 12859
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "9dfdf92bdc6193840a0a29b57847e9f98043d0b3",
-        "is_verified": false,
-        "line_number": 12869
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "6b1a82c97e594e4278dc62d0831d408111dbb5f7",
-        "is_verified": false,
-        "line_number": 12879
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "d44cafba13f990614a8dc0d86b83b650d782c12b",
-        "is_verified": false,
-        "line_number": 12889
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "f8c4978afef0945fbdca034164875ca18fc19e0e",
-        "is_verified": false,
-        "line_number": 12899
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "a47b753c718b53e19ec384b89b7b2a7a4a0025f1",
-        "is_verified": false,
-        "line_number": 12909
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "65cf9cada574a96230c7e7b70b68826bcd63ff97",
-        "is_verified": false,
-        "line_number": 12919
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "888f5d3ef9067bf1e14f9731fa5a8c74a6382c1a",
-        "is_verified": false,
-        "line_number": 12929
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "998fe95ef5081452c2e81c375f6fbefdc7653879",
-        "is_verified": false,
-        "line_number": 12939
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "a9424a3fe89e118a64de1e1d9c58c4e45bb6b359",
-        "is_verified": false,
-        "line_number": 12949
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "e1b7ab407768e359bb3f864b8617ac344e73754a",
-        "is_verified": false,
-        "line_number": 12959
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "9de3303a1a28cdb5a7b556d7b5edb8a10cfc74be",
-        "is_verified": false,
-        "line_number": 12969
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "550484e100d520d1422fdfa5d74ea1c8a4b94dd4",
-        "is_verified": false,
-        "line_number": 12979
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "76079264e4c82692d4b6b4ff0400a7ce79d16865",
-        "is_verified": false,
-        "line_number": 12989
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "7110cb070eda93c66bd44a5cc59729271b5a9685",
-        "is_verified": false,
-        "line_number": 12999
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "886b0249146c6451478edc7d610a91a1a5df79fa",
-        "is_verified": false,
-        "line_number": 13009
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "c327f809802f0433fd9520cab42229a0c74c7fcc",
-        "is_verified": false,
-        "line_number": 13019
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "fc498fd80ee8683b6b37d83f382992cd373d6e19",
-        "is_verified": false,
-        "line_number": 13029
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "4e9fc5d8986075b39c326dc5f84d4acf295ee820",
-        "is_verified": false,
-        "line_number": 13039
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "f3343dd4626e380e317dec257171403c5d85ddf6",
-        "is_verified": false,
-        "line_number": 13049
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "4325662abe11648a0d50cfcdc6450828e45493d2",
-        "is_verified": false,
-        "line_number": 13059
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "ffb2fd1c3d4ca11ade069b51ddb46ac71679b9c0",
-        "is_verified": false,
-        "line_number": 13069
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "22aaf238399233811f79724ff80ce4361d39647a",
-        "is_verified": false,
-        "line_number": 13079
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "891a4430a22e418b17299a62c2ce6906f3d3f3ec",
-        "is_verified": false,
-        "line_number": 13089
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "cf5f9f4a109d3e244b41f264e9ec41baa3866d96",
-        "is_verified": false,
-        "line_number": 13099
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "55b856615032da99bd256cdf9aa0a5ccacf6131f",
-        "is_verified": false,
-        "line_number": 13109
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "dd893240fe57e68dcd697ee45771c5d9f5398a79",
-        "is_verified": false,
-        "line_number": 13119
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "d95582862203bc7503938aac2a2d0b451f7f782b",
-        "is_verified": false,
-        "line_number": 13129
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "bc2316e092d5305f03dcf817bf8e236ac4b557d6",
-        "is_verified": false,
-        "line_number": 13139
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "7b35baaf7335f7802a67a40a1c37c2d9bd691804",
-        "is_verified": false,
-        "line_number": 13149
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "267866521d406f3d61fe81f8d3fcb367a2339562",
-        "is_verified": false,
-        "line_number": 13159
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "8cb66573969fd5a6ba4b9437ea9426e2b56c9106",
-        "is_verified": false,
-        "line_number": 13169
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "b9aa70ece576c28c41819a09d55a6ae3cd8455de",
-        "is_verified": false,
-        "line_number": 13179
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "1f9ef710c051c3bf94dc978003983a4ab588ae97",
-        "is_verified": false,
-        "line_number": 13189
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "42250d082f533ee9f083a017e2f4a88269328867",
-        "is_verified": false,
-        "line_number": 13199
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "6d5424cbcb54632c7e85ffcf8cad41cd216625b8",
-        "is_verified": false,
-        "line_number": 13209
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "337bb0fb0f768a10ea547337e6c11e8d12564280",
-        "is_verified": false,
-        "line_number": 13219
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "477d041e46e335133b975a5ab08355add8dbac13",
-        "is_verified": false,
-        "line_number": 13229
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "3b8a78f47dbba066e665302802fcafd6c266dd09",
-        "is_verified": false,
-        "line_number": 13239
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "5b87ecd0b0a22941ab4ae598eae34eb6ff61c325",
-        "is_verified": false,
-        "line_number": 13249
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "ffd96a1112eb14793ea95dfa96620e529fc5e2bc",
-        "is_verified": false,
-        "line_number": 13259
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "0c8b0bc2db3517182108f0b5b29f0a223cbf714e",
-        "is_verified": false,
-        "line_number": 13269
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "4310fa67e611c8610dbf4866cb9bc10042e81bdb",
-        "is_verified": false,
-        "line_number": 13279
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "7f3d4b048ecb4eafeaf76cef4c85b7bcf40131fa",
-        "is_verified": false,
-        "line_number": 13289
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "5d8cd94d878e0b25f840e53dd28956550aa9af5b",
-        "is_verified": false,
-        "line_number": 13299
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "89a3e8b4ffed7f09545fee44c4fc6dfdeb1f602b",
-        "is_verified": false,
-        "line_number": 13309
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "8d25fa0eb59fad8894bde055ce1e75177c3f43b4",
-        "is_verified": false,
-        "line_number": 13319
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "02608f1983c930365cb4d8aa1d20fef80bee1616",
-        "is_verified": false,
-        "line_number": 13329
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "29cbd61bbae5c005f29ccb27490396e881288ced",
-        "is_verified": false,
-        "line_number": 13339
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "778a89e8d1b7a2184d6843f445db61611befac13",
-        "is_verified": false,
-        "line_number": 13349
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "e3f7dc34bf7f16e0ca7cf825be273f1c72375d56",
-        "is_verified": false,
-        "line_number": 13359
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "cda0ef41c723859db9780d7362266b80e2bfec2a",
-        "is_verified": false,
-        "line_number": 13369
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "8f3d790b065f2ef3acb817de363ac6e11bf6542b",
-        "is_verified": false,
-        "line_number": 13379
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "5ee8ad024f1cdd9b39793ae4b020a2fe5fa16b25",
-        "is_verified": false,
-        "line_number": 13389
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "2cdcb4930e6573a1efee916de3ed1871d4e6d172",
-        "is_verified": false,
-        "line_number": 13399
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "86a2abcdc40706d3a5d776771c3b817ed608a6cd",
-        "is_verified": false,
-        "line_number": 13409
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "7cb64012daf2bee52487093dab0653c65b1919f7",
-        "is_verified": false,
-        "line_number": 13419
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "771f6b4c327e199719218d2d0645f79d1fee5aff",
-        "is_verified": false,
-        "line_number": 13429
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "84236d246bfc0a34e24358c9b6cac2c6fd90bf84",
-        "is_verified": false,
-        "line_number": 13439
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "8a1830dfb099f31bc5093856084ebf8a3242fc30",
-        "is_verified": false,
-        "line_number": 13449
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "9fa0323930f4a63967066b1a839414ec69f1bfe1",
-        "is_verified": false,
-        "line_number": 13459
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "de1ee8202970a7412716b998544aada64262f6ab",
-        "is_verified": false,
-        "line_number": 13469
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "f535f8f709766da318424e53a976b6036a931bbf",
-        "is_verified": false,
-        "line_number": 13479
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "df4cbf6acac03345cd6d49a959972a9e105dc289",
-        "is_verified": false,
-        "line_number": 13489
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "7d36b69b2db5b2fa4a4b14ff951d4ab760c9136f",
-        "is_verified": false,
-        "line_number": 13499
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "5e123011192ae222ba71eff3bcc8fb92ad729de6",
-        "is_verified": false,
-        "line_number": 13509
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "63519411ca9973ccc39cc2f7e8153e08e6d3879c",
-        "is_verified": false,
-        "line_number": 13519
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "5723a87324c99fe181d10ad8fe726ba26599432a",
-        "is_verified": false,
-        "line_number": 13529
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "b9f14690c98b73f1ed63837dd31985037ed5f7fd",
-        "is_verified": false,
-        "line_number": 13539
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "119d6af985a7b080e09ad0c2331b08cd2a049b1a",
-        "is_verified": false,
-        "line_number": 13549
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "5a3a21dd238f390113e05a10eef481a770a7f8bb",
-        "is_verified": false,
-        "line_number": 13559
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "249ce604e00a3bcbefed121f51ca1de73c9bfc0a",
-        "is_verified": false,
-        "line_number": 13569
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "fb9c16e450b84145a25776c9a18d51fa899db724",
-        "is_verified": false,
-        "line_number": 13579
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "6d0089adbf52ab5406f9545bf8ab1741e20d5b0c",
-        "is_verified": false,
-        "line_number": 13589
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "c64b333a9b1d97cc9daf7de5f12bb2f9d640e593",
-        "is_verified": false,
-        "line_number": 13599
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "77b74235f88b28d58fe7e7f7ee39df93df7b606b",
-        "is_verified": false,
-        "line_number": 13609
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "ae6ba184fc8965bb0aa473a037111e6dbb26c7d8",
-        "is_verified": false,
-        "line_number": 13619
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "216a8c3532fac377e727d321e769eea960962c11",
-        "is_verified": false,
-        "line_number": 13629
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "9abdbf6193d7ecbfcf2c7845dd2c82a5cee266fe",
-        "is_verified": false,
-        "line_number": 13639
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "a6b68b46b115c817a9f3580d5de1d40fd17b3f72",
-        "is_verified": false,
-        "line_number": 13649
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "e3439f2d1fbee9de864d1e4b13deb5bbba0e8bec",
-        "is_verified": false,
-        "line_number": 13659
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "4c33518844d8f763c1b1239ae1b8d7b244943530",
-        "is_verified": false,
-        "line_number": 13669
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "6b4fdcca9aad54258fea43e0f651d9066967df4b",
-        "is_verified": false,
-        "line_number": 13679
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "73b5addb590ed7321057e3ceedd08dc822bbcf7e",
-        "is_verified": false,
-        "line_number": 13689
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "958120cdd907d451650918b88fb97dde1d8824b6",
-        "is_verified": false,
-        "line_number": 13699
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "88b8172f5a2d0c32c6abd8eed01ab348f58da364",
-        "is_verified": false,
-        "line_number": 13709
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "5a9e5aca50b4d479cbec2292c6ba7fd957c12810",
-        "is_verified": false,
-        "line_number": 13719
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "371196608f952ccb500dcde21666cb894b2b4939",
-        "is_verified": false,
-        "line_number": 13729
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "afd19f80436cc075205ffc82d779b6f05078126e",
-        "is_verified": false,
-        "line_number": 13739
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "e44c2ddec8d7eb2c7e93d191e79ede7b4325afcc",
-        "is_verified": false,
-        "line_number": 13749
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "44a9e561fd327796f9e5e40b6988a715f6c83553",
-        "is_verified": false,
-        "line_number": 13799
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "082a129a008456b24e600054b51b29e1ac5b9980",
-        "is_verified": false,
-        "line_number": 13849
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "33648b10408df7e0e45ca2c3d8b510c34fbf3534",
-        "is_verified": false,
-        "line_number": 14069
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "e689fb6a64c64f55d4e2798a25f5ba77669ce4f5",
-        "is_verified": false,
-        "line_number": 14099
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "fe6e98bb5bae5139821683fe5e15e1d72cdd1ac5",
-        "is_verified": false,
-        "line_number": 14409
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "0b510da6bf6dbba10fc304968406b758a7ae253a",
-        "is_verified": false,
-        "line_number": 14419
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "c2738008a9d6096150cb7757a94415afbe9606c4",
-        "is_verified": false,
-        "line_number": 14569
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "26193cf23a3d43138d32799df87a8002f43af3e3",
-        "is_verified": false,
-        "line_number": 14579
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "9c00aa904a0fca28158cd21e874ed0b5662697e3",
-        "is_verified": false,
-        "line_number": 14589
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "25928cd3b8f44d9cfa6d9480beaf56235381879d",
-        "is_verified": false,
-        "line_number": 14649
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "5beff1b6870f2fe5a0c70fc704806823a5383d92",
-        "is_verified": false,
-        "line_number": 14659
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "23b3471c6bbb2e2f23b5c693315351b9a996b6d3",
-        "is_verified": false,
-        "line_number": 14669
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "3dbeb3d24e8d86835b38b42aeccbca984a682f03",
-        "is_verified": false,
-        "line_number": 14679
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "42311f63217d24aafd2132d1fb54cdd62894b96e",
-        "is_verified": false,
-        "line_number": 14689
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "1f83b3b4d500cd8329ec28fa024d7db65ba32974",
-        "is_verified": false,
-        "line_number": 14699
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "04d69bcc895b13f98f6c67b062a43782eee1852e",
-        "is_verified": false,
-        "line_number": 14709
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "eec9cc58bf16c8094c67d0b8815755cdbed2df8c",
-        "is_verified": false,
-        "line_number": 14719
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "f8d2f5fb035ddc10efa7ba535006736e849c6b50",
-        "is_verified": false,
-        "line_number": 14729
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/codebase.json",
-        "hashed_secret": "c1a96e926874cab591bb3be5d6cae61cb8e7139e",
-        "is_verified": false,
-        "line_number": 14759
-      }
-    ],
-    "datasets/investment-analysis-platform/json_exports/ml_models.json": [
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/ml_models.json",
-        "hashed_secret": "38c13cc6c6549b6e5f48930da6f76a1fad709269",
-        "is_verified": false,
-        "line_number": 756
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/json_exports/ml_models.json",
-        "hashed_secret": "803c8b1b96698b952e30e1f091ea9a67855ecded",
-        "is_verified": false,
-        "line_number": 772
-      }
-    ],
-    "datasets/investment-analysis-platform/metrics/state.json": [
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/metrics/state.json",
-        "hashed_secret": "d4141c0e66fd84d93ebaeb065598a9bcd2c99936",
-        "is_verified": false,
-        "line_number": 7
-      }
-    ],
-    "datasets/investment-analysis-platform/ml_models/state.json": [
-      {
-        "type": "Hex High Entropy String",
-        "filename": "datasets/investment-analysis-platform/ml_models/state.json",
-        "hashed_secret": "649d4b568bd4fff92b3d16e55f0799ac5ccaf374",
-        "is_verified": false,
-        "line_number": 7
+        "line_number": 64,
+        "is_secret": false
       }
     ],
     "docker-compose.test.yml": [
@@ -13550,7 +1550,38 @@
         "filename": "docker-compose.test.yml",
         "hashed_secret": "9fb7fe1217aed442b04c0f5e43b5d5a7d3287097",
         "is_verified": false,
-        "line_number": 12
+        "line_number": 12,
+        "is_secret": false
+      }
+    ],
+    "docs/BACKUP_RECOVERY_GUIDE.md": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/BACKUP_RECOVERY_GUIDE.md",
+        "hashed_secret": "2caa9691169ab801ed21d7b841c8dbed6c422b19",
+        "is_verified": false,
+        "line_number": 67,
+        "is_secret": false
+      }
+    ],
+    "docs/ENVIRONMENT.md": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "docs/ENVIRONMENT.md",
+        "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
+        "is_verified": false,
+        "line_number": 307,
+        "is_secret": false
+      }
+    ],
+    "docs/GITHUB_WORKFLOWS.md": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "docs/GITHUB_WORKFLOWS.md",
+        "hashed_secret": "206c80413b9a96c1312cc346b7d2517b84463edd",
+        "is_verified": false,
+        "line_number": 719,
+        "is_secret": false
       }
     ],
     "docs/PRODUCTION_DEPLOYMENT_GUIDE.md": [
@@ -13559,7 +1590,8 @@
         "filename": "docs/PRODUCTION_DEPLOYMENT_GUIDE.md",
         "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
         "is_verified": false,
-        "line_number": 170
+        "line_number": 170,
+        "is_secret": false
       }
     ],
     "docs/QA_ACTION_PLAN.md": [
@@ -13568,7 +1600,8 @@
         "filename": "docs/QA_ACTION_PLAN.md",
         "hashed_secret": "382caa7c44ee23ee25616f7e303af33c591efc3a",
         "is_verified": false,
-        "line_number": 943
+        "line_number": 943,
+        "is_secret": false
       }
     ],
     "docs/SECURITY.md": [
@@ -13577,37 +1610,42 @@
         "filename": "docs/SECURITY.md",
         "hashed_secret": "354b3a4b7715d3694c88a4fa7db49e41de86568e",
         "is_verified": false,
-        "line_number": 85
+        "line_number": 86,
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/SECURITY.md",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 214
+        "line_number": 215,
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/SECURITY.md",
         "hashed_secret": "33eafeb967e2f62c6da67fa985f48bc181c4b3cb",
         "is_verified": false,
-        "line_number": 762
+        "line_number": 763,
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/SECURITY.md",
         "hashed_secret": "b60d121b438a380c343d5ec3c2037564b82ffef3",
         "is_verified": false,
-        "line_number": 1066
+        "line_number": 1067,
+        "is_secret": false
       }
     ],
     "docs/TROUBLESHOOTING.md": [
       {
         "type": "Secret Keyword",
         "filename": "docs/TROUBLESHOOTING.md",
-        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "hashed_secret": "b48cf0140bea12734db05ebcdb012f1d265bed84",
         "is_verified": false,
-        "line_number": 693
+        "line_number": 319,
+        "is_secret": false
       }
     ],
     "docs/api/V1_TO_V2_MIGRATION_GUIDE.md": [
@@ -13616,7 +1654,104 @@
         "filename": "docs/api/V1_TO_V2_MIGRATION_GUIDE.md",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 239
+        "line_number": 239,
+        "is_secret": false
+      }
+    ],
+    "docs/audits/2026-04/_meta/aggregate.json": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/audits/2026-04/_meta/aggregate.json",
+        "hashed_secret": "0737c22d3bfae812339732d14d8c7dbd6dc4e09c",
+        "is_verified": false,
+        "line_number": 143,
+        "is_secret": false
+      }
+    ],
+    "docs/audits/2026-04/_synthesis/_meta/artifacts/A1-rotation-runbook.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/audits/2026-04/_synthesis/_meta/artifacts/A1-rotation-runbook.md",
+        "hashed_secret": "1727362a714475223abe7282c85576599adc7ff9",
+        "is_verified": false,
+        "line_number": 58,
+        "is_secret": false
+      }
+    ],
+    "docs/audits/2026-04/_synthesis/_meta/findings-master.jsonl": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "docs/audits/2026-04/_synthesis/_meta/findings-master.jsonl",
+        "hashed_secret": "1727362a714475223abe7282c85576599adc7ff9",
+        "is_verified": false,
+        "line_number": 121,
+        "is_secret": false
+      }
+    ],
+    "docs/audits/2026-04/_synthesis/_meta/slices/A.jsonl": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "docs/audits/2026-04/_synthesis/_meta/slices/A.jsonl",
+        "hashed_secret": "1727362a714475223abe7282c85576599adc7ff9",
+        "is_verified": false,
+        "line_number": 3,
+        "is_secret": false
+      }
+    ],
+    "docs/audits/2026-04/_synthesis/workpaper/A.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/audits/2026-04/_synthesis/workpaper/A.md",
+        "hashed_secret": "1727362a714475223abe7282c85576599adc7ff9",
+        "is_verified": false,
+        "line_number": 46,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/audits/2026-04/_synthesis/workpaper/A.md",
+        "hashed_secret": "0af0ffa2418d0d92acde7278fccad873d0d03e8a",
+        "is_verified": false,
+        "line_number": 108,
+        "is_secret": false
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "docs/audits/2026-04/_synthesis/workpaper/A.md",
+        "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
+        "is_verified": false,
+        "line_number": 215,
+        "is_secret": false
+      }
+    ],
+    "docs/audits/2026-04/_synthesis/workpaper/B.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/audits/2026-04/_synthesis/workpaper/B.md",
+        "hashed_secret": "9f316ce93b81ace393adf7db021afc3643c2b8e1",
+        "is_verified": false,
+        "line_number": 7,
+        "is_secret": false
+      }
+    ],
+    "docs/audits/2026-04/reports/07-database-persistence.md": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "docs/audits/2026-04/reports/07-database-persistence.md",
+        "hashed_secret": "1727362a714475223abe7282c85576599adc7ff9",
+        "is_verified": false,
+        "line_number": 61,
+        "is_secret": false
+      }
+    ],
+    "docs/audits/2026-04/reports/15-test-suite.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/audits/2026-04/reports/15-test-suite.md",
+        "hashed_secret": "7a17bc9911a8d3f78c5da0d68d79590d24f1123f",
+        "is_verified": false,
+        "line_number": 310,
+        "is_secret": false
       }
     ],
     "docs/deployment/PHASE3_DEPLOYMENT_CHECKLIST.md": [
@@ -13625,14 +1760,36 @@
         "filename": "docs/deployment/PHASE3_DEPLOYMENT_CHECKLIST.md",
         "hashed_secret": "0c6ba03885f3aae765fbf20f07f514a44dbda30a",
         "is_verified": false,
-        "line_number": 396
+        "line_number": 396,
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/deployment/PHASE3_DEPLOYMENT_CHECKLIST.md",
         "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
         "is_verified": false,
-        "line_number": 645
+        "line_number": 645,
+        "is_secret": false
+      }
+    ],
+    "docs/deployment/PHASE6_PHASE1_COMPLETE.md": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "docs/deployment/PHASE6_PHASE1_COMPLETE.md",
+        "hashed_secret": "112bb791304791ddcf692e29fd5cf149b35fea37",
+        "is_verified": false,
+        "line_number": 183,
+        "is_secret": false
+      }
+    ],
+    "docs/deployment/PHASE6_PHASE1_PROGRESS.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/deployment/PHASE6_PHASE1_PROGRESS.md",
+        "hashed_secret": "927da732e6d17a927f309644b0389308f230db68",
+        "is_verified": false,
+        "line_number": 34,
+        "is_secret": true
       }
     ],
     "docs/ml/ML_PIPELINE_DOCUMENTATION.md": [
@@ -13641,7 +1798,8 @@
         "filename": "docs/ml/ML_PIPELINE_DOCUMENTATION.md",
         "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
         "is_verified": false,
-        "line_number": 305
+        "line_number": 305,
+        "is_secret": false
       }
     ],
     "docs/reports/security-audit-report.md": [
@@ -13650,28 +1808,50 @@
         "filename": "docs/reports/security-audit-report.md",
         "hashed_secret": "927da732e6d17a927f309644b0389308f230db68",
         "is_verified": false,
-        "line_number": 37
+        "line_number": 37,
+        "is_secret": true
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/reports/security-audit-report.md",
         "hashed_secret": "b20f9c889bbeb53e42ce33177661c76a1cd825a8",
         "is_verified": false,
-        "line_number": 38
+        "line_number": 38,
+        "is_secret": true
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/reports/security-audit-report.md",
         "hashed_secret": "4f55b30ec71ee060cf60830e7e55a7249f441835",
         "is_verified": false,
-        "line_number": 39
+        "line_number": 39,
+        "is_secret": true
       },
       {
         "type": "GitHub Token",
         "filename": "docs/reports/security-audit-report.md",
         "hashed_secret": "e175c6f5f2a92e8623bd9a4820edb4e8c1b0fd10",
         "is_verified": false,
-        "line_number": 353
+        "line_number": 353,
+        "is_secret": false
+      }
+    ],
+    "docs/runbooks/credential-rotation.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/runbooks/credential-rotation.md",
+        "hashed_secret": "bc8f905e183a476c634a0ede9de377544ebfcc94",
+        "is_verified": false,
+        "line_number": 64,
+        "is_secret": false
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/runbooks/credential-rotation.md",
+        "hashed_secret": "d8181e8991390739324a3f498b4b7b268e9a6ff7",
+        "is_verified": false,
+        "line_number": 65,
+        "is_secret": false
       }
     ],
     "docs/security/PHASE1_VERIFICATION_CHECKLIST.md": [
@@ -13680,7 +1860,18 @@
         "filename": "docs/security/PHASE1_VERIFICATION_CHECKLIST.md",
         "hashed_secret": "b7bbb48a5b7749f1f908eb3c0c021200c72738ce",
         "is_verified": false,
-        "line_number": 42
+        "line_number": 42,
+        "is_secret": false
+      }
+    ],
+    "docs/security/PHASE3_SECURITY_FINAL.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/security/PHASE3_SECURITY_FINAL.md",
+        "hashed_secret": "51684124902645217fb8fdef7f0ef389d28d5e76",
+        "is_verified": false,
+        "line_number": 231,
+        "is_secret": false
       }
     ],
     "docs/security/SECRET_ROTATION_PLAN.md": [
@@ -13689,7 +1880,8 @@
         "filename": "docs/security/SECRET_ROTATION_PLAN.md",
         "hashed_secret": "b7bbb48a5b7749f1f908eb3c0c021200c72738ce",
         "is_verified": false,
-        "line_number": 51
+        "line_number": 51,
+        "is_secret": false
       }
     ],
     "docs/security/SECURITY_CREDENTIALS_AUDIT.md": [
@@ -13698,14 +1890,16 @@
         "filename": "docs/security/SECURITY_CREDENTIALS_AUDIT.md",
         "hashed_secret": "fb3b076bd0777815b4f2d40ec4f1673365fee257",
         "is_verified": false,
-        "line_number": 299
+        "line_number": 299,
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
         "filename": "docs/security/SECURITY_CREDENTIALS_AUDIT.md",
         "hashed_secret": "45630f008187f94b526edb7fec47b3772ed03957",
         "is_verified": false,
-        "line_number": 300
+        "line_number": 300,
+        "is_secret": false
       }
     ],
     "docs/testing/TESTING_GUIDE.md": [
@@ -13714,7 +1908,28 @@
         "filename": "docs/testing/TESTING_GUIDE.md",
         "hashed_secret": "72559b51f94a7a3ad058c5740cbe2f7cb0d4080b",
         "is_verified": false,
-        "line_number": 74
+        "line_number": 74,
+        "is_secret": false
+      }
+    ],
+    "frontend/web/src/pages/auth.test.tsx": [
+      {
+        "type": "Secret Keyword",
+        "filename": "frontend/web/src/pages/auth.test.tsx",
+        "hashed_secret": "cbfdac6008f9cab4083784cbd1874f76618d2a97",
+        "is_verified": false,
+        "line_number": 222,
+        "is_secret": false
+      }
+    ],
+    "frontend/web/src/store/slices/slices.test.ts": [
+      {
+        "type": "Secret Keyword",
+        "filename": "frontend/web/src/store/slices/slices.test.ts",
+        "hashed_secret": "1a91d62f7ca67399625a4368a6ab5d4a3baa6073",
+        "is_verified": false,
+        "line_number": 242,
+        "is_secret": false
       }
     ],
     "frontend/web/tests/e2e/auth.spec.ts": [
@@ -13723,14 +1938,16 @@
         "filename": "frontend/web/tests/e2e/auth.spec.ts",
         "hashed_secret": "0ea1e65c276f457fa82a25f563643f30b9f6edab",
         "is_verified": false,
-        "line_number": 10
+        "line_number": 10,
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
         "filename": "frontend/web/tests/e2e/auth.spec.ts",
         "hashed_secret": "2e3bb45acf7a48448b2ae735112bd62aa0ef592d",
         "is_verified": false,
-        "line_number": 16
+        "line_number": 16,
+        "is_secret": false
       }
     ],
     "frontend/web/tests/e2e/portfolio.spec.ts": [
@@ -13739,7 +1956,8 @@
         "filename": "frontend/web/tests/e2e/portfolio.spec.ts",
         "hashed_secret": "bc70a2fd0d3f16612198d8467cfcad40cc43253b",
         "is_verified": false,
-        "line_number": 10
+        "line_number": 10,
+        "is_secret": false
       }
     ],
     "infrastructure/database/optimizations.sql": [
@@ -13748,7 +1966,18 @@
         "filename": "infrastructure/database/optimizations.sql",
         "hashed_secret": "f99e569c9067414cd018907691a7404c28dfe6d9",
         "is_verified": false,
-        "line_number": 309
+        "line_number": 309,
+        "is_secret": false
+      }
+    ],
+    "infrastructure/docker/postgres/init.sql": [
+      {
+        "type": "Secret Keyword",
+        "filename": "infrastructure/docker/postgres/init.sql",
+        "hashed_secret": "7124dbb97abc294040ff36a3e23fe23831ac860a",
+        "is_verified": false,
+        "line_number": 31,
+        "is_secret": false
       }
     ],
     "infrastructure/docker/postgres/postgresql.prod.conf": [
@@ -13757,7 +1986,8 @@
         "filename": "infrastructure/docker/postgres/postgresql.prod.conf",
         "hashed_secret": "2f1aa1e2a58704b452a5dd60ab1bd2b761bf296a",
         "is_verified": false,
-        "line_number": 14
+        "line_number": 14,
+        "is_secret": false
       }
     ],
     "infrastructure/monitoring/prometheus.yml": [
@@ -13766,7 +1996,18 @@
         "filename": "infrastructure/monitoring/prometheus.yml",
         "hashed_secret": "d033e22ae348aeb5660fc2140aec35850c4da997",
         "is_verified": false,
-        "line_number": 86
+        "line_number": 88,
+        "is_secret": false
+      }
+    ],
+    "pyproject.toml": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "pyproject.toml",
+        "hashed_secret": "6a09d10ac296d6a5291bfab19290309af9396b17",
+        "is_verified": false,
+        "line_number": 194,
+        "is_secret": false
       }
     ],
     "run_integration_tests.py": [
@@ -13775,21 +2016,34 @@
         "filename": "run_integration_tests.py",
         "hashed_secret": "6731834487e9dd32ec3df63994d996da1133dbb9",
         "is_verified": false,
-        "line_number": 60
+        "line_number": 77,
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
         "filename": "run_integration_tests.py",
         "hashed_secret": "3e8ab69f2adc85896abec6e7bf845b982397e521",
         "is_verified": false,
-        "line_number": 69
+        "line_number": 86,
+        "is_secret": false
       },
       {
         "type": "Secret Keyword",
         "filename": "run_integration_tests.py",
         "hashed_secret": "23dbd7a2322ecda0f1d50fedfd4428061ece733d",
         "is_verified": false,
-        "line_number": 78
+        "line_number": 95,
+        "is_secret": false
+      }
+    ],
+    "scripts/apply-test-migrations.sh": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "scripts/apply-test-migrations.sh",
+        "hashed_secret": "927da732e6d17a927f309644b0389308f230db68",
+        "is_verified": false,
+        "line_number": 16,
+        "is_secret": false
       }
     ],
     "scripts/data/activate_pipeline.py": [
@@ -13798,7 +2052,18 @@
         "filename": "scripts/data/activate_pipeline.py",
         "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
         "is_verified": false,
-        "line_number": 63
+        "line_number": 63,
+        "is_secret": false
+      }
+    ],
+    "scripts/data/background_loader_enhanced.py": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "scripts/data/background_loader_enhanced.py",
+        "hashed_secret": "eb1821b2ca018503a2afcdb3abb4ce286c7b000e",
+        "is_verified": false,
+        "line_number": 63,
+        "is_secret": false
       }
     ],
     "scripts/deployment/blue_green_deploy.sh": [
@@ -13807,7 +2072,8 @@
         "filename": "scripts/deployment/blue_green_deploy.sh",
         "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
         "is_verified": false,
-        "line_number": 253
+        "line_number": 253,
+        "is_secret": true
       }
     ],
     "scripts/deployment/start_data_loading.sh": [
@@ -13816,16 +2082,18 @@
         "filename": "scripts/deployment/start_data_loading.sh",
         "hashed_secret": "1727362a714475223abe7282c85576599adc7ff9",
         "is_verified": false,
-        "line_number": 58
+        "line_number": 58,
+        "is_secret": true
       }
     ],
-    "scripts/deployment/start_monitoring.sh": [
+    "scripts/init-test-schema.py": [
       {
         "type": "Basic Auth Credentials",
-        "filename": "scripts/deployment/start_monitoring.sh",
-        "hashed_secret": "f865b53623b121fd34ee5426c792e5c33af8c227",
+        "filename": "scripts/init-test-schema.py",
+        "hashed_secret": "927da732e6d17a927f309644b0389308f230db68",
         "is_verified": false,
-        "line_number": 295
+        "line_number": 22,
+        "is_secret": false
       }
     ],
     "scripts/init_airflow_db.sql": [
@@ -13834,7 +2102,8 @@
         "filename": "scripts/init_airflow_db.sql",
         "hashed_secret": "191a7370b2a34f1faf71dd33efcbc6de689c5b5c",
         "is_verified": false,
-        "line_number": 12
+        "line_number": 12,
+        "is_secret": false
       }
     ],
     "scripts/init_database.sh": [
@@ -13843,7 +2112,8 @@
         "filename": "scripts/init_database.sh",
         "hashed_secret": "9e813a280b28cbe1aa4226768add3243d443dc95",
         "is_verified": false,
-        "line_number": 290
+        "line_number": 290,
+        "is_secret": false
       }
     ],
     "scripts/init_database_windows.ps1": [
@@ -13852,7 +2122,18 @@
         "filename": "scripts/init_database_windows.ps1",
         "hashed_secret": "1727362a714475223abe7282c85576599adc7ff9",
         "is_verified": false,
-        "line_number": 74
+        "line_number": 74,
+        "is_secret": false
+      }
+    ],
+    "scripts/load_historical_data.py": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "scripts/load_historical_data.py",
+        "hashed_secret": "eb1821b2ca018503a2afcdb3abb4ce286c7b000e",
+        "is_verified": false,
+        "line_number": 104,
+        "is_secret": false
       }
     ],
     "scripts/quick_setup.py": [
@@ -13861,7 +2142,8 @@
         "filename": "scripts/quick_setup.py",
         "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
         "is_verified": false,
-        "line_number": 53
+        "line_number": 53,
+        "is_secret": false
       }
     ],
     "scripts/security_validation.py": [
@@ -13870,7 +2152,28 @@
         "filename": "scripts/security_validation.py",
         "hashed_secret": "deb6894e47fb5cd2abea8e47f1c4399ac1ff7d11",
         "is_verified": false,
-        "line_number": 34
+        "line_number": 34,
+        "is_secret": false
+      }
+    ],
+    "scripts/seed_demo_data.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "scripts/seed_demo_data.py",
+        "hashed_secret": "c1d115fa919390abd0eefa5316f1d7591c4f2352",
+        "is_verified": false,
+        "line_number": 82,
+        "is_secret": false
+      }
+    ],
+    "scripts/setup-test-env.sh": [
+      {
+        "type": "Secret Keyword",
+        "filename": "scripts/setup-test-env.sh",
+        "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
+        "is_verified": false,
+        "line_number": 24,
+        "is_secret": false
       }
     ],
     "scripts/setup/SETUP_ENVIRONMENT.sh": [
@@ -13879,7 +2182,8 @@
         "filename": "scripts/setup/SETUP_ENVIRONMENT.sh",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 278
+        "line_number": 278,
+        "is_secret": false
       }
     ],
     "scripts/setup/fix_immediate.py": [
@@ -13888,7 +2192,8 @@
         "filename": "scripts/setup/fix_immediate.py",
         "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
         "is_verified": false,
-        "line_number": 83
+        "line_number": 83,
+        "is_secret": false
       }
     ],
     "scripts/setup/setup.sh": [
@@ -13897,7 +2202,8 @@
         "filename": "scripts/setup/setup.sh",
         "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
         "is_verified": false,
-        "line_number": 79
+        "line_number": 79,
+        "is_secret": false
       }
     ],
     "scripts/setup/setup_local.py": [
@@ -13906,7 +2212,8 @@
         "filename": "scripts/setup/setup_local.py",
         "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
         "is_verified": false,
-        "line_number": 89
+        "line_number": 89,
+        "is_secret": false
       }
     ],
     "scripts/setup_airflow_complete.sh": [
@@ -13915,76 +2222,34 @@
         "filename": "scripts/setup_airflow_complete.sh",
         "hashed_secret": "0c539ba70dc0c491f54295b2d9b6f7e4dd9c59b0",
         "is_verified": false,
-        "line_number": 133
+        "line_number": 133,
+        "is_secret": true
       },
       {
         "type": "Secret Keyword",
         "filename": "scripts/setup_airflow_complete.sh",
         "hashed_secret": "9354f6cdb6e90b0e934459751e8b0464d3ce4224",
         "is_verified": false,
-        "line_number": 134
+        "line_number": 134,
+        "is_secret": true
       },
       {
         "type": "Secret Keyword",
         "filename": "scripts/setup_airflow_complete.sh",
         "hashed_secret": "1d81b5f6815bf0da9ea6d3eb45b7d82face79775",
         "is_verified": false,
-        "line_number": 140
+        "line_number": 140,
+        "is_secret": true
       }
     ],
-    "scripts/testing/test_services_corrected.py": [
-      {
-        "type": "Secret Keyword",
-        "filename": "scripts/testing/test_services_corrected.py",
-        "hashed_secret": "1727362a714475223abe7282c85576599adc7ff9",
-        "is_verified": false,
-        "line_number": 19
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "scripts/testing/test_services_corrected.py",
-        "hashed_secret": "8675bd58b707a96861a9f84673bbc61ad3316790",
-        "is_verified": false,
-        "line_number": 48
-      }
-    ],
-    "scripts/testing/test_services_fixed.py": [
-      {
-        "type": "Secret Keyword",
-        "filename": "scripts/testing/test_services_fixed.py",
-        "hashed_secret": "1727362a714475223abe7282c85576599adc7ff9",
-        "is_verified": false,
-        "line_number": 20
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "scripts/testing/test_services_fixed.py",
-        "hashed_secret": "637f6654579ed325033bec71e3823a402b0bbc93",
-        "is_verified": false,
-        "line_number": 42
-      }
-    ],
-    "scripts/testing/test_services_quick.py": [
-      {
-        "type": "Secret Keyword",
-        "filename": "scripts/testing/test_services_quick.py",
-        "hashed_secret": "1727362a714475223abe7282c85576599adc7ff9",
-        "is_verified": false,
-        "line_number": 19
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "scripts/testing/test_services_quick.py",
-        "hashed_secret": "637f6654579ed325033bec71e3823a402b0bbc93",
-        "is_verified": false,
-        "line_number": 39
-      },
+    "scripts/testing/test_docker_connections.py": [
       {
         "type": "Base64 High Entropy String",
-        "filename": "scripts/testing/test_services_quick.py",
+        "filename": "scripts/testing/test_docker_connections.py",
         "hashed_secret": "7c9fc7ab4baa375bb162479221d5b2c77a5ed41f",
         "is_verified": false,
-        "line_number": 55
+        "line_number": 81,
+        "is_secret": true
       }
     ],
     "tests/security/test_row_locking.py": [
@@ -13993,9 +2258,10 @@
         "filename": "tests/security/test_row_locking.py",
         "hashed_secret": "f409ce90a1cd144912d1df8620215b2dc9fda731",
         "is_verified": false,
-        "line_number": 28
+        "line_number": 28,
+        "is_secret": false
       }
     ]
   },
-  "generated_at": "2026-01-28T02:29:49Z"
+  "generated_at": "2026-08-11T17:59:15Z"
 }

--- a/docs/runbooks/credential-rotation.md
+++ b/docs/runbooks/credential-rotation.md
@@ -418,6 +418,12 @@ place or archive) · `.context/refresh_analysis.sh:99` ·
    locations are cleaned, keeping the baseline the living rotation ledger.
 5. Re-run the §12.1 acceptance grep + `git ls-files | grep -E '^\.env\.(secure|airflow)$'`
    (must be empty) and close #219 + the F8-16-001/002 batch findings.
+6. **Flip the secrets scanners from advisory to gating** (F8-14-004): in
+   `.github/workflows/security-scan.yml`, remove `continue-on-error: true`
+   (and the `|| true`) from the TruffleHog and GitLeaks steps and drop the
+   "advisory until U2 rotation completes" suffix from their names. Gating
+   them before this window would have tripped on the known tracked secrets
+   on every run; after step 4's clean scans they must gate permanently.
 
 ### 12.6 Window acceptance (PRD §4)
 

--- a/docs/runbooks/credential-rotation.md
+++ b/docs/runbooks/credential-rotation.md
@@ -1,8 +1,11 @@
 # Credential Rotation Runbook — Live Postgres + Redis
 
-**Version: 1.0.0** · **Last Updated: 2026-06-17**
+**Version: 1.1.0** · **Last Updated: 2026-08-11**
 
-**Status:** Authored, awaiting a scheduled maintenance window. This runbook is the
+**Status:** Authorized (U2 decision, 2026-08-11) — ONE maintenance window covering
+§1–§8 (PG+Redis), the §12 additional batches, and the §9 KDF rotation (now bundled
+per U2; §9's opt-in framing is superseded). Operator executes; see §12 for the full
+window plan. This runbook is the
 operational procedure that resolves the git-history credential exposure tracked in
 **issue #219**.
 
@@ -336,3 +339,89 @@ Do not let KDF complications block or delay the PG/Redis rotation that closes #2
 - (authored) — PG+Redis rotation runbook created as the #219-closing procedure,
   awaiting maintenance window. Soak duration left as `__MAINTAINER_INPUT__` for the
   operator to size against pool TTL + one ingest/API cycle.
+
+## 12. U2 window extension (2026-08) — additional batches in the SAME window
+
+**Decision U2 (2026-08-11):** one maintenance window rotates everything below in
+addition to §1–§8. Sequencing inside the window: PG → Redis (§2) → Batch B → Batch C
+→ Batch D → KDF (§9, now bundled) → post-window hygiene (§12.5). Every batch keeps
+the §0 principles: pre-stage in 1Password, old value valid until revoke, per-batch
+GO/NO-GO.
+
+### 12.1 Batch B — vendor API keys (F8-16-001, critical)
+
+Rotate at each provider console, then replace the tracked values with placeholders.
+Eight keys: `ALPHA_VANTAGE`, `FINNHUB`, `POLYGON`, `NEWS`, `FMP`, `MARKETAUX`,
+`FRED`, `OPENWEATHER` (`*_API_KEY`). Reissue latency varies by vendor — request the
+new keys FIRST (start-of-window), swap + verify ingest, then delete the old keys at
+the provider (their "revoke").
+
+Tracked locations (all must be placeholder after the window):
+`.env.production.example:82-85` · `.env.secure:64-80` ·
+`.env_backup_DONOTUSE/.env.production.backup:5-14` ·
+`.env_backup_DONOTUSE/.env.production.example:91-94` ·
+`.env_backup_DONOTUSE/.env.secure:63-72`
+
+Acceptance: `python3 -c "import re;[print(l.split('=')[0]) for l in open('.env.production.example') if re.match(r'^[A-Z_]+_API_KEY=(?!your_)',l)]"` prints nothing.
+
+### 12.2 Batch C — app signing secrets + Airflow (F8-16-002, critical)
+
+- `SECRET_KEY` + `JWT_SECRET_KEY` (`.env.secure:21-22`, backup copies): rotate; JWT
+  rotation invalidates outstanding tokens — do this inside the window, not before.
+- `AIRFLOW_SECRET_KEY` (`.env.airflow:15`): currently BYTE-IDENTICAL to the app
+  `SECRET_KEY`. Give Airflow its own distinct key — do not rotate them to a shared
+  value again.
+- `AIRFLOW_FERNET_KEY` (`.env.airflow:12`): Fernet rotation re-encrypts stored
+  Airflow connections — run `airflow rotate-fernet-key` with old+new keys configured,
+  verify connections decrypt, THEN drop the old key.
+
+### 12.3 Batch D — script/service credentials (scope 17 + baseline audit 2026-08-11)
+
+The adjudicated `.secrets.baseline` (20 `is_secret: true` entries) is the
+authoritative inventory; these locations must all be dead after the window:
+
+- `scripts/testing/test_all_passwords.py` — 4 service creds (scope 17)
+- `scripts/testing/test_docker_connections.py:81` — Elasticsearch basic-auth (store
+  decommissioned; confirm the credential is dead rather than rotating)
+- `.context/refresh_analysis.sh:99` — exported `PGPASSWORD` (NOT in the prior audit
+  inventory; found by the 2026-08-11 baseline adjudication; rotates with the §3 PG batch)
+- `scripts/setup_airflow_complete.sh:133-140` — hardcoded Airflow DB + Flower
+  passwords (rotate with Batch C; replace with env lookups)
+- `scripts/deployment/blue_green_deploy.sh:253` — embedded `DATABASE_URL` (rotates
+  with the §3 PG batch; replace with env lookup)
+
+### 12.4 Complete tracked-location inventory for the §3 PG/Redis pair (F8-16-019)
+
+The §1 checklist's inventory plus these previously-missing locations — sweep ALL of
+them post-rotation: `.env.secure:37,38,45` ·
+`.env_backup_DONOTUSE/.env.production.backup:20,96` ·
+`scripts/deployment/start_data_loading.sh:58` (anchor) · embedded `DATABASE_URL` /
+`REDIS_URL` connection strings in both env files ·
+`docs/reports/security-audit-report.md:37-39` and
+`docs/deployment/PHASE6_PHASE1_PROGRESS.md:34` (credential-bearing docs — redact in
+place or archive) · `.context/refresh_analysis.sh:99` ·
+`scripts/deployment/blue_green_deploy.sh:253`.
+
+### 12.5 Post-window hygiene (ORDER MATTERS — all AFTER revoke completes)
+
+1. `git rm --cached` the tracked secret-bearing env files (`.env.secure`,
+   `.env.airflow`, `.env.production`, `frontend/web/.env.production`) so the
+   existing `.gitignore` rules become real (F8-16-006).
+2. `git rm -r --cached .env_backup_DONOTUSE/` then delete the directory
+   (F8-16-018 / U6). **Deletion is hygiene, not remediation** — history still
+   holds the old values; only the completed rotation closes the exposure.
+3. Run `scripts/security/git_secrets_cleanup.sh` (never yet run).
+4. Verify with the FIXED scanners (landed pre-window in PR-D):
+   `gitleaks detect --config .gitleaks.toml --redact` over the working tree, and
+   `detect-secrets scan --baseline .secrets.baseline` — both must report nothing
+   new. Flip the 20 `is_secret: true` baseline entries to resolved/removed as the
+   locations are cleaned, keeping the baseline the living rotation ledger.
+5. Re-run the §12.1 acceptance grep + `git ls-files | grep -E '^\.env\.(secure|airflow)$'`
+   (must be empty) and close #219 + the F8-16-001/002 batch findings.
+
+### 12.6 Window acceptance (PRD §4)
+
+- 0 tracked credential-shaped values outside the parked set
+- `.gitleaks.toml` extends defaults (F8-08-003, landed pre-window)
+- `.secrets.baseline` fully adjudicated, 0 nulls (F8-08-004, landed pre-window)
+- #219 closed on rotation evidence, not working-tree state

--- a/tests/test_gitleaks_config_f8_08_003.py
+++ b/tests/test_gitleaks_config_f8_08_003.py
@@ -1,0 +1,48 @@
+"""F8-08-003: .gitleaks.toml must EXTEND the default ruleset, not replace it.
+
+gitleaks v8 uses a supplied config *in place of* its defaults unless
+``[extend] useDefault = true`` is present — so generic-api-key,
+high-entropy-string and private-key detection never ran. The file allowlist
+additionally suppressed every ``*test*.py`` and ``*.md`` file, which is
+exactly where scope 17's service creds and the F-08-009 credential docs
+live. Four of the eight leaked vendor keys (FMP, MARKETAUX, FRED,
+OPENWEATHER) had no matching rule at all.
+
+Source-level (regex on the TOML text — py3.9 has no tomllib), runs under
+``pytest --noconftest``.
+"""
+
+import re
+from pathlib import Path
+
+CONFIG = Path(__file__).resolve().parents[1] / ".gitleaks.toml"
+
+
+def _text() -> str:
+    return CONFIG.read_text()
+
+
+class TestF8_08_003_GitleaksConfig:
+    def test_extends_default_ruleset(self):
+        t = _text()
+        assert re.search(r"^\[extend\]", t, re.M), "missing [extend] block"
+        assert re.search(r"^\s*useDefault\s*=\s*true", t, re.M), (
+            "without useDefault=true the 13 custom rules REPLACE the entire "
+            "default ruleset"
+        )
+
+    def test_no_blanket_test_file_allowlist(self):
+        assert ".*test.*\\.py$" not in _text()
+        assert ".*_test\\.py$" not in _text()
+
+    def test_no_blanket_markdown_allowlist(self):
+        assert ".*\\.md$" not in _text()
+
+    def test_rules_exist_for_all_eight_leaked_vendor_keys(self):
+        t = _text()
+        for rule_id in (
+            "alpha-vantage-api-key", "finnhub-api-key", "polygon-api-key",
+            "news-api-key", "fmp-api-key", "marketaux-api-key",
+            "fred-api-key", "openweather-api-key",
+        ):
+            assert f'id = "{rule_id}"' in t, f"no rule for {rule_id}"

--- a/tests/test_secrets_baseline_f8_08_004.py
+++ b/tests/test_secrets_baseline_f8_08_004.py
@@ -1,0 +1,60 @@
+"""F8-08-004: .secrets.baseline must be an audited allowlist, not 1,925
+blanket suppressions.
+
+The old baseline (2026-01-28) carried is_secret: null on every entry —
+never triaged — while .pre-commit-config.yaml fed it to detect-secrets,
+permanently suppressing every location including the #219 Postgres anchor.
+1,386 entries were datasets/ noise and 346 were .claude/ noise.
+
+Source-level JSON checks, runs under ``pytest --noconftest``.
+"""
+
+import json
+from pathlib import Path
+
+BASELINE = Path(__file__).resolve().parents[1] / ".secrets.baseline"
+
+
+def _load():
+    return json.loads(BASELINE.read_text())
+
+
+class TestF8_08_004_Baseline:
+    def test_every_entry_is_adjudicated(self):
+        d = _load()
+        nulls = [
+            (f, e.get("line_number"))
+            for f, entries in d["results"].items()
+            for e in entries
+            if e.get("is_secret") is None
+        ]
+        assert nulls == [], f"{len(nulls)} unaudited suppressions remain"
+
+    def test_no_noise_directories(self):
+        d = _load()
+        noisy = [f for f in d["results"] if f.startswith(("datasets/", ".claude/"))]
+        assert noisy == [], noisy
+
+    def test_true_entries_exist_as_rotation_inventory(self):
+        """The audit-confirmed live exposures must be marked is_secret: true —
+        they are inputs to the U2/A1 rotation window, not false positives."""
+        d = _load()
+        trues = {
+            f for f, entries in d["results"].items()
+            if any(e.get("is_secret") is True for e in entries)
+        }
+        for expected in (
+            ".env.secure",
+            ".env.airflow",
+            "scripts/deployment/start_data_loading.sh",
+            "docs/reports/security-audit-report.md",
+            ".context/refresh_analysis.sh",
+        ):
+            assert expected in trues, f"{expected} not marked as live exposure"
+
+    def test_filters_exclude_noise_dirs_for_regeneration(self):
+        d = _load()
+        patterns = str(d.get("filters_used", []))
+        assert "datasets" in patterns and "claude" in patterns, (
+            "regeneration filters must keep excluding the noise directories"
+        )


### PR DESCRIPTION
## C2 secret-rotation prep (2026-08 remediation) — no secrets touched, no rotation performed

Per decision **U2** (single maintenance window, authorized 2026-08-11): this PR lands everything that must exist **before** the window so the post-rotation scan is meaningful. The rotation itself is operator-executed per the runbook.

### Commits (per-finding, fail-first --noconftest tests)
- `d64e0d7` — **F8-08-003**: `.gitleaks.toml` now `[extend] useDefault = true` (previously the 13 custom rules *replaced* the entire default ruleset — zero generic/entropy/private-key detection); blanket `*test*.py`/`*.md` allowlists removed; rules added for the 4 leaked vendor keys that had none (FMP, MARKETAUX, FRED, OPENWEATHER). Verified with gitleaks 8.30.1: seeded keys in a `*_test.py` and a `.md` are flagged 2/2.
- `d0151bd` — **F8-08-004**: `.secrets.baseline` regenerated with the pre-commit pin (detect-secrets==1.4.0), excluding `datasets/`+`.claude/` noise (was 1,925 entries, all `is_secret: null`): now **237 entries / 125 files, every one adjudicated** (values inspected masked, never printed). **20 `is_secret: true` = the rotation inventory**, incl. 3 locations the audit had not inventoried: `.context/refresh_analysis.sh:99` PGPASSWORD, `scripts/setup_airflow_complete.sh` hardcoded Airflow/Flower passwords, `scripts/deployment/blue_green_deploy.sh:253` embedded DATABASE_URL.
- `f5e828f` — **F8-16-019** + U2: `docs/runbooks/credential-rotation.md` §12 — the single-window plan (PG/Redis → vendor keys → signing/Fernet → script creds → KDF F-08-001 now bundled), the completed tracked-location inventory, and post-window hygiene strictly AFTER revoke (F8-16-006 untrack, F8-16-018/U6 backup delete, cleanup script, re-scan).

### Notes for review
- The CI gitleaks step is `continue-on-error: true` (advisory), so the now-honest scanner surfaces the known tracked secrets in reports without blocking merges — that visibility is the point of landing this pre-window.
- Out of bounds respected: no secret rotated, printed, or edited; no git history rewritten.

### Test plan
- [x] `tests/test_gitleaks_config_f8_08_003.py` (4 RED→GREEN) + real-gitleaks seeded-leak acceptance
- [x] `tests/test_secrets_baseline_f8_08_004.py` (RED against old baseline→GREEN); baseline loads under detect-secrets 1.4.0
- [x] ruff clean on new test files
- [ ] CI green (docs gate: runbook carries **Version: 1.1.0** / **Last Updated: 2026-08-11**)