### PR TITLE
fix(ci): C3 — CI gates that can fail (scope 14 + 15, 14 finding-fix commits)

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -63,7 +63,7 @@ All workflows have been standardized to:
 | `actions/download-artifact` | v4 | v3 |
 | `github/codeql-action/*` | v3 | v2 |
 
-**Note:** `staging-deploy.yml` and `production-deploy.yml` still reference `codeql-action/upload-sarif@v2` for SARIF uploads in their deploy pipelines.
+**Note:** `staging-deploy.yml` and `production-deploy.yml` upload SARIF via `codeql-action/upload-sarif@v3` (F-14-007 closed; guarded with `if: always() && hashFiles(...)` and per-scan `category:`).
 
 ## Features
 
@@ -327,7 +327,14 @@ fine for application code but not for CI service container connections.
 **3. TA-Lib Build Failures**
 TA-Lib requires the C library to be compiled from source on Ubuntu runners:
 ```bash
-wget http://prdownloads.sourceforge.net/ta-lib/ta-lib-0.4.0-src.tar.gz
+# F-14-003 / F-13-009: HTTPS release + sha256 verification — never the
+# plaintext-HTTP sourceforge mirror.
+TA_LIB_VERSION="0.4.0"
+TA_LIB_SHA256="9ff41efcb1c011a4b4b6dfc91610b06e39b1d7973ed5d4dee55029a0ac4dc651"
+curl -fsSL --proto '=https' --tlsv1.2 \
+  "https://github.com/ta-lib/ta-lib/releases/download/v${TA_LIB_VERSION}/ta-lib-${TA_LIB_VERSION}-src.tar.gz" \
+  -o ta-lib-0.4.0-src.tar.gz
+echo "${TA_LIB_SHA256}  ta-lib-0.4.0-src.tar.gz" | sha256sum -c -
 tar -xzf ta-lib-0.4.0-src.tar.gz
 cd ta-lib/ && ./configure --prefix=/usr && make && sudo make install
 ```

--- a/.github/scripts/injection_guard.py
+++ b/.github/scripts/injection_guard.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Deny-by-default workflow shell-injection guard (F8-14-006, AT-G3-1.1).
+
+Flags ANY ``${{ github.event.* }}`` or ``${{ inputs.* }}`` /
+``${{ github.event.inputs.* }}`` expression appearing inside a ``run:`` or
+``script:`` block of a workflow. The prior guard allowlisted nine variable
+names, so any new name (TAG=, PCT=, REASON=) sailed through — a
+name-allowlist cannot catch code written after the allowlist.
+
+Opt-out for a reviewed line: put ``guard: allow-interpolation`` in a comment
+on the same line or the line directly above.
+
+Exit 0 = clean; exit 1 = findings (one per line on stdout).
+"""
+
+import re
+import sys
+from pathlib import Path
+
+UNTRUSTED = re.compile(r"\$\{\{\s*(github\.event\.|inputs\.)")
+BLOCK_KEY = re.compile(r"^(\s*)(?:-\s+)?(run|script):")
+OPT_OUT = "guard: allow-interpolation"
+
+
+def scan_file(path: Path):
+    findings = []
+    lines = path.read_text(errors="ignore").split("\n")
+    in_block = False
+    block_indent = 0
+    for i, line in enumerate(lines):
+        stripped = line.lstrip()
+        indent = len(line) - len(stripped)
+        m = BLOCK_KEY.match(line)
+        if m:
+            in_block, block_indent = True, len(m.group(1))
+            continue
+        if in_block and stripped and indent <= block_indent:
+            in_block = False
+        if not in_block or not UNTRUSTED.search(line):
+            continue
+        if OPT_OUT in line or (i > 0 and OPT_OUT in lines[i - 1]):
+            continue
+        findings.append(f"{path}:{i + 1}: {stripped[:120]}")
+    return findings
+
+
+def _key(finding: str) -> str:
+    """Baseline key: path + normalized line content (line numbers drift)."""
+    path, _line, content = finding.split(":", 2)
+    return f"{path}::{content.strip()}"
+
+
+def main(argv):
+    args = list(argv[1:])
+    baseline_path = None
+    if "--baseline" in args:
+        baseline_path = Path(args[args.index("--baseline") + 1])
+        del args[args.index("--baseline"):args.index("--baseline") + 2]
+
+    roots = [Path(a) for a in args] or [Path(".github/workflows")]
+    findings = []
+    for root in roots:
+        files = [root] if root.is_file() else sorted(root.rglob("*.yml")) + sorted(root.rglob("*.yaml"))
+        for f in files:
+            findings.extend(scan_file(f))
+
+    # Differential gate (repo convention, cf. T2.4): legacy findings listed
+    # in the baseline warn; anything NEW fails. Burn the baseline down to
+    # empty — never add to it without review.
+    baseline = set()
+    if baseline_path and baseline_path.exists():
+        baseline = {
+            line.strip() for line in baseline_path.read_text().split("\n")
+            if line.strip() and not line.startswith("#")
+        }
+    new = [f for f in findings if _key(f) not in baseline]
+    legacy = len(findings) - len(new)
+    if legacy:
+        print(f"::notice::{legacy} baselined legacy interpolation(s) pending burn-down")
+    for f in new:
+        print(f)
+    return 1 if new else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/.github/scripts/injection_guard_baseline.txt
+++ b/.github/scripts/injection_guard_baseline.txt
@@ -1,0 +1,80 @@
+# F8-14-006 legacy interpolation baseline (frozen 2026-08-11).
+# These 76 pre-existing github.event/inputs interpolations inside
+# run:/script: blocks predate the deny-by-default guard. BURN THIS FILE DOWN
+# (env-hoist each site) — never add entries without security review.
+.github/workflows/auto-sync.yml::REASON="PR #${{ github.event.pull_request.number }} closed"
+.github/workflows/auto-sync.yml::REASON="PR #${{ github.event.pull_request.number }} merged"
+.github/workflows/auto-sync.yml::if [[ "${{ github.event.pull_request.merged }}" == "true" ]]; then
+.github/workflows/auto-sync.yml::if [[ "${{ github.event.workflow_run.conclusion }}" == "failure" ]]; then
+.github/workflows/automated-release.yml::prerelease_tag = "${{ github.event.inputs.prerelease_tag }}" or "rc"
+.github/workflows/automated-release.yml::release_type = "${{ github.event.inputs.release_type }}" or "patch"
+.github/workflows/board-sync.yml::--url ${{ github.event.issue.html_url }} || true
+.github/workflows/board-sync.yml::--url ${{ github.event.pull_request.html_url }} || true
+.github/workflows/board-sync.yml::echo "Sync type: ${{ github.event.inputs.sync_type }}" >> $GITHUB_STEP_SUMMARY
+.github/workflows/board-sync.yml::gh issue edit ${{ github.event.issue.number }} --add-label "status:completed" || true
+.github/workflows/cleanup.yml::**Dry Run**: ${{ github.event.inputs.dry_run || 'true' }}
+.github/workflows/cleanup.yml::DRY_RUN="${{ github.event.inputs.dry_run || 'true' }}"
+.github/workflows/cleanup.yml::const dryRun = ${{ github.event.inputs.dry_run || true }};
+.github/workflows/cleanup.yml::const dryRun = ${{ github.event.inputs.dry_run || true }};
+.github/workflows/cleanup.yml::const dryRun = ${{ github.event.inputs.dry_run || true }};
+.github/workflows/cleanup.yml::echo "**Cleanup Type**: ${{ github.event.inputs.cleanup_type || 'all' }}" >> $GITHUB_STEP_SUMMARY
+.github/workflows/cleanup.yml::echo "**Dry Run**: ${{ github.event.inputs.dry_run || 'true' }}" >> $GITHUB_STEP_SUMMARY
+.github/workflows/daily-pipeline-validation.yml::test_mode = '${{ github.event.inputs.test_mode }}' == 'true'
+.github/workflows/dependency-updates.yml::echo "**Update Type**: ${{ github.event.inputs.update_type || 'all' }}" >> js-update-summary.md
+.github/workflows/dependency-updates.yml::echo "**Update Type**: ${{ github.event.inputs.update_type || 'all' }}" >> python-update-summary.md
+.github/workflows/dependency-updates.yml::if [[ "${{ github.event.inputs.update_type }}" == "security-only" ]]; then
+.github/workflows/dependency-updates.yml::if [[ "${{ github.event.inputs.update_type }}" == "security-only" ]]; then
+.github/workflows/dependency-updates.yml::if [[ "${{ github.event.inputs.update_type }}" == "security-only" ]]; then
+.github/workflows/github-swarm.yml::body += `PR #${{ github.event.pull_request.number }} was merged and may require documentation updates:\n\n`;
+.github/workflows/github-swarm.yml::title: `docs: Update documentation for PR #${{ github.event.pull_request.number }}`,
+.github/workflows/issue-management.yml::ISSUE_NUMBER="${{ github.event.issue.number }}"
+.github/workflows/issue-management.yml::ISSUE_NUMBER="${{ github.event.issue.number }}"
+.github/workflows/issue-management.yml::echo -e "$COMMENT" | gh issue comment ${{ github.event.issue.number }} --body-file -
+.github/workflows/issue-management.yml::echo -e "$COMMENT" | gh issue comment ${{ github.event.issue.number }} --body-file -
+.github/workflows/issue-management.yml::echo -e "$COMMENT" | gh issue comment ${{ github.event.issue.number }} --body-file -
+.github/workflows/issue-management.yml::gh issue edit ${{ github.event.issue.number }} --add-label "$label" || echo "Label may not exist: $label"
+.github/workflows/issue-management.yml::if [ "$issue_num" != "${{ github.event.issue.number }}" ]; then
+.github/workflows/migration-check.yml::DIFF_RANGE="${{ github.event.before }}..${{ github.sha }}"
+.github/workflows/monitoring-notifications.yml::echo "**Run ID**: ${{ github.event.workflow_run.id }}" >> $GITHUB_STEP_SUMMARY
+.github/workflows/notion-github-sync.yml::"conflict_resolution": "${{ github.event.inputs.conflict_resolution || 'github_wins' }}",
+.github/workflows/notion-github-sync.yml::"direction": "${{ github.event.inputs.direction || 'bidirectional' }}",
+.github/workflows/notion-github-sync.yml::"dry_run": ${{ github.event.inputs.dry_run || false }},
+.github/workflows/notion-github-sync.yml::echo "**Conflict Resolution**: ${{ github.event.inputs.conflict_resolution || 'github_wins' }}" >> $GITHUB_STEP_SUMMARY
+.github/workflows/notion-github-sync.yml::echo "**Direction**: ${{ github.event.inputs.direction || 'bidirectional' }}" >> $GITHUB_STEP_SUMMARY
+.github/workflows/notion-github-sync.yml::echo "Conflicts were resolved using **${{ github.event.inputs.conflict_resolution || 'github_wins' }}** strategy." >> $G
+.github/workflows/performance-monitoring.yml::"environment": "${{ github.event.inputs.test_environment || 'staging' }}",
+.github/workflows/performance-monitoring.yml::DURATION="${{ github.event.inputs.test_duration || '5' }}m"
+.github/workflows/performance-monitoring.yml::case "${{ github.event.inputs.test_intensity || 'light' }}" in
+.github/workflows/performance-monitoring.yml::echo "**Environment**: ${{ github.event.inputs.test_environment || 'staging' }}" >> $GITHUB_STEP_SUMMARY
+.github/workflows/performance-monitoring.yml::echo "**Environment**: ${{ github.event.inputs.test_environment || 'staging' }}" >> performance-report.md
+.github/workflows/performance-monitoring.yml::echo "**Test Duration**: ${{ github.event.inputs.test_duration || '5' }} minutes" >> performance-report.md
+.github/workflows/performance-monitoring.yml::echo "**Test Intensity**: ${{ github.event.inputs.test_intensity || 'light' }}" >> performance-report.md
+.github/workflows/performance-monitoring.yml::if [ "${{ github.event.inputs.test_environment || 'staging' }}" = "production" ]; then
+.github/workflows/performance-monitoring.yml::test_duration_minutes = ${{ github.event.inputs.test_duration || '5' }}
+.github/workflows/pr-automation.yml::# gh pr edit ${{ github.event.pull_request.number }} --add-reviewer "$REVIEWERS"
+.github/workflows/pr-automation.yml::BASE_BRANCH="${{ github.event.pull_request.base.ref }}"
+.github/workflows/pr-automation.yml::HEAD_BRANCH="${{ github.event.pull_request.head.ref }}"
+.github/workflows/pr-automation.yml::PR_NUMBER="${{ github.event.pull_request.number }}"
+.github/workflows/pr-automation.yml::PR_NUMBER="${{ github.event.pull_request.number }}"
+.github/workflows/pr-automation.yml::PR_NUMBER="${{ github.event.pull_request.number }}"
+.github/workflows/pr-automation.yml::echo "✅ Auto-merge enabled for PR #${{ github.event.pull_request.number }}"
+.github/workflows/pr-automation.yml::echo -e "$COMMENT" | gh pr comment ${{ github.event.pull_request.number }} --body-file -
+.github/workflows/pr-automation.yml::echo -e "$COMMENT" | gh pr comment ${{ github.event.pull_request.number }} --body-file -
+.github/workflows/pr-automation.yml::gh pr edit ${{ github.event.pull_request.number }} --add-label "$label" || true
+.github/workflows/pr-automation.yml::gh pr merge ${{ github.event.pull_request.number }} \
+.github/workflows/production-deploy.yml::echo "prerelease=${{ github.event.release.prerelease }}" >> $GITHUB_OUTPUT
+.github/workflows/production-deploy.yml::echo "tag_name=${{ github.event.inputs.tag }}" >> $GITHUB_OUTPUT
+.github/workflows/production-deploy.yml::echo "tag_name=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
+.github/workflows/production-deploy.yml::git checkout ${{ github.event.inputs.tag || github.event.release.tag_name }}
+.github/workflows/release-management.yml::is_prerelease = "true" if ("${{ github.event.inputs.pre_release }}" == "true" or "-rc" in version or "-alpha" in version
+.github/workflows/release-management.yml::release_type = "${{ github.event.inputs.release_type }}"
+.github/workflows/reusable-build.yml::case "${{ inputs.environment }}" in
+.github/workflows/reusable-build.yml::echo "**Environment**: ${{ inputs.environment }}" >> $GITHUB_STEP_SUMMARY
+.github/workflows/reusable-build.yml::echo "**Platforms**: ${{ inputs.platforms }}" >> $GITHUB_STEP_SUMMARY
+.github/workflows/reusable-build.yml::echo "**Push Images**: ${{ inputs.push-images }}" >> $GITHUB_STEP_SUMMARY
+.github/workflows/reusable-test.yml::if [[ "${{ inputs.skip-slow-tests }}" == "true" ]]; then
+.github/workflows/reusable-test.yml::if [[ "${{ inputs.skip-slow-tests }}" == "true" ]]; then
+.github/workflows/workflow-coordinator.yml::ENVIRONMENT="${{ github.event.inputs.environment }}"
+.github/workflows/workflow-coordinator.yml::SKIP_TESTS="${{ github.event.inputs.skip_tests }}"
+.github/workflows/workflow-coordinator.yml::WORKFLOW_TYPE="${{ github.event.inputs.workflow_type }}"
+.github/workflows/workflow-coordinator.yml::echo "**Workflow Type**: ${{ github.event.inputs.workflow_type }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/auto-sync.yml
+++ b/.github/workflows/auto-sync.yml
@@ -63,6 +63,10 @@ jobs:
     steps:
       - name: Analyze Trigger
         id: analyze
+        env:
+          # F8-14-009: workflow name reaches the shell via env, not
+          # YAML interpolation inside a quoted assignment.
+          TRIGGER_WORKFLOW: ${{ github.event.workflow_run.name }}
         run: |
           SHOULD_SYNC="true"
           REASON=""
@@ -84,7 +88,7 @@ jobs:
               fi
               ;;
             workflow_run)
-              REASON="Workflow '${{ github.event.workflow_run.name }}' completed"
+              REASON="Workflow '$TRIGGER_WORKFLOW' completed"
               if [[ "${{ github.event.workflow_run.conclusion }}" == "failure" ]]; then
                 PRIORITY="high"
               fi

--- a/.github/workflows/auto-sync.yml
+++ b/.github/workflows/auto-sync.yml
@@ -40,6 +40,11 @@ on:
         default: false
         type: boolean
 
+# F8-14-002: default the workflow token to read-only; jobs that
+# write are granted narrow scopes at job level.
+permissions:
+  contents: read
+
 concurrency:
   group: auto-sync-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/automated-release.yml
+++ b/.github/workflows/automated-release.yml
@@ -28,6 +28,11 @@ on:
     paths:
       - 'VERSION'
 
+# F8-14-002: default the workflow token to read-only; jobs that
+# write are granted narrow scopes at job level.
+permissions:
+  contents: read
+
 env:
   PYTHON_VERSION: '3.12'
   NODE_VERSION: '20'
@@ -274,6 +279,8 @@ jobs:
 
   # Create GitHub release
   create-release:
+    permissions:
+      contents: write
     needs: [calculate-version, pre-release-checks]
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -342,6 +349,8 @@ jobs:
 
   # Trigger deployment
   trigger-deployment:
+    permissions:
+      actions: write
     needs: [calculate-version, create-release]
     if: needs.calculate-version.outputs.is_prerelease == 'false'
     runs-on: ubuntu-latest

--- a/.github/workflows/canary-deploy.yml
+++ b/.github/workflows/canary-deploy.yml
@@ -51,27 +51,38 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # F8-14-005: inputs reach the shell only via env (never YAML-rendered
+      # into run text), and the manifest is built with jq so no input can
+      # break the JSON or the surrounding shell.
       - name: Resolve canary ref
         id: meta
+        env:
+          IMAGE_TAG: ${{ github.event.inputs.image_tag }}
+          CANARY_PERCENT: ${{ github.event.inputs.canary_percent }}
         run: |
-          TAG="${{ github.event.inputs.image_tag }}"
-          PCT="${{ github.event.inputs.canary_percent }}"
-          echo "ref=$TAG" >> "$GITHUB_OUTPUT"
-          echo "percent=$PCT" >> "$GITHUB_OUTPUT"
-          echo "Canary tag=$TAG at ${PCT}% traffic"
+          echo "ref=$IMAGE_TAG" >> "$GITHUB_OUTPUT"
+          echo "percent=$CANARY_PERCENT" >> "$GITHUB_OUTPUT"
+          echo "Canary tag=$IMAGE_TAG at ${CANARY_PERCENT}% traffic"
 
       - name: Record canary deployment intent
+        env:
+          IMAGE_TAG: ${{ github.event.inputs.image_tag }}
+          CANARY_PERCENT: ${{ github.event.inputs.canary_percent }}
+          TARGET_ENV: ${{ github.event.inputs.environment }}
+          HEALTH_URL: ${{ github.event.inputs.health_url }}
         run: |
           mkdir -p artifacts
-          cat > artifacts/canary-manifest.json <<EOF
-          {
-            "image_tag": "${{ github.event.inputs.image_tag }}",
-            "canary_percent": ${{ github.event.inputs.canary_percent }},
-            "environment": "${{ github.event.inputs.environment }}",
-            "health_url": "${{ github.event.inputs.health_url }}",
-            "started_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-          }
-          EOF
+          jq -n \
+            --arg image_tag "$IMAGE_TAG" \
+            --arg canary_percent "$CANARY_PERCENT" \
+            --arg environment "$TARGET_ENV" \
+            --arg health_url "$HEALTH_URL" \
+            --arg started_at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            '{image_tag: $image_tag,
+              canary_percent: ($canary_percent | tonumber),
+              environment: $environment,
+              health_url: $health_url,
+              started_at: $started_at}' > artifacts/canary-manifest.json
           cat artifacts/canary-manifest.json
 
       # Placeholder for real orchestrator (K8s/ECS/Nomad). Keeps workflow green

--- a/.github/workflows/canary-deploy.yml
+++ b/.github/workflows/canary-deploy.yml
@@ -14,9 +14,8 @@ on:
         default: "10"
         type: string
       health_url:
-        description: "Health check URL for canary"
-        required: false
-        default: "https://staging.example.com/api/health"
+        description: "Health check URL for canary (no default — F8-14-011)"
+        required: true
         type: string
       environment:
         description: "Target environment"
@@ -48,6 +47,19 @@ jobs:
     outputs:
       canary_ref: ${{ steps.meta.outputs.ref }}
     steps:
+      # F8-14-011: with the old example.com default, every default-input
+      # dispatch probed a reserved domain five times and rolled back. Fail
+      # at input validation instead, with an actionable message.
+      - name: Validate health_url input
+        env:
+          HEALTH_URL: ${{ github.event.inputs.health_url }}
+        run: |
+          case "$HEALTH_URL" in
+            ""|*example.com*)
+              echo "ERROR: health_url is '$HEALTH_URL' — supply the real canary health endpoint (example.com is a reserved placeholder)."
+              exit 1 ;;
+          esac
+
       - name: Checkout
         uses: actions/checkout@v4
 
@@ -91,13 +103,14 @@ jobs:
         env:
           DEPLOY_TOKEN: ${{ secrets.DEPLOY_TOKEN }}
         run: |
+          # F8-14-013: the former dry_run GITHUB_ENV writes were read by
+          # nothing (and job env cannot cross jobs); promote/rollback derive
+          # credential presence from DEPLOY_TOKEN directly.
           if [ -z "$DEPLOY_TOKEN" ]; then
             echo "No DEPLOY_TOKEN secret — recording dry-run canary only."
-            echo "dry_run=true" >> "$GITHUB_ENV"
           else
             echo "DEPLOY_TOKEN present — invoke external canary apply here."
             # Example: kubectl set image / aws ecs update-service ...
-            echo "dry_run=false" >> "$GITHUB_ENV"
           fi
 
       - name: Upload canary manifest

--- a/.github/workflows/canary-deploy.yml
+++ b/.github/workflows/canary-deploy.yml
@@ -27,6 +27,11 @@ on:
           - staging
           - production
 
+# F8-14-002: default the workflow token to read-only; jobs that
+# write are granted narrow scopes at job level.
+permissions:
+  contents: read
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,11 @@ on:
       - 'pyproject.toml'
       - 'pytest.ini'
 
+# F8-14-002: default the workflow token to read-only; jobs that
+# write are granted narrow scopes at job level.
+permissions:
+  contents: read
+
 env:
   PYTHON_VERSION: '3.12'
   NODE_VERSION: '20'

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -10,6 +10,11 @@ on:
     #   - "src/**/*.js"
     #   - "src/**/*.jsx"
 
+# F8-14-002: default the workflow token to read-only; jobs that
+# write are granted narrow scopes at job level.
+permissions:
+  contents: read
+
 jobs:
   claude-review:
     # Optional: Filter by PR author

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,6 +10,11 @@ on:
   pull_request_review:
     types: [submitted]
 
+# F8-14-002: default the workflow token to read-only; jobs that
+# write are granted narrow scopes at job level.
+permissions:
+  contents: read
+
 jobs:
   claude:
     if: |

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -23,6 +23,11 @@ on:
         default: true
         type: boolean
 
+# F8-14-002: default the workflow token to read-only; jobs that
+# write are granted narrow scopes at job level.
+permissions:
+  contents: read
+
 env:
   RETENTION_DAYS_ARTIFACTS: 30
   RETENTION_DAYS_PACKAGES: 90
@@ -35,6 +40,8 @@ concurrency:
 jobs:
   # Cleanup old workflow artifacts
   cleanup-artifacts:
+    permissions:
+      actions: write
     runs-on: ubuntu-latest
     if: github.event.inputs.cleanup_type == 'artifacts' || github.event.inputs.cleanup_type == 'all' || github.event.inputs.cleanup_type == ''
     
@@ -111,6 +118,8 @@ jobs:
 
   # Cleanup old container packages
   cleanup-packages:
+    permissions:
+      packages: write
     runs-on: ubuntu-latest
     if: github.event.inputs.cleanup_type == 'packages' || github.event.inputs.cleanup_type == 'all' || github.event.inputs.cleanup_type == ''
     
@@ -223,6 +232,8 @@ jobs:
 
   # Cleanup GitHub Actions cache
   cleanup-cache:
+    permissions:
+      actions: write
     runs-on: ubuntu-latest
     if: github.event.inputs.cleanup_type == 'cache' || github.event.inputs.cleanup_type == 'all' || github.event.inputs.cleanup_type == ''
     

--- a/.github/workflows/comprehensive-testing.yml
+++ b/.github/workflows/comprehensive-testing.yml
@@ -9,6 +9,11 @@ on:
     # Run comprehensive tests daily at 2 AM UTC
     - cron: '0 2 * * *'
 
+# F8-14-002: default the workflow token to read-only; jobs that
+# write are granted narrow scopes at job level.
+permissions:
+  contents: read
+
 env:
   PYTHON_VERSION: '3.12'
   NODE_VERSION: '20'
@@ -722,6 +727,9 @@ ENVEOF
 
   # Generate comprehensive test report
   test-report:
+    permissions:
+      issues: write
+      pull-requests: write
     runs-on: ubuntu-latest
     name: Generate Test Report
     needs: [security-scan, code-quality, unit-tests, integration-tests, financial-model-tests, security-compliance-tests, frontend-tests]

--- a/.github/workflows/comprehensive-testing.yml
+++ b/.github/workflows/comprehensive-testing.yml
@@ -579,12 +579,9 @@ jobs:
           cd frontend/web
           npm test -- --coverage --run
 
-      - name: Run frontend E2E tests
-        continue-on-error: true
-        run: |
-          cd frontend/web
-          npm run test:e2e || echo "E2E tests skipped (Cypress not configured)"
-
+      # F8-15-002: E2E runs in the dedicated e2e-tests job below; this job
+      # keeps unit tests only (the old step here echo-skipped and pointed its
+      # artifacts at directories Playwright never writes).
       - name: Upload frontend test reports
         uses: actions/upload-artifact@v4
         if: always()
@@ -592,8 +589,6 @@ jobs:
           name: frontend-test-reports
           path: |
             frontend/web/coverage/
-            frontend/web/cypress/screenshots/
-            frontend/web/cypress/videos/
 
   # Docker build and test
   docker-build:
@@ -680,58 +675,109 @@ ENVEOF
             backend-security-scan.json
             frontend-security-scan.json
 
-  # End-to-end testing
+  # End-to-end testing (F8-15-002: real Playwright suite, no
+  # continue-on-error — this job MUST be able to fail. Chromium-only on
+  # push; the full 5-browser matrix runs on the nightly schedule only
+  # (F8-15-023). Kept on main-push + schedule until proven green, then
+  # widen to PRs.)
   e2e-tests:
     runs-on: ubuntu-latest
-    name: End-to-End Tests
+    name: End-to-End Tests (Playwright)
     needs: [unit-tests, integration-tests]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'schedule'
+    services:
+      postgres:
+        image: postgres:15-alpine
+        env:
+          POSTGRES_DB: test_db
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: testpass
+        options: >-
+          --health-cmd pg_isready --health-interval 10s
+          --health-timeout 5s --health-retries 5
+        ports:
+          - 5432:5432
+      redis:
+        image: redis:7-alpine
+        options: >-
+          --health-cmd "redis-cli ping" --health-interval 10s
+          --health-timeout 5s --health-retries 5
+        ports:
+          - 6379:6379
+    env:
+      DATABASE_URL: postgresql://postgres:testpass@localhost:5432/test_db
+      REDIS_URL: redis://localhost:6379/0
+      SECRET_KEY: test-secret-key-for-ci
+      JWT_SECRET_KEY: test-jwt-secret-key-for-ci
+      MASTER_SECRET_KEY: test-master-secret-key-for-ci
+      SESSION_SECRET_KEY: test-session-secret-key-for-ci
+      ENVIRONMENT: testing
+      TESTING: "True"
+      E2E_USER_PASSWORD: E2eCiPassword123!
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
 
-      - name: Start full application stack
-        continue-on-error: true
+      - name: Install backend dependencies (for the Playwright webServer)
         run: |
-          docker compose -f docker-compose.yml -f docker-compose.test.yml up -d
+          sudo apt-get update
+          sudo apt-get install -y build-essential libpq-dev
+          # TA-Lib (F-14-003 / F-13-009: HTTPS + sha256 verify)
+          TA_LIB_VERSION="0.4.0"
+          TA_LIB_SHA256="9ff41efcb1c011a4b4b6dfc91610b06e39b1d7973ed5d4dee55029a0ac4dc651"
+          curl -fsSL --proto '=https' --tlsv1.2 \
+            "https://github.com/ta-lib/ta-lib/releases/download/v${TA_LIB_VERSION}/ta-lib-${TA_LIB_VERSION}-src.tar.gz" \
+            -o ta-lib-src.tar.gz
+          echo "${TA_LIB_SHA256}  ta-lib-src.tar.gz" | sha256sum -c -
+          tar -xzf ta-lib-src.tar.gz
+          (cd ta-lib/ && ./configure --prefix=/usr && make && sudo make install)
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
 
-          # Wait for all services to be ready
-          sleep 60
-
-      - name: Set up Node.js for E2E tests
+      - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+          cache-dependency-path: frontend/web/package-lock.json
 
-      - name: Install E2E test dependencies
-        continue-on-error: true
-        run: |
-          npm install -g cypress
-
-      - name: Run E2E tests
-        continue-on-error: true
+      - name: Install frontend dependencies + Playwright chromium
         run: |
           cd frontend/web
-          npm run cypress:run || echo "E2E tests skipped or failed"
+          npm ci
+          npx playwright install --with-deps chromium
 
-      - name: Stop application stack
-        if: always()
-        continue-on-error: true
+      - name: Run Playwright suite (chromium)
+        if: github.event_name != 'schedule'
         run: |
-          docker compose -f docker-compose.yml -f docker-compose.test.yml down || true
+          cd frontend/web
+          npx playwright test --project=chromium
 
-      - name: Upload E2E test reports
+      - name: Install remaining browsers (nightly)
+        if: github.event_name == 'schedule'
+        run: |
+          cd frontend/web
+          npx playwright install --with-deps
+
+      - name: Run Playwright suite (full matrix, nightly)
+        if: github.event_name == 'schedule'
+        run: |
+          cd frontend/web
+          npx playwright test
+
+      - name: Upload Playwright artifacts
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: e2e-test-reports
+          name: playwright-artifacts
           path: |
-            frontend/web/cypress/screenshots/
-            frontend/web/cypress/videos/
-            frontend/web/cypress/reports/
+            frontend/web/playwright-report/
+            frontend/web/test-results/
 
   # Generate comprehensive test report
   test-report:

--- a/.github/workflows/comprehensive-testing.yml
+++ b/.github/workflows/comprehensive-testing.yml
@@ -649,20 +649,28 @@ ENVEOF
           # Stop services
           docker compose -f docker-compose.yml -f docker-compose.test.yml down
 
-      - name: Run security scan on Docker images
+      # F8-14-014: the former apt-key install path is deprecated (removed
+      # on newer Ubuntu images) and unpinned; use the same pinned action as
+      # every other Trivy call site (F8-14-001).
+      - name: Scan backend image (Trivy)
         continue-on-error: true
-        run: |
-          # Install trivy
-          sudo apt-get update
-          sudo apt-get install wget apt-transport-https gnupg lsb-release
-          wget -qO - https://aquasecurity.github.io/trivy-repo/deb/public.key | sudo apt-key add -
-          echo "deb https://aquasecurity.github.io/trivy-repo/deb $(lsb_release -sc) main" | sudo tee -a /etc/apt/sources.list.d/trivy.list
-          sudo apt-get update
-          sudo apt-get install trivy
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          scan-type: image
+          image-ref: investment-app-backend:test
+          format: json
+          output: backend-security-scan.json
+          exit-code: '0'
 
-          # Scan images
-          trivy image --exit-code 0 --format json -o backend-security-scan.json investment-app-backend:test
-          trivy image --exit-code 0 --format json -o frontend-security-scan.json investment-app-frontend:test
+      - name: Scan frontend image (Trivy)
+        continue-on-error: true
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          scan-type: image
+          image-ref: investment-app-frontend:test
+          format: json
+          output: frontend-security-scan.json
+          exit-code: '0'
 
       - name: Upload Docker security reports
         uses: actions/upload-artifact@v4

--- a/.github/workflows/daily-pipeline-validation.yml
+++ b/.github/workflows/daily-pipeline-validation.yml
@@ -23,6 +23,11 @@ on:
         - ml-training
         - recommendations
 
+# F8-14-002: default the workflow token to read-only; jobs that
+# write are granted narrow scopes at job level.
+permissions:
+  contents: read
+
 env:
   PYTHON_VERSION: '3.12'
   # Cost optimization - use smaller runners

--- a/.github/workflows/dependency-updates.yml
+++ b/.github/workflows/dependency-updates.yml
@@ -22,6 +22,11 @@ on:
         default: false
         type: boolean
 
+# F8-14-002: default the workflow token to read-only; jobs that
+# write are granted narrow scopes at job level.
+permissions:
+  contents: read
+
 env:
   PYTHON_VERSION: '3.12'
   NODE_VERSION: '20'
@@ -367,6 +372,9 @@ jobs:
 
   # Create pull request with updates
   create-update-pr:
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     needs: [security-check, update-python-deps, update-js-deps]
     if: always() && (needs.update-python-deps.result == 'success' || needs.update-js-deps.result == 'success')

--- a/.github/workflows/documentation-sync.yml
+++ b/.github/workflows/documentation-sync.yml
@@ -18,6 +18,11 @@ on:
         type: boolean
         default: false
 
+# F8-14-002: default the workflow token to read-only; jobs that
+# write are granted narrow scopes at job level.
+permissions:
+  contents: read
+
 env:
   NOTION_API_KEY: ${{ secrets.NOTION_API_KEY }}
   NOTION_DATABASE_ID: ${{ secrets.NOTION_DATABASE_ID }}
@@ -322,6 +327,8 @@ jobs:
         continue-on-error: true
 
   update-index:
+    permissions:
+      contents: write
     name: Update Documentation Index
     runs-on: ubuntu-latest
     needs: [detect-duplicates, validate-links, check-versions]

--- a/.github/workflows/github-swarm.yml
+++ b/.github/workflows/github-swarm.yml
@@ -16,6 +16,11 @@ on:
     # Hourly infrastructure health check
     - cron: '0 * * * *'
 
+# F8-14-002: default the workflow token to read-only; jobs that
+# write are granted narrow scopes at job level.
+permissions:
+  contents: read
+
 concurrency:
   group: github-swarm-${{ github.event_name }}-${{ github.event.number || github.ref }}
   cancel-in-progress: false

--- a/.github/workflows/migration-check.yml
+++ b/.github/workflows/migration-check.yml
@@ -61,8 +61,20 @@ jobs:
     - name: Detect migration changes
       id: changes
       run: |
+        # F8-14-010: github.event.before is unset on pull_request, which
+        # rendered a broken range that the old "|| echo" chain silently
+        # swallowed — every PR reported has_migrations=false. Use the PR
+        # base on PR events (fetch-depth: 0 is set above) and fail loudly.
+        set -euo pipefail
+        if [ "${{ github.event_name }}" = "pull_request" ]; then
+          DIFF_RANGE="origin/${{ github.base_ref }}...HEAD"
+        else
+          DIFF_RANGE="${{ github.event.before }}..${{ github.sha }}"
+        fi
+        echo "Diff range: $DIFF_RANGE"
+
         # Check for new migration files
-        MIGRATION_FILES=$(git diff --name-only ${{ github.event.before }}..${{ github.sha }} -- backend/migrations/versions/ || git diff --name-only HEAD~1..HEAD -- backend/migrations/versions/ || echo "")
+        MIGRATION_FILES=$(git diff --name-only "$DIFF_RANGE" -- backend/migrations/versions/)
         
         if [ -n "$MIGRATION_FILES" ]; then
           echo "has_migrations=true" >> $GITHUB_OUTPUT
@@ -76,7 +88,7 @@ jobs:
         fi
         
         # Check for model changes
-        MODEL_CHANGES=$(git diff --name-only ${{ github.event.before }}..${{ github.sha }} -- backend/models/ || git diff --name-only HEAD~1..HEAD -- backend/models/ || echo "")
+        MODEL_CHANGES=$(git diff --name-only "$DIFF_RANGE" -- backend/models/)
         
         if [ -n "$MODEL_CHANGES" ]; then
           echo "has_model_changes=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -5,6 +5,11 @@ name: Type Checking (mypy) [DEPRECATED]
 on:
   workflow_dispatch:  # manual only — push/PR type checks live in type-check.yml
 
+# F8-14-002: default the workflow token to read-only; jobs that
+# write are granted narrow scopes at job level.
+permissions:
+  contents: read
+
 jobs:
   mypy:
     name: Deprecated — use type-check.yml

--- a/.github/workflows/notion-github-sync.yml
+++ b/.github/workflows/notion-github-sync.yml
@@ -41,6 +41,11 @@ on:
         default: false
         type: boolean
 
+# F8-14-002: default the workflow token to read-only; jobs that
+# write are granted narrow scopes at job level.
+permissions:
+  contents: read
+
 concurrency:
   group: notion-github-sync
   cancel-in-progress: false

--- a/.github/workflows/performance-monitoring.yml
+++ b/.github/workflows/performance-monitoring.yml
@@ -34,6 +34,11 @@ on:
         - moderate
         - heavy
 
+# F8-14-002: default the workflow token to read-only; jobs that
+# write are granted narrow scopes at job level.
+permissions:
+  contents: read
+
 env:
   PYTHON_VERSION: '3.12'
   # Cost optimization - use smaller runners when possible

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -307,6 +307,18 @@ jobs:
 
     - name: Security gate check
       run: |
+        # F8-14-003: preflight ported from staging-deploy (de87a4a). Without
+        # strict mode + existence checks, a failed Trivy scan leaves no
+        # report, the JSON parse emits nothing, wc -l returns 0 and the gate
+        # vacuously prints "deployment approved".
+        set -euo pipefail
+        for f in backend-trivy-results.json frontend-trivy-results.json; do
+          if [ ! -f "$f" ]; then
+            echo "ERROR: missing Trivy report $f (scan produced no output). Failing the gate."
+            exit 1
+          fi
+        done
+
         # Check for critical and high vulnerabilities
         BACKEND_CRITICAL=$(jq '.Results[]?.Vulnerabilities[]? | select(.Severity=="CRITICAL") | .VulnerabilityID' backend-trivy-results.json | wc -l)
         BACKEND_HIGH=$(jq '.Results[]?.Vulnerabilities[]? | select(.Severity=="HIGH") | .VulnerabilityID' backend-trivy-results.json | wc -l)

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -275,7 +275,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Run comprehensive Trivy scan on backend
-      uses: aquasecurity/trivy-action@master
+      uses: aquasecurity/trivy-action@v0.36.0
       with:
         image-ref: ${{ needs.build-production-images.outputs.backend-image }}
         format: 'json'
@@ -283,7 +283,7 @@ jobs:
         severity: 'CRITICAL,HIGH,MEDIUM,LOW'
 
     - name: Run comprehensive Trivy scan on frontend
-      uses: aquasecurity/trivy-action@master
+      uses: aquasecurity/trivy-action@v0.36.0
       with:
         image-ref: ${{ needs.build-production-images.outputs.frontend-image }}
         format: 'json'
@@ -291,7 +291,7 @@ jobs:
         severity: 'CRITICAL,HIGH,MEDIUM,LOW'
 
     - name: Generate SARIF reports
-      uses: aquasecurity/trivy-action@master
+      uses: aquasecurity/trivy-action@v0.36.0
       with:
         image-ref: ${{ needs.build-production-images.outputs.backend-image }}
         format: 'sarif'

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -15,6 +15,11 @@ on:
         default: false
         type: boolean
 
+# F8-14-002: default the workflow token to read-only; jobs that
+# write are granted narrow scopes at job level.
+permissions:
+  contents: read
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
@@ -166,6 +171,9 @@ jobs:
 
   # Build production images
   build-production-images:
+    permissions:
+      contents: read
+      packages: write
     runs-on: ubuntu-latest
     needs: [validate-release, pre-deployment-tests]
     if: always() && (needs.pre-deployment-tests.result == 'success' || needs.pre-deployment-tests.result == 'skipped')
@@ -350,6 +358,8 @@ jobs:
 
   # Deploy to production
   deploy-production:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     needs: [validate-release, build-production-images, security-scan]
     environment: production

--- a/.github/workflows/release-management.yml
+++ b/.github/workflows/release-management.yml
@@ -502,7 +502,7 @@ jobs:
     
     steps:
     - name: Run Trivy vulnerability scanner
-      uses: aquasecurity/trivy-action@master
+      uses: aquasecurity/trivy-action@v0.36.0
       with:
         image-ref: ${{ needs.build-release-artifacts.outputs.backend-image }}
         format: 'json'

--- a/.github/workflows/release-management.yml
+++ b/.github/workflows/release-management.yml
@@ -27,6 +27,11 @@ on:
         default: false
         type: boolean
 
+# F8-14-002: default the workflow token to read-only; jobs that
+# write are granted narrow scopes at job level.
+permissions:
+  contents: read
+
 env:
   PYTHON_VERSION: '3.12'
   NODE_VERSION: '20'
@@ -316,6 +321,9 @@ jobs:
 
   # Build release artifacts
   build-release-artifacts:
+    permissions:
+      contents: read
+      packages: write
     runs-on: ubuntu-latest
     timeout-minutes: 30
     needs: [prepare-release, pre-release-validation]
@@ -395,6 +403,8 @@ jobs:
 
   # Create GitHub release
   create-github-release:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: [prepare-release, build-release-artifacts]

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -43,12 +43,20 @@ on:
         description: 'Frontend image digest'
         value: ${{ jobs.build.outputs.frontend-digest }}
 
+# F8-14-002: default the workflow token to read-only; jobs that
+# write are granted narrow scopes at job level.
+permissions:
+  contents: read
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   build:
+    permissions:
+      contents: read
+      packages: write
     runs-on: ubuntu-latest
     outputs:
       backend-image: ${{ steps.backend-meta.outputs.tags }}

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -52,6 +52,11 @@ on:
         description: 'Overall test results'
         value: ${{ jobs.test-summary.outputs.results }}
 
+# F8-14-002: default the workflow token to read-only; jobs that
+# write are granted narrow scopes at job level.
+permissions:
+  contents: read
+
 env:
   PYTHON_VERSION: ${{ inputs.python-version }}
   NODE_VERSION: ${{ inputs.node-version }}

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -275,7 +275,7 @@ jobs:
         "
 
     - name: Yarn/NPM dependency scan with Snyk
-      uses: snyk/actions/node@master
+      uses: snyk/actions/node@0.4.0
       continue-on-error: true
       env:
         SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
@@ -452,7 +452,7 @@ jobs:
 
     - name: Run Trivy vulnerability scanner on backend (all severities, report only)
       continue-on-error: true
-      uses: aquasecurity/trivy-action@master
+      uses: aquasecurity/trivy-action@v0.36.0
       with:
         image-ref: 'security-scan-backend:latest'
         format: 'json'
@@ -461,7 +461,7 @@ jobs:
 
     - name: Run Trivy vulnerability scanner on backend (advisory; remediation tracked separately)
       continue-on-error: true  # CVE remediation is an ongoing maintenance task, not gating
-      uses: aquasecurity/trivy-action@master
+      uses: aquasecurity/trivy-action@v0.36.0
       with:
         image-ref: 'security-scan-backend:latest'
         format: 'table'
@@ -471,7 +471,7 @@ jobs:
 
     - name: Run Trivy vulnerability scanner on frontend (all severities, report only)
       continue-on-error: true
-      uses: aquasecurity/trivy-action@master
+      uses: aquasecurity/trivy-action@v0.36.0
       with:
         image-ref: 'security-scan-frontend:latest'
         format: 'json'
@@ -480,7 +480,7 @@ jobs:
 
     - name: Run Trivy vulnerability scanner on frontend (advisory)
       continue-on-error: true
-      uses: aquasecurity/trivy-action@master
+      uses: aquasecurity/trivy-action@v0.36.0
       with:
         image-ref: 'security-scan-frontend:latest'
         format: 'table'
@@ -489,7 +489,7 @@ jobs:
         ignore-unfixed: true
 
     - name: Run Trivy config scan
-      uses: aquasecurity/trivy-action@master
+      uses: aquasecurity/trivy-action@v0.36.0
       with:
         scan-type: 'config'
         format: 'json'

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -22,6 +22,11 @@ on:
         - secrets
         - containers
 
+# F8-14-002: default the workflow token to read-only; jobs that
+# write are granted narrow scopes at job level.
+permissions:
+  contents: read
+
 env:
   PYTHON_VERSION: '3.12'
   NODE_VERSION: '20'
@@ -570,6 +575,9 @@ jobs:
 
   # Security report generation
   security-report:
+    permissions:
+      issues: write
+      pull-requests: write
     runs-on: ubuntu-latest
     needs: [code-security, dependency-security, secret-scanning, container-security]
     if: always()

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -335,7 +335,10 @@ jobs:
       with:
         fetch-depth: 0  # Full history for secret scanning
 
-    - name: Run TruffleHog secret scan
+    # F8-14-004: advisory until U2 rotation completes — the known tracked
+    # secrets (rotation inventory, PR-D) would trip a gating scan on every
+    # run. Flip to gating in the U2 post-window hygiene step (runbook §12.5).
+    - name: Run TruffleHog secret scan (advisory until U2 rotation completes)
       continue-on-error: true
       run: |
         docker run --rm -v "$PWD:/pwd" trufflesecurity/trufflehog:latest \
@@ -343,7 +346,7 @@ jobs:
           --only-verified \
           --json > trufflehog-results.json 2>/dev/null || true
 
-    - name: Run GitLeaks secret scan
+    - name: Run GitLeaks secret scan (advisory until U2 rotation completes)
       continue-on-error: true
       uses: gitleaks/gitleaks-action@v2
       env:
@@ -464,13 +467,14 @@ jobs:
         output: 'backend-container-scan.json'
         severity: 'UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL'
 
-    - name: Run Trivy vulnerability scanner on backend (advisory; remediation tracked separately)
-      continue-on-error: true  # CVE remediation is an ongoing maintenance task, not gating
+    # F8-14-004: CRITICAL gates (fixable criticals block); HIGH stays
+    # visible in the JSON report step above but does not gate.
+    - name: Trivy backend CRITICAL gate
       uses: aquasecurity/trivy-action@v0.36.0
       with:
         image-ref: 'security-scan-backend:latest'
         format: 'table'
-        severity: 'HIGH,CRITICAL'
+        severity: 'CRITICAL'
         exit-code: '1'
         ignore-unfixed: true  # skip CVEs without an upstream fix (e.g. python-ecdsa CVE-2024-23342)
 
@@ -483,13 +487,12 @@ jobs:
         output: 'frontend-container-scan.json'
         severity: 'UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL'
 
-    - name: Run Trivy vulnerability scanner on frontend (advisory)
-      continue-on-error: true
+    - name: Trivy frontend CRITICAL gate
       uses: aquasecurity/trivy-action@v0.36.0
       with:
         image-ref: 'security-scan-frontend:latest'
         format: 'table'
-        severity: 'HIGH,CRITICAL'
+        severity: 'CRITICAL'
         exit-code: '1'
         ignore-unfixed: true
 

--- a/.github/workflows/type-check.yml
+++ b/.github/workflows/type-check.yml
@@ -14,8 +14,16 @@ on:
       - '.mypy.ini'
       - 'backend/requirements*.txt'
 
+# F8-14-002: default the workflow token to read-only; jobs that
+# write are granted narrow scopes at job level.
+permissions:
+  contents: read
+
 jobs:
   mypy:
+    permissions:
+      issues: write
+      pull-requests: write
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/workflow-coordinator.yml
+++ b/.github/workflows/workflow-coordinator.yml
@@ -29,6 +29,11 @@ on:
         type: boolean
         default: false
 
+# F8-14-002: default the workflow token to read-only; jobs that
+# write are granted narrow scopes at job level.
+permissions:
+  contents: read
+
 env:
   PYTHON_VERSION: '3.12'
   NODE_VERSION: '20'
@@ -147,6 +152,8 @@ jobs:
 
   # Security scan coordination
   coordinated-security:
+    permissions:
+      actions: write
     needs: [orchestration-setup]
     if: needs.orchestration-setup.outputs.run_security == 'true'
     runs-on: ubuntu-latest
@@ -171,6 +178,9 @@ jobs:
 
   # Build coordination
   coordinated-build:
+    permissions:
+      contents: read
+      packages: write
     needs: [orchestration-setup, coordinated-tests]
     if: |
       always() &&

--- a/.github/workflows/workflow-injection-guard.yml
+++ b/.github/workflows/workflow-injection-guard.yml
@@ -23,14 +23,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: AT-G3-1.1 — no untrusted github.event.* fields inlined into shell vars
+      - name: AT-G3-1.1 — deny-by-default untrusted interpolation guard (F8-14-006)
         run: |
           set -euo pipefail
-          # Catches `VAR="${{ github.event.* }}"` shell-style assignments inside
-          # run: blocks. The safe pattern is `env: VAR: ${{ ... }}` followed by
-          # `VAR="$VAR"` (or just `"$VAR"`) inside the script.
-          if grep -nE '(AUTHOR|TITLE|BODY|MESSAGE|NAME|TEXT|URL|REASON|COMMENT)="\$\{\{ *github\.event' .github/workflows/*.yml; then
-            echo "::error::Workflow shell-injection regression (F-14-001/002). Move the value to an env: block and dereference with \"\$VAR\"."
+          # F8-14-006: the old nine-name allowlist regex missed every new
+          # variable name (TAG=, PCT=, REASON=...). The Python scanner flags
+          # ANY github.event / inputs expression interpolated inside
+          # run:/script: blocks. Legacy sites live in the frozen baseline
+          # (burn-down list); NEW sites fail. Reviewed exceptions opt out
+          # with a 'guard: allow-interpolation' comment.
+          if ! python3 .github/scripts/injection_guard.py \
+              --baseline .github/scripts/injection_guard_baseline.txt; then
+            echo "::error::Workflow shell-injection regression (F-14-001/002/F8-14-006). Move the value to an env: block and dereference with \"\$VAR\"."
             exit 1
           fi
 

--- a/.github/workflows/workflow-injection-guard.yml
+++ b/.github/workflows/workflow-injection-guard.yml
@@ -42,8 +42,10 @@ jobs:
         run: |
           set -euo pipefail
           # Catch wget OR curl HTTP (no -s requirement) plus bare URLs in shell.
+          # F8-14-007: scope includes all of .github/ so docs cannot
+          # re-seed the vulnerable recipe.
           if grep -rnE 'http://prdownloads\.sourceforge\.net' \
-              .github/workflows/ Dockerfile* infrastructure/ 2>/dev/null \
+              .github/ Dockerfile* infrastructure/ 2>/dev/null \
               | grep -vE 'workflow-injection-guard\.yml|::error::'; then
             echo "::error::Plaintext-HTTP TA-Lib download regression (F-14-003/F-13-009). Use https://github.com/ta-lib/ta-lib/releases/... + sha256sum -c."
             exit 1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,17 +1,10 @@
 repos:
-  # Type checking with mypy
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.11.1
-    hooks:
-      - id: mypy
-        args: [--config-file=.mypy.ini, --no-error-summary]
-        additional_dependencies: [types-all, lxml]
-        files: ^backend/.*\.py$
-        # Allow failures for now (baseline: 3636 errors)
-        # Remove this once errors are reduced
-        verbose: true
-        pass_filenames: false
-        always_run: false  # Only run on Python files
+  # F8-14-008: mypy removed from pre-commit. pre-commit has no
+  # failure-tolerance mechanism, so the former hook's "allow failures"
+  # comment was inert — with a 3,636-error baseline it blocked every
+  # backend commit, and its stub meta-package dependency cannot resolve.
+  # Type gating runs in CI via .github/workflows/type-check.yml, which
+  # carries the differential baseline logic (fail on NEW errors only).
 
   # Code formatting with black
   - repo: https://github.com/psf/black

--- a/frontend/web/package.json
+++ b/frontend/web/package.json
@@ -57,9 +57,7 @@
     "test:all": "npm run test && npm run test:e2e",
     "lint": "eslint src/**/*.{js,jsx,ts,tsx}",
     "format": "prettier --write src/**/*.{js,jsx,ts,tsx,css,scss}",
-    "format:check": "prettier --check src/**/*.{js,jsx,ts,tsx,css,scss}",
-    "cypress:run": "echo 'Cypress tests not implemented yet'",
-    "cypress:open": "echo 'Cypress tests not implemented yet'"
+    "format:check": "prettier --check src/**/*.{js,jsx,ts,tsx,css,scss}"
   },
   "eslintConfig": {
     "extends": [

--- a/frontend/web/playwright.config.ts
+++ b/frontend/web/playwright.config.ts
@@ -60,6 +60,22 @@ export default defineConfig({
       url: 'http://localhost:8000/api/health',
       reuseExistingServer: !process.env.CI,
       timeout: 120000,
+      // F8-15-012: backend.config.settings instantiates at import and
+      // hard-requires these; without them uvicorn never binds and the run
+      // dies as a webServer timeout instead of a test failure. Values
+      // mirror ci.yml's test env; real env vars win when set. The API also
+      // needs Postgres/Redis running (see the e2e-tests CI job / README).
+      env: {
+        DATABASE_URL:
+          process.env.DATABASE_URL || 'postgresql://postgres:testpass@localhost:5432/test_db',
+        REDIS_URL: process.env.REDIS_URL || 'redis://localhost:6379/0',
+        SECRET_KEY: process.env.SECRET_KEY || 'test-secret-key-for-ci',
+        JWT_SECRET_KEY: process.env.JWT_SECRET_KEY || 'test-jwt-secret-key-for-ci',
+        MASTER_SECRET_KEY: process.env.MASTER_SECRET_KEY || 'test-master-secret-key-for-ci',
+        SESSION_SECRET_KEY: process.env.SESSION_SECRET_KEY || 'test-session-secret-key-for-ci',
+        ENVIRONMENT: process.env.ENVIRONMENT || 'testing',
+        TESTING: process.env.TESTING || 'True',
+      },
     },
   ],
 });

--- a/frontend/web/tests/e2e/helpers.ts
+++ b/frontend/web/tests/e2e/helpers.ts
@@ -1,29 +1,75 @@
-import { Page, expect } from '@playwright/test';
+import { Page, expect, request as pwRequest } from '@playwright/test';
 
 export const BASE_URL = process.env.BASE_URL || 'http://localhost:3000';
 export const API_URL = process.env.API_URL || 'http://localhost:8000';
 
+// F8-15-022: no committed credential literal. The password must come from
+// the environment; failing fast here beats a suite that silently runs
+// unauthenticated. CI sets E2E_USER_PASSWORD in the e2e-tests job.
+function requiredPassword(): string {
+  const value = process.env.E2E_USER_PASSWORD;
+  if (!value) {
+    throw new Error(
+      'E2E_USER_PASSWORD is required (no committed default). ' +
+        'Set E2E_USER_EMAIL/E2E_USER_PASSWORD before running the E2E suite.',
+    );
+  }
+  return value;
+}
+
 export const E2E_USER = {
   email: process.env.E2E_USER_EMAIL || 'portfolio-test@example.com',
-  password: process.env.E2E_USER_PASSWORD || 'PortfolioTest123!',
+  get password(): string {
+    return requiredPassword();
+  },
 };
 
-/** Login via UI and land on dashboard (or stay if already authenticated). */
+/**
+ * Ensure the E2E user exists (idempotent). Registers via the API; a 400
+ * "already registered" is success. Anything else is a real failure.
+ */
+export async function ensureTestUser(): Promise<void> {
+  const api = await pwRequest.newContext({ baseURL: API_URL });
+  try {
+    const res = await api.post('/api/v1/auth/register', {
+      data: { email: E2E_USER.email, password: E2E_USER.password },
+    });
+    if (!res.ok() && res.status() !== 400) {
+      throw new Error(
+        `E2E user registration failed: HTTP ${res.status()} ${await res.text()}`,
+      );
+    }
+  } finally {
+    await api.dispose();
+  }
+}
+
+/**
+ * Login via UI and land on an authenticated route.
+ *
+ * F8-15-013: a missing login form THROWS (no silent degrade), the site
+ * root is not accepted as a post-login URL, and a real auth signal
+ * (access_token in localStorage) is asserted before returning.
+ */
 export async function loginAsTestUser(page: Page): Promise<void> {
+  await ensureTestUser();
   await page.goto(`${BASE_URL}/login`);
   const email = page.locator('input[name="email"], input[type="email"]').first();
-  if (await email.isVisible({ timeout: 5000 }).catch(() => false)) {
-    await email.fill(E2E_USER.email);
-    await page
-      .locator('input[name="password"], input[type="password"]')
-      .first()
-      .fill(E2E_USER.password);
-    await page
-      .locator('button:has-text("Sign In"), button:has-text("Login"), button[type="submit"]')
-      .first()
-      .click();
+  await email.waitFor({ state: 'visible', timeout: 10000 });
+  await email.fill(E2E_USER.email);
+  await page
+    .locator('input[name="password"], input[type="password"]')
+    .first()
+    .fill(E2E_USER.password);
+  await page
+    .locator('button:has-text("Sign In"), button:has-text("Login"), button[type="submit"]')
+    .first()
+    .click();
+  await page.waitForURL(/dashboard|portfolio|watchlist/, { timeout: 30000 });
+  const hasToken = await page.evaluate(() => !!localStorage.getItem('access_token'));
+  if (!hasToken) {
+    throw new Error('login navigated but produced no access_token — auth is broken');
   }
-  await page.waitForURL(/dashboard|portfolio|watchlist|\/$/, { timeout: 30000 });
 }
 
 /** Navigate to a protected route after login. */

--- a/frontend/web/tests/e2e/portfolio.spec.ts
+++ b/frontend/web/tests/e2e/portfolio.spec.ts
@@ -1,13 +1,17 @@
 import { test, expect, Page } from '@playwright/test';
+import { E2E_USER } from './helpers';
 
 const BASE_URL = process.env.BASE_URL || 'http://localhost:3000';
 const API_URL = process.env.API_URL || 'http://localhost:8000';
 
 // Test user for portfolio operations
 const TEST_USER = {
-  email: 'portfolio-test@example.com',
+  email: E2E_USER.email,
   username: 'portfolio-test',
-  password: 'PortfolioTest123!',
+  get password(): string {
+    // F8-15-022: no committed literal — sourced from E2E_USER_PASSWORD.
+    return E2E_USER.password;
+  },
 };
 
 test.describe('Portfolio Management', () => {

--- a/tests/test_ci_gates_f8_14.py
+++ b/tests/test_ci_gates_f8_14.py
@@ -84,3 +84,36 @@ class TestF8_14_005_CanaryInterpolation:
             if in_run and re.search(r"\$\{\{\s*(github\.event\.|inputs\.)", line):
                 offenders.append(i)
         assert offenders == [], f"input interpolation inside run blocks at lines {offenders}"
+
+
+class TestF8_14_011_CanaryHealthUrl:
+    """The canary health gate must not default to a reserved example domain
+    (every default-input dispatch probed https://staging.example.com five
+    times, failed, and rolled back)."""
+
+    def test_health_url_is_required_with_no_default(self):
+        text = (WORKFLOWS / "canary-deploy.yml").read_text()
+        block = re.search(r"health_url:\n(?:\s{8}.+\n)+", text).group(0)
+        assert "required: true" in block, block
+        assert "example.com" not in block, "placeholder default still present"
+
+    def test_early_validation_rejects_example_domain(self):
+        lines = (WORKFLOWS / "canary-deploy.yml").read_text().split("\n")
+        for i, line in enumerate(lines):
+            window = "\n".join(lines[i:i + 10])
+            if ("HEALTH_URL" in line and "example.com" in window
+                    and "exit 1" in window):
+                return
+        raise AssertionError("no fail-fast validation step rejecting an "
+                             "example.com HEALTH_URL")
+
+
+class TestF8_14_013_DryRunVar:
+    """dry_run must be consumed or deleted — a GITHUB_ENV write nothing
+    reads (and which cannot cross jobs anyway) is dead signalling."""
+
+    def test_dry_run_written_only_if_read(self):
+        text = (WORKFLOWS / "canary-deploy.yml").read_text()
+        writes = len(re.findall(r'"?dry_run=', text))
+        reads = len(re.findall(r"env\.dry_run|\$dry_run|\$\{dry_run\}", text))
+        assert writes == 0 or reads > 0, f"{writes} writes, {reads} reads"

--- a/tests/test_ci_gates_f8_14.py
+++ b/tests/test_ci_gates_f8_14.py
@@ -201,7 +201,8 @@ class TestF8_14_006_DenyByDefaultGuard:
         assert "AUTHOR|TITLE|BODY" not in text, "old name-allowlist regex remains"
 
     def test_repo_tree_has_no_unbaselined_findings(self):
-        import subprocess, sys
+        import subprocess
+        import sys
         r = subprocess.run(
             [sys.executable, ".github/scripts/injection_guard.py",
              "--baseline", ".github/scripts/injection_guard_baseline.txt"],

--- a/tests/test_ci_gates_f8_14.py
+++ b/tests/test_ci_gates_f8_14.py
@@ -27,3 +27,25 @@ class TestF8_14_001_MutableActionRefs:
                 if re.search(r"uses:\s*[^@\s]+@(master|main)\s*$", line):
                     offenders.append(f"{wf.name}:{i}")
         assert offenders == [], offenders
+
+
+class TestF8_14_003_ProductionTrivyGate:
+    """The production security gate must fail when the Trivy reports are
+    missing — otherwise jq emits nothing, wc -l says 0, and the step prints
+    'deployment approved' after a failed scan."""
+
+    def _gate(self):
+        t = (WORKFLOWS / "production-deploy.yml").read_text()
+        start = t.index("- name: Security gate check")
+        end = t.index("- name:", start + 10)
+        return t[start:end]
+
+    def test_gate_uses_strict_shell_mode(self):
+        assert "set -euo pipefail" in self._gate()
+
+    def test_gate_checks_report_existence_before_jq(self):
+        gate = self._gate()
+        assert re.search(r'if \[ ! -f "\$f" \]', gate), "no existence preflight"
+        assert gate.index("! -f") < gate.index("jq "), (
+            "existence check must run before any jq parse"
+        )

--- a/tests/test_ci_gates_f8_14.py
+++ b/tests/test_ci_gates_f8_14.py
@@ -49,3 +49,16 @@ class TestF8_14_003_ProductionTrivyGate:
         assert gate.index("! -f") < gate.index("jq "), (
             "existence check must run before any jq parse"
         )
+
+
+class TestF8_14_002_PermissionsBlocks:
+    """Every workflow must declare a top-level permissions: block so jobs
+    stop inheriting the repo-default GITHUB_TOKEN scope (F-14-006 regressed
+    12 -> 22 missing)."""
+
+    def test_every_workflow_declares_top_level_permissions(self):
+        missing = [
+            wf.name for wf in _workflow_files()
+            if not re.search(r"^permissions:", wf.read_text(), re.M)
+        ]
+        assert missing == [], missing

--- a/tests/test_ci_gates_f8_14.py
+++ b/tests/test_ci_gates_f8_14.py
@@ -223,3 +223,31 @@ class TestF8_14_007_GithubReadmeTruth:
         assert re.search(r"grep -rnE 'http://prdownloads[^']*'\s*\\\n\s*\.github/ ", text), (
             "plaintext-HTTP grep must scan .github/ (not just workflows/)"
         )
+
+
+class TestF8_14_008_PreCommitMypy:
+    """pre-commit has no failure-tolerance mechanism, so the mypy hook's
+    'Allow failures for now' comment was a lie: with a 3,636-error baseline
+    it blocked every backend commit, and its 'types-all' extra dependency
+    cannot even resolve. Type gating lives in type-check.yml (differential
+    baseline logic)."""
+
+    def test_mypy_hook_removed_from_pre_commit(self):
+        text = (REPO_ROOT / ".pre-commit-config.yaml").read_text()
+        assert "mirrors-mypy" not in text
+        assert "types-all" not in text
+
+    def test_pointer_to_ci_type_gate_remains(self):
+        text = (REPO_ROOT / ".pre-commit-config.yaml").read_text()
+        assert "type-check.yml" in text, "document where type gating went"
+
+
+class TestF8_14_014_TrivyInstall:
+    """apt-key is deprecated/removed on newer Ubuntu images; the unpinned
+    apt path also drifts independently of the pinned action refs."""
+
+    def test_no_apt_key_add_anywhere_in_workflows(self):
+        offenders = [
+            wf.name for wf in _workflow_files() if "apt-key add" in wf.read_text()
+        ]
+        assert offenders == [], offenders

--- a/tests/test_ci_gates_f8_14.py
+++ b/tests/test_ci_gates_f8_14.py
@@ -1,0 +1,29 @@
+"""CI-gate regression tests for scope-14 findings (2026-08 audit, cluster C3).
+
+Source-level (pure file reads over .github/**), runs under
+``pytest --noconftest``.
+"""
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WORKFLOWS = REPO_ROOT / ".github" / "workflows"
+
+
+def _workflow_files():
+    return sorted(WORKFLOWS.glob("*.yml")) + sorted(WORKFLOWS.glob("*.yaml"))
+
+
+class TestF8_14_001_MutableActionRefs:
+    """Security actions must not float on a mutable branch ref: any push to
+    the action's default branch would execute immediately inside jobs holding
+    GITHUB_TOKEN (and, in production-deploy.yml, the production context)."""
+
+    def test_no_uses_pinned_to_master_or_main(self):
+        offenders = []
+        for wf in _workflow_files():
+            for i, line in enumerate(wf.read_text().split("\n"), 1):
+                if re.search(r"uses:\s*[^@\s]+@(master|main)\s*$", line):
+                    offenders.append(f"{wf.name}:{i}")
+        assert offenders == [], offenders

--- a/tests/test_ci_gates_f8_14.py
+++ b/tests/test_ci_gates_f8_14.py
@@ -251,3 +251,32 @@ class TestF8_14_014_TrivyInstall:
             wf.name for wf in _workflow_files() if "apt-key add" in wf.read_text()
         ]
         assert offenders == [], offenders
+
+
+class TestF8_14_004_GatingSubset:
+    """security-scan.yml had zero 'exit 1' across 990 lines — every scanner
+    neutralized by continue-on-error and/or || true. The audit's minimum
+    gating set: Trivy CRITICAL gates now; secrets scanners flip to gating
+    once the U2 rotation removes the known tracked secrets (gating them
+    earlier guarantees a red main)."""
+
+    def _text(self):
+        return (WORKFLOWS / "security-scan.yml").read_text()
+
+    def test_trivy_critical_steps_gate(self):
+        t = self._text()
+        gating = re.findall(
+            r"- name: [^\n]*CRITICAL gate[^\n]*\n(?:.+\n)+?(?=\n    - name:|\Z)", t
+        )
+        assert len(gating) == 2, "expected backend+frontend CRITICAL gate steps"
+        for step in gating:
+            assert "continue-on-error" not in step
+            assert "severity: 'CRITICAL'" in step
+            assert "exit-code: '1'" in step
+
+    def test_secret_scanners_carry_post_u2_flip_marker(self):
+        t = self._text()
+        assert t.count("advisory until U2 rotation completes") >= 2, (
+            "TruffleHog/gitleaks advisory state must be an explicit recorded "
+            "decision, not silent drift"
+        )

--- a/tests/test_ci_gates_f8_14.py
+++ b/tests/test_ci_gates_f8_14.py
@@ -150,3 +150,61 @@ class TestF8_14_010_MigrationDetection:
         assert re.search(r"pull_request\.base\.sha|base_ref", text), (
             "no PR-aware diff base"
         )
+
+
+class TestF8_14_006_DenyByDefaultGuard:
+    """The injection guard must deny by default: ANY event/inputs
+    interpolation in a run/script block is flagged, regardless of variable
+    name — a name-allowlist cannot catch code written after the allowlist."""
+
+    @staticmethod
+    def _guard():
+        import importlib.util
+        spec = importlib.util.spec_from_file_location(
+            "injection_guard",
+            REPO_ROOT / ".github" / "scripts" / "injection_guard.py",
+        )
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod
+
+    def test_flags_names_outside_the_old_allowlist(self, tmp_path):
+        wf = tmp_path / "x.yml"
+        wf.write_text(
+            "jobs:\n  j:\n    steps:\n      - run: |\n"
+            '          TAG="${{ github.event.inputs.image_tag }}"\n'
+        )
+        assert len(self._guard().scan_file(wf)) == 1
+
+    def test_opt_out_comment_is_honoured(self, tmp_path):
+        wf = tmp_path / "x.yml"
+        wf.write_text(
+            "jobs:\n  j:\n    steps:\n      - run: |\n"
+            "          # guard: allow-interpolation (reviewed: sha only)\n"
+            '          BASE="${{ github.event.before }}"\n'
+        )
+        assert self._guard().scan_file(wf) == []
+
+    def test_env_blocks_are_not_flagged(self, tmp_path):
+        wf = tmp_path / "x.yml"
+        wf.write_text(
+            "jobs:\n  j:\n    steps:\n      - env:\n"
+            "          TAG: ${{ github.event.inputs.image_tag }}\n"
+            "        run: |\n"
+            '          echo "$TAG"\n'
+        )
+        assert self._guard().scan_file(wf) == []
+
+    def test_guard_workflow_invokes_the_scanner(self):
+        text = (WORKFLOWS / "workflow-injection-guard.yml").read_text()
+        assert "injection_guard.py" in text
+        assert "AUTHOR|TITLE|BODY" not in text, "old name-allowlist regex remains"
+
+    def test_repo_tree_has_no_unbaselined_findings(self):
+        import subprocess, sys
+        r = subprocess.run(
+            [sys.executable, ".github/scripts/injection_guard.py",
+             "--baseline", ".github/scripts/injection_guard_baseline.txt"],
+            cwd=REPO_ROOT, capture_output=True, text=True,
+        )
+        assert r.returncode == 0, r.stdout + r.stderr

--- a/tests/test_ci_gates_f8_14.py
+++ b/tests/test_ci_gates_f8_14.py
@@ -208,3 +208,18 @@ class TestF8_14_006_DenyByDefaultGuard:
             cwd=REPO_ROOT, capture_output=True, text=True,
         )
         assert r.returncode == 0, r.stdout + r.stderr
+
+
+class TestF8_14_007_GithubReadmeTruth:
+    """.github/README.md must not document states that no longer exist."""
+
+    def test_no_stale_sarif_v2_claim_or_http_recipe(self):
+        text = (REPO_ROOT / ".github" / "README.md").read_text()
+        assert "upload-sarif@v2" not in text
+        assert "http://prdownloads" not in text
+
+    def test_guard_http_grep_covers_all_of_dot_github(self):
+        text = (WORKFLOWS / "workflow-injection-guard.yml").read_text()
+        assert re.search(r"grep -rnE 'http://prdownloads[^']*'\s*\\\n\s*\.github/ ", text), (
+            "plaintext-HTTP grep must scan .github/ (not just workflows/)"
+        )

--- a/tests/test_ci_gates_f8_14.py
+++ b/tests/test_ci_gates_f8_14.py
@@ -117,3 +117,36 @@ class TestF8_14_013_DryRunVar:
         writes = len(re.findall(r'"?dry_run=', text))
         reads = len(re.findall(r"env\.dry_run|\$dry_run|\$\{dry_run\}", text))
         assert writes == 0 or reads > 0, f"{writes} writes, {reads} reads"
+
+
+class TestF8_14_009_AutoSyncInterpolation:
+    """workflow_run.name is repo-influenced text; it must reach the shell
+    via env, not YAML interpolation inside a quoted assignment."""
+
+    def test_workflow_run_name_not_interpolated_in_run(self):
+        text = (WORKFLOWS / "auto-sync.yml").read_text()
+        offenders = [
+            i for i, line in enumerate(text.split("\n"), 1)
+            if "${{ github.event.workflow_run.name }}" in line
+            and "env:" not in line and not line.strip().startswith(("TRIGGER_WORKFLOW:",))
+        ]
+        assert offenders == [], offenders
+
+
+class TestF8_14_010_MigrationDetection:
+    """Migration detection must work on pull_request events (github.event.
+    before is unset there) and must not swallow failures with || echo ''."""
+
+    def test_no_silent_fallback_swallowing_diff_failures(self):
+        text = (WORKFLOWS / "migration-check.yml").read_text()
+        offenders = [
+            i for i, line in enumerate(text.split("\n"), 1)
+            if "git diff" in line and '|| echo ""' in line
+        ]
+        assert offenders == [], f"git diff failures swallowed at {offenders}"
+
+    def test_pull_request_aware_diff_range(self):
+        text = (WORKFLOWS / "migration-check.yml").read_text()
+        assert re.search(r"pull_request\.base\.sha|base_ref", text), (
+            "no PR-aware diff base"
+        )

--- a/tests/test_ci_gates_f8_14.py
+++ b/tests/test_ci_gates_f8_14.py
@@ -62,3 +62,25 @@ class TestF8_14_002_PermissionsBlocks:
             if not re.search(r"^permissions:", wf.read_text(), re.M)
         ]
         assert missing == [], missing
+
+
+class TestF8_14_005_CanaryInterpolation:
+    """workflow_dispatch inputs must not be YAML-interpolated into run:
+    shell/heredoc text — the exact ${{ }}-into-shell pattern G3 closed."""
+
+    def test_no_event_or_input_interpolation_inside_run_blocks(self):
+        text = (WORKFLOWS / "canary-deploy.yml").read_text()
+        offenders = []
+        in_run = False
+        run_indent = 0
+        for i, line in enumerate(text.split("\n"), 1):
+            stripped = line.lstrip()
+            indent = len(line) - len(stripped)
+            if stripped.startswith("run:"):
+                in_run, run_indent = True, indent
+                continue
+            if in_run and stripped and indent <= run_indent:
+                in_run = False
+            if in_run and re.search(r"\$\{\{\s*(github\.event\.|inputs\.)", line):
+                offenders.append(i)
+        assert offenders == [], f"input interpolation inside run blocks at lines {offenders}"

--- a/tests/test_e2e_wiring_f8_15.py
+++ b/tests/test_e2e_wiring_f8_15.py
@@ -1,0 +1,60 @@
+"""E2E-wiring regression tests for scope-15 findings (2026-08 audit, C3).
+
+Source-level file reads, runs under ``pytest --noconftest``.
+"""
+
+import json
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+FRONTEND = REPO_ROOT / "frontend" / "web"
+CT = REPO_ROOT / ".github" / "workflows" / "comprehensive-testing.yml"
+
+
+class TestF8_15_002_RealE2EInCI:
+    """The CI 'End-to-End Tests' job ran an echo stub via npm run
+    cypress:run under continue-on-error, so 10 Playwright specs gated
+    nothing. The job must run the real suite and be able to fail."""
+
+    def test_cypress_echo_stubs_deleted(self):
+        pkg = json.loads((FRONTEND / "package.json").read_text())
+        scripts = pkg.get("scripts", {})
+        assert "cypress:run" not in scripts
+        assert "cypress:open" not in scripts
+
+    def test_no_cypress_references_left_in_workflow(self):
+        assert "cypress" not in CT.read_text().lower()
+
+    def _e2e_job(self):
+        t = CT.read_text()
+        start = t.index("  e2e-tests:")
+        nxt = re.search(r"^  [a-z0-9_-]+:\s*$", t[start + 15:], re.M)
+        return t[start:start + 15 + (nxt.start() if nxt else len(t))]
+
+    def test_e2e_job_runs_playwright_without_continue_on_error(self):
+        job = self._e2e_job()
+        assert "playwright test" in job, "job must run the real suite"
+        assert "continue-on-error" not in job, (
+            "an E2E job that cannot fail gates nothing"
+        )
+
+    def test_artifacts_point_at_playwright_outputs(self):
+        job = self._e2e_job()
+        assert "playwright-report" in job
+        assert "test-results" in job
+
+
+class TestF8_15_023_ProjectMatrix:
+    """PR/push runs use one browser project; the full 5-browser matrix runs
+    only on the nightly schedule."""
+
+    def test_chromium_only_outside_schedule(self):
+        t = CT.read_text()
+        assert "--project=chromium" in t
+
+    def test_full_matrix_reserved_for_schedule(self):
+        t = CT.read_text()
+        assert re.search(r"github\.event_name\s*==\s*'schedule'", t), (
+            "no schedule-gated full-matrix path"
+        )

--- a/tests/test_e2e_wiring_f8_15.py
+++ b/tests/test_e2e_wiring_f8_15.py
@@ -58,3 +58,52 @@ class TestF8_15_023_ProjectMatrix:
         assert re.search(r"github\.event_name\s*==\s*'schedule'", t), (
             "no schedule-gated full-matrix path"
         )
+
+
+class TestF8_15_012_WebServerEnv:
+    """The backend webServer entry must carry an explicit env block —
+    backend.config.settings hard-requires SECRET_KEY/JWT_SECRET_KEY/
+    REDIS_URL at import, so without one uvicorn never binds and Playwright
+    times out at webServer startup instead of failing a test."""
+
+    def test_backend_webserver_has_env_block(self):
+        t = (FRONTEND / "playwright.config.ts").read_text()
+        m = re.search(r"\{[^{}]*uvicorn[^{}]*env:\s*\{(?P<env>[^}]*)\}", t, re.S)
+        assert m, "backend webServer entry has no env block"
+        env = m.group("env")
+        for var in ("SECRET_KEY", "JWT_SECRET_KEY", "REDIS_URL", "DATABASE_URL"):
+            assert var in env, f"webServer env missing {var}"
+
+
+class TestF8_15_013_022_LoginHelper:
+    """F8-15-013: loginAsTestUser must not silently degrade to
+    'not logged in' when the form fails to render, must not accept the
+    site root as a post-login URL, and must assert a real auth signal.
+    F8-15-022: no hardcoded default password literal."""
+
+    def _helpers(self):
+        return (FRONTEND / "tests" / "e2e" / "helpers.ts").read_text()
+
+    def test_no_silent_catch_fallback_on_login_form(self):
+        assert ".catch(() => false)" not in self._helpers()
+
+    def test_no_site_root_alternative_in_post_login_url(self):
+        assert re.search(r"waitForURL\(/[^/]*\\\/\$", self._helpers()) is None, (
+            r"the \/$ alternative matches the unauthenticated site root"
+        )
+
+    def test_asserts_post_login_auth_signal(self):
+        assert "access_token" in self._helpers(), (
+            "no post-login signal assertion (auth breakage would pass)"
+        )
+
+    def test_no_hardcoded_default_password(self):
+        assert "PortfolioTest" not in self._helpers()
+        hits = [p for p in (FRONTEND / "tests").rglob("*.ts")
+                if "PortfolioTest123" in p.read_text()]
+        assert hits == [], hits
+
+    def test_missing_password_env_fails_fast(self):
+        assert re.search(r"E2E_USER_PASSWORD.*(throw|Error)", self._helpers(), re.S), (
+            "unset E2E_USER_PASSWORD must raise a clear error"
+        )


### PR DESCRIPTION
## C3: CI-gates-that-can-fail (2026-08 remediation)

Every later cluster leans on this safety net. 16 findings from scopes 14 (CI/CD) and 15 (test suite), one atomic commit per finding/pair, each with a fail-first `--noconftest` test (`tests/test_ci_gates_f8_14.py`, `tests/test_e2e_wiring_f8_15.py` — 35 assertions). Differential actionlint on every touched workflow: no file worse than main.

### Supply chain / token scope
- **F8-14-001**: 10 `@master` security-action refs pinned (trivy v0.36.0, snyk 0.4.0)
- **F8-14-002**: `permissions: contents: read` on all 22 workflows missing it; narrow job-level writes verified per job (16 writing jobs)
- **F8-14-014**: deprecated `apt-key` Trivy install → pinned action

### Gates that could pass vacuously
- **F8-14-003**: production Trivy gate now fails on missing reports (staging preflight ported)
- **F8-14-010**: migration detection was a silent no-op on every PR (`github.event.before` unset + swallowed failures) — now PR-aware and loud
- **F8-14-004** ⚠️ **policy note (audit Q1)**: implements the audit's minimum gating set — Trivy **CRITICAL gates now**; TruffleHog/gitleaks stay **advisory with an explicit in-file marker** because gating them before the U2 rotation (PR #263) would trip on the known tracked secrets every run. The flip is step 6 of runbook §12.5. Widen/revert by editing two steps.

### Injection surface
- **F8-14-005**: canary inputs → env + `jq` (unquoted JSON interpolation closed)
- **F8-14-009**: auto-sync workflow-name interpolation → env
- **F8-14-006**: injection guard rewritten **deny-by-default** (`.github/scripts/injection_guard.py`): flags ANY event/inputs interpolation in run/script blocks; 76 legacy sites frozen in a burn-down baseline (repo's differential-gate convention); comment opt-out for reviewed lines
- **F8-14-011/013**: canary `health_url` required + validated (was example.com → guaranteed rollback); dead `dry_run` removed

### E2E: from theater to gate
- **F8-15-002/023**: echo-Cypress stubs deleted; `e2e-tests` job runs the real Playwright suite (**no continue-on-error**) with postgres/redis services + backend deps; chromium on main-push, full 5-browser matrix nightly-only. Kept off PRs until proven green on main (recorded follow-up).
- **F8-15-012**: Playwright's uvicorn webServer gets an explicit test env (was a guaranteed 120s webServer timeout)
- **F8-15-013/022**: login helper throws on missing form, asserts the `access_token` signal, self-seeds via `/api/v1/auth/register`; committed `PortfolioTest123!` literal removed (env-required, `rg PortfolioTest` → 0)
- **F8-14-007/008**: `.github/README.md` doc-lies fixed + guard scans all of `.github/`; inert-tolerance mypy hook removed from pre-commit (type gating stays in `type-check.yml`'s differential baseline)

### Verification
- 35 fail-first tests RED→GREEN; `playwright --list` loads 48 tests / 9 files; guard green vs baseline; pre-commit + workflow YAML parse; ruff clean on new files

### Follow-ups recorded
- Burn down `injection_guard_baseline.txt` (76 legacy sites)
- Widen e2e job to PRs once green on main; enrich the 7 URL-only specs (F8-15-014, C11)
- SHA-pin all action refs (F-14-004, prior)